### PR TITLE
Throw a more helpful error when transitioning to an undefined state

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -165,6 +165,10 @@ class StateNode {
       currentHistory = currentHistory[subPath] as IHistory;
     });
 
+    if (currentState === undefined) {
+      throw Error(`Action '${action}' on state '${history.$current}' leads to undefined state '${nextPath}'.`)
+    }
+
     while (currentState.initial) {
       currentState = currentState.states[currentState.initial];
     }

--- a/test/dfa.ts
+++ b/test/dfa.ts
@@ -51,7 +51,8 @@ describe('deterministic machine', () => {
     states: {
       a: {
         on: {
-          T: 'b.b1'
+          T: 'b.b1',
+          F: 'c'
         }
       },
       b: {
@@ -141,6 +142,10 @@ describe('deterministic machine', () => {
 
     it('should throw an error for transitions from invalid states', () => {
       assert.throws(() => testMachine.transition('fake', 'T'));
+    });
+
+    it('should throw an error for transitions to invalid states', () => {
+      assert.throws((() => testMachine.transition('a', 'F')), "Action 'F' on state 'a' leads to undefined state 'c'.");
     });
 
     it('should throw an error for transitions from invalid substates', () => {


### PR DESCRIPTION
Thanks for the great library. This has been immensely helpful for what I'm working on right now.

The only pain point I've had in about a week of using this is that when transitioning to a state that is not defined:

``` javascript
states: {
  a: {
    on: {
       continue: 'b'
    }
  // 'b' should be declared here but I forgot
}
```

the error logged seems completely unrelated to the actual problem at first glance.

![screen shot 2017-11-04 at 2 43 07 pm](https://user-images.githubusercontent.com/2013804/32408465-9dd434fe-c16e-11e7-8151-edb2d2d6a143.png)

When I read "cannot read property 'initial'", I thought my chart provided to the `Machine()` function was invalid somehow. This was confusing because I transitioned to 3 other states before seeing this error and spent 2 hours thinking I was crazy and the stacktrace was utterly useless.

Anyway, I hope this is a good start to the solution so others don't run into this problem.