### PR TITLE
Added some tests that expose problems with deeply nested states

### DIFF
--- a/test/deep.test.ts
+++ b/test/deep.test.ts
@@ -1,0 +1,90 @@
+import { assert } from 'chai';
+import { Machine } from '../src/index';
+
+describe('deep transitions', () => {
+  const deepMachine = Machine({
+    key: 'deep',
+    initial: 'A',
+    parallel: false,
+    on: {
+      MACHINE_EVENT: '#DONE'
+    },
+    states: {
+      DONE: {},
+      FAIL: {},
+      A: {
+        on: {
+          A_EVENT: '#deep.DONE',
+          B_EVENT: 'FAIL' // shielded by B's B_EVENT
+        },
+        onExit: 'EXIT_A',
+        initial: 'B',
+        states: {
+          B: {
+            on: {
+              B_EVENT: '#deep.DONE'
+            },
+            onExit: 'EXIT_B',
+            initial: 'C',
+            states: {
+              C: {
+                on: {
+                  C_EVENT: '#deep.DONE'
+                },
+                onExit: 'EXIT_C',
+                initial: 'D',
+                states: {
+                  D: {
+                    on: {
+                      D_EVENT: '#deep.DONE'
+                    },
+                    onExit: 'EXIT_D'
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  });
+
+  describe('exiting super/substates', () => {
+    it('should exit all substates when superstates exits (A_EVENT)', () => {
+      const actual = deepMachine.transition(deepMachine.initialState, 'A_EVENT')
+        .actions;
+      const expected = ['EXIT_D', 'EXIT_C', 'EXIT_B', 'EXIT_A'];
+      assert.deepEqual(actual, expected);
+    });
+
+    it('should exit substates and superstates when exiting (B_EVENT)', () => {
+      const actual = deepMachine.transition(deepMachine.initialState, 'B_EVENT')
+        .actions;
+      const expected = ['EXIT_D', 'EXIT_C', 'EXIT_B', 'EXIT_A'];
+      assert.deepEqual(actual, expected);
+    });
+
+    it('should exit substates and superstates when exiting (C_EVENT)', () => {
+      const actual = deepMachine.transition(deepMachine.initialState, 'C_EVENT')
+        .actions;
+      const expected = ['EXIT_D', 'EXIT_C', 'EXIT_B', 'EXIT_A'];
+      assert.deepEqual(actual, expected);
+    });
+
+    it('should exit superstates when exiting (D_EVENT)', () => {
+      const actual = deepMachine.transition(deepMachine.initialState, 'D_EVENT')
+        .actions;
+      const expected = ['EXIT_D', 'EXIT_C', 'EXIT_B', 'EXIT_A'];
+      assert.deepEqual(actual, expected);
+    });
+
+    it('should exit substate when machine handles event (MACHINE_EVENT)', () => {
+      const actual = deepMachine.transition(
+        deepMachine.initialState,
+        'MACHINE_EVENT'
+      ).actions;
+      const expected = ['EXIT_D', 'EXIT_C', 'EXIT_B', 'EXIT_A'];
+      assert.deepEqual(actual, expected);
+    });
+  });
+});

--- a/test/deep.test.ts
+++ b/test/deep.test.ts
@@ -15,8 +15,11 @@ describe('deep transitions', () => {
       A: {
         on: {
           A_EVENT: '#deep.DONE',
-          B_EVENT: 'FAIL' // shielded by B's B_EVENT
+          B_EVENT: 'FAIL', // shielded by B's B_EVENT
+          A_S: '#deep.P.Q.R.S',
+          A_P: '#deep.P'
         },
+        onEntry: 'ENTER_A',
         onExit: 'EXIT_A',
         initial: 'B',
         states: {
@@ -24,6 +27,7 @@ describe('deep transitions', () => {
             on: {
               B_EVENT: '#deep.DONE'
             },
+            onEntry: 'ENTER_B',
             onExit: 'EXIT_B',
             initial: 'C',
             states: {
@@ -31,14 +35,56 @@ describe('deep transitions', () => {
                 on: {
                   C_EVENT: '#deep.DONE'
                 },
+                onEntry: 'ENTER_C',
                 onExit: 'EXIT_C',
                 initial: 'D',
                 states: {
                   D: {
                     on: {
-                      D_EVENT: '#deep.DONE'
+                      D_EVENT: '#deep.DONE',
+                      D_S: '#deep.P.Q.R.S',
+                      D_P: '#deep.P'
                     },
+                    onEntry: 'ENTER_D',
                     onExit: 'EXIT_D'
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      P: {
+        on: {
+          P_EVENT: '#deep.DONE',
+          Q_EVENT: 'FAIL' // shielded by Q's Q_EVENT
+        },
+        onEntry: 'ENTER_P',
+        onExit: 'EXIT_P',
+        initial: 'Q',
+        states: {
+          Q: {
+            on: {
+              Q_EVENT: '#deep.DONE'
+            },
+            onEntry: 'ENTER_Q',
+            onExit: 'EXIT_Q',
+            initial: 'R',
+            states: {
+              R: {
+                on: {
+                  R_EVENT: '#deep.DONE'
+                },
+                onEntry: 'ENTER_R',
+                onExit: 'EXIT_R',
+                initial: 'S',
+                states: {
+                  S: {
+                    on: {
+                      S_EVENT: '#deep.DONE'
+                    },
+                    onEntry: 'ENTER_S',
+                    onExit: 'EXIT_S'
                   }
                 }
               }
@@ -84,6 +130,45 @@ describe('deep transitions', () => {
         'MACHINE_EVENT'
       ).actions;
       const expected = ['EXIT_D', 'EXIT_C', 'EXIT_B', 'EXIT_A'];
+      assert.deepEqual(actual, expected);
+    });
+
+    const DBCAPQRS = [
+      'EXIT_D',
+      'EXIT_C',
+      'EXIT_B',
+      'EXIT_A',
+      'ENTER_P',
+      'ENTER_Q',
+      'ENTER_R',
+      'ENTER_S'
+    ];
+
+    it('should exit deep and enter deep (A_S)', () => {
+      const actual = deepMachine.transition(deepMachine.initialState, 'A_S')
+        .actions;
+      const expected = DBCAPQRS;
+      assert.deepEqual(actual, expected);
+    });
+
+    it('should exit deep and enter deep (D_P)', () => {
+      const actual = deepMachine.transition(deepMachine.initialState, 'D_P')
+        .actions;
+      const expected = DBCAPQRS;
+      assert.deepEqual(actual, expected);
+    });
+
+    it('should exit deep and enter deep (A_P)', () => {
+      const actual = deepMachine.transition(deepMachine.initialState, 'A_P')
+        .actions;
+      const expected = DBCAPQRS;
+      assert.deepEqual(actual, expected);
+    });
+
+    it('should exit deep and enter deep (D_S)', () => {
+      const actual = deepMachine.transition(deepMachine.initialState, 'D_S')
+        .actions;
+      const expected = DBCAPQRS;
       assert.deepEqual(actual, expected);
     });
   });

--- a/test/deep.test.ts
+++ b/test/deep.test.ts
@@ -103,28 +103,28 @@ describe('deep transitions', () => {
       assert.deepEqual(actual, expected);
     });
 
-    it('should exit substates and superstates when exiting (B_EVENT)', () => {
+    xit('should exit substates and superstates when exiting (B_EVENT)', () => {
       const actual = deepMachine.transition(deepMachine.initialState, 'B_EVENT')
         .actions;
       const expected = ['EXIT_D', 'EXIT_C', 'EXIT_B', 'EXIT_A'];
       assert.deepEqual(actual, expected);
     });
 
-    it('should exit substates and superstates when exiting (C_EVENT)', () => {
+    xit('should exit substates and superstates when exiting (C_EVENT)', () => {
       const actual = deepMachine.transition(deepMachine.initialState, 'C_EVENT')
         .actions;
       const expected = ['EXIT_D', 'EXIT_C', 'EXIT_B', 'EXIT_A'];
       assert.deepEqual(actual, expected);
     });
 
-    it('should exit superstates when exiting (D_EVENT)', () => {
+    xit('should exit superstates when exiting (D_EVENT)', () => {
       const actual = deepMachine.transition(deepMachine.initialState, 'D_EVENT')
         .actions;
       const expected = ['EXIT_D', 'EXIT_C', 'EXIT_B', 'EXIT_A'];
       assert.deepEqual(actual, expected);
     });
 
-    it('should exit substate when machine handles event (MACHINE_EVENT)', () => {
+    xit('should exit substate when machine handles event (MACHINE_EVENT)', () => {
       const actual = deepMachine.transition(
         deepMachine.initialState,
         'MACHINE_EVENT'
@@ -151,7 +151,7 @@ describe('deep transitions', () => {
       assert.deepEqual(actual, expected);
     });
 
-    it('should exit deep and enter deep (D_P)', () => {
+    xit('should exit deep and enter deep (D_P)', () => {
       const actual = deepMachine.transition(deepMachine.initialState, 'D_P')
         .actions;
       const expected = DBCAPQRS;
@@ -165,7 +165,7 @@ describe('deep transitions', () => {
       assert.deepEqual(actual, expected);
     });
 
-    it('should exit deep and enter deep (D_S)', () => {
+    xit('should exit deep and enter deep (D_S)', () => {
       const actual = deepMachine.transition(deepMachine.initialState, 'D_S')
         .actions;
       const expected = DBCAPQRS;


### PR DESCRIPTION
This test case has a machine with four nested levels, A, B, C, D, which happens to be the initial state.  A has two sibling states DONE and FAIL, and the nodes A, B, C and D all react to A_EVENT, B_EVENT and so on.

Currently the test only checks that the right exit handlers are called, and exposes problems with handling deeply nested states.