### PR TITLE
getShortestPaths + condition

### DIFF
--- a/src/graph.ts
+++ b/src/graph.ts
@@ -15,15 +15,16 @@ export interface INodesAndEdges {
 
 export function getNodes(node: StateNode): StateNode[] {
   const { states } = node;
-  const nodes = Object.keys(
-    states
-  ).reduce((accNodes: StateNode[], stateKey) => {
-    const subState = states[stateKey];
-    const subNodes = getNodes(states[stateKey]);
+  const nodes = Object.keys(states).reduce(
+    (accNodes: StateNode[], stateKey) => {
+      const subState = states[stateKey];
+      const subNodes = getNodes(states[stateKey]);
 
-    accNodes.push(subState, ...subNodes);
-    return accNodes;
-  }, []);
+      accNodes.push(subState, ...subNodes);
+      return accNodes;
+    },
+    []
+  );
 
   return nodes;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -362,7 +362,9 @@ class StateNode implements StateNodeConfig {
           subPath = currentState.initial;
         } else {
           throw new Error(
-            `Cannot read '${HISTORY_KEY}' from state '${currentState.id}': missing 'initial'`
+            `Cannot read '${HISTORY_KEY}' from state '${
+              currentState.id
+            }': missing 'initial'`
           );
         }
       }
@@ -371,7 +373,9 @@ class StateNode implements StateNodeConfig {
 
       if (currentState === undefined) {
         throw new Error(
-          `Event '${event}' on state '${currentPath}' leads to undefined state '${nextStatePath}'.`
+          `Event '${event}' on state '${
+            currentPath
+          }' leads to undefined state '${nextStatePath}'.`
         );
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -324,11 +324,12 @@ class StateNode implements StateNodeConfig {
         const { cond, actions: transitionActions } = transition[
           candidate
         ] as TransitionConfig;
+        const extendedStateObject = extendedState || {};
         const eventObject: EventObject =
           typeof event === 'string' || typeof event === 'number'
             ? { type: event }
             : event;
-        if (!cond || cond(extendedState, eventObject)) {
+        if (!cond || cond(extendedStateObject, eventObject)) {
           nextStateString = candidate;
           if (transitionActions) {
             actionMap.actions = actionMap.actions.concat(transitionActions);

--- a/test/examples/6.17.test.ts
+++ b/test/examples/6.17.test.ts
@@ -55,9 +55,9 @@ describe('Example 6.17', () => {
     Object.keys(expected[fromState]).forEach(eventTypes => {
       const toState = expected[fromState][eventTypes];
 
-      it(`should go from ${fromState} to ${JSON.stringify(
-        toState
-      )} on ${eventTypes}`, () => {
+      it(`should go from ${fromState} to ${JSON.stringify(toState)} on ${
+        eventTypes
+      }`, () => {
         const resultState = testMultiTransition(machine, fromState, eventTypes);
 
         assert.deepEqual(resultState.value, toState);

--- a/test/graph.test.ts
+++ b/test/graph.test.ts
@@ -315,6 +315,26 @@ describe('graph utilities', () => {
         0
       );
     });
+
+    it('should not throw when a condition is present', () => {
+      const condMachine = Machine({
+        initial: 'a',
+        states: {
+          a: {
+            on: {
+              NEXT: {
+                'b': {
+                  cond: payload => payload.foo
+                }
+              }
+            }
+          },
+          b: {}
+        }
+      });
+
+      assert.doesNotThrow(() => getShortestPaths(condMachine))
+    });
   });
 
   describe('getShortestPathsAsArray()', () => {


### PR DESCRIPTION
The `getShortestPaths` method is currently failing when a condition is present because the `cond` function is called with `undefined`. 
This PR fixes the issue, the relevant changes are in https://github.com/davidkpiano/xstate/commit/52fb0e236f8795e222d99f624e9cd56b4912b783.