### PR TITLE
Fix extended state on transition

### DIFF
--- a/src/graph.ts
+++ b/src/graph.ts
@@ -23,15 +23,16 @@ export interface INodesAndEdges {
 
 export function getNodes(node: StateNode): StateNode[] {
   const { states } = node;
-  const nodes = Object.keys(
-    states
-  ).reduce((accNodes: StateNode[], stateKey) => {
-    const subState = states[stateKey];
-    const subNodes = getNodes(states[stateKey]);
+  const nodes = Object.keys(states).reduce(
+    (accNodes: StateNode[], stateKey) => {
+      const subState = states[stateKey];
+      const subNodes = getNodes(states[stateKey]);
 
-    accNodes.push(subState, ...subNodes);
-    return accNodes;
-  }, []);
+      accNodes.push(subState, ...subNodes);
+      return accNodes;
+    },
+    []
+  );
 
   return nodes;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -296,7 +296,8 @@ class StateNode implements StateNodeConfig {
         activities: parentActivities
       } = this.states[subStateKey].next(
         event,
-        history ? history.value : undefined
+        history ? history.value : undefined,
+        extendedState
       );
       const nextActions = nextStateValue[subStateKey].actions;
       const activities = nextStateValue[subStateKey].activities;
@@ -469,7 +470,9 @@ class StateNode implements StateNodeConfig {
           subPath = currentState.initial;
         } else {
           throw new Error(
-            `Cannot read '${HISTORY_KEY}' from state '${currentState.id}': missing 'initial'`
+            `Cannot read '${HISTORY_KEY}' from state '${
+              currentState.id
+            }': missing 'initial'`
           );
         }
       } else if (subPath === NULL_EVENT) {
@@ -482,9 +485,9 @@ class StateNode implements StateNodeConfig {
 
       if (currentState === undefined) {
         throw new Error(
-          `Event '${event}' on state '${currentPath}' leads to undefined state '${nextStatePath.join(
-            STATE_DELIMITER
-          )}'.`
+          `Event '${event}' on state '${
+            currentPath
+          }' leads to undefined state '${nextStatePath.join(STATE_DELIMITER)}'.`
         );
       }
 

--- a/test/examples/6.17.test.ts
+++ b/test/examples/6.17.test.ts
@@ -55,9 +55,9 @@ describe('Example 6.17', () => {
     Object.keys(expected[fromState]).forEach(eventTypes => {
       const toState = expected[fromState][eventTypes];
 
-      it(`should go from ${fromState} to ${JSON.stringify(
-        toState
-      )} on ${eventTypes}`, () => {
+      it(`should go from ${fromState} to ${JSON.stringify(toState)} on ${
+        eventTypes
+      }`, () => {
         const resultState = testMultiTransition(machine, fromState, eventTypes);
 
         assert.deepEqual(resultState.value, toState);

--- a/test/matches-state.test.ts
+++ b/test/matches-state.test.ts
@@ -79,6 +79,6 @@ describe('matchesState()', () => {
   });
 
   it('should mix/match string state values and object state values', () => {
-    assert.ok(matchesState('a.b.c', {a: {b: 'c'}}));
+    assert.ok(matchesState('a.b.c', { a: { b: 'c' } }));
   });
 });

--- a/test/parallel.test.ts
+++ b/test/parallel.test.ts
@@ -103,9 +103,9 @@ describe('parallel states', () => {
     Object.keys(expected[fromState]).forEach(eventTypes => {
       const toState = expected[fromState][eventTypes];
 
-      it(`should go from ${fromState} to ${JSON.stringify(
-        toState
-      )} on ${eventTypes}`, () => {
+      it(`should go from ${fromState} to ${JSON.stringify(toState)} on ${
+        eventTypes
+      }`, () => {
         const resultState = testMultiTransition(
           wordMachine,
           fromState,

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -24,9 +24,9 @@ export function testAll(machine: StateNode, expected: {}): void {
     Object.keys(expected[fromState]).forEach(eventTypes => {
       const toState = expected[fromState][eventTypes];
 
-      it(`should go from ${fromState} to ${JSON.stringify(
-        toState
-      )} on ${eventTypes}`, () => {
+      it(`should go from ${fromState} to ${JSON.stringify(toState)} on ${
+        eventTypes
+      }`, () => {
         const resultState = testMultiTransition(machine, fromState, eventTypes);
 
         if (toState === undefined) {


### PR DESCRIPTION
The `extendedState` isn't pass when we call the transition on the parent.