### PR TITLE
Top level events aren't handled, exposes bug #71

### DIFF
--- a/test/machine.test.ts
+++ b/test/machine.test.ts
@@ -45,6 +45,21 @@ describe('machine', () => {
     }
   });
 
+  const topLevelMachine = Machine({
+    initial: 'Hidden',
+    on: {
+      CLICKED_CLOSE: 'Hidden'
+    },
+    states: {
+      Hidden: {
+        on: {
+          PUBLISH_FAILURE: 'Failure'
+        }
+      },
+      Failure: {}
+    }
+  });
+
   describe('machine.states', () => {
     it('should properly register machine states', () => {
       assert.deepEqual(Object.keys(lightMachine.states), [
@@ -73,5 +88,11 @@ describe('machine', () => {
     it('should return the initial state', () => {
       assert.equal(lightMachine.initialState.value, 'green');
     });
+  });
+
+  it('should listen to events declared at top state', () => {
+    const actualState = topLevelMachine.transition('Failure', 'CLICKED_CLOSE');
+
+    assert.deepEqual(actualState.value, 'Hidden');
   });
 });


### PR DESCRIPTION
When a machine declares event handlers at the top level, they seem to
be ignored altogether.