### PR TITLE
Reject invalid state targets

### DIFF
--- a/src/StateNode.ts
+++ b/src/StateNode.ts
@@ -515,11 +515,13 @@ class StateNode implements StateNodeConfig {
     }
 
     const transition = this.on[eventType] as Transition;
-    let nextStateString: string | undefined;
+
+    let nextStateStrings: string[] = [];
 
     if (typeof transition === 'string') {
-      nextStateString = transition;
+      nextStateStrings = [transition];
     } else {
+      // convert object form to array form, by adding .target to each object
       const candidates = Array.isArray(transition)
         ? transition
         : Object.keys(transition).map(key => ({
@@ -547,7 +549,9 @@ class StateNode implements StateNodeConfig {
           (!cond || cond(extendedStateObject, eventObject)) &&
           (!stateIn || isInState)
         ) {
-          nextStateString = candidate.target;
+          nextStateStrings = Array.isArray(candidate.target)
+            ? candidate.target
+            : [candidate.target];
           if (transitionActions) {
             actionMap.actions = actionMap.actions.concat(transitionActions);
           }
@@ -556,7 +560,7 @@ class StateNode implements StateNodeConfig {
       }
     }
 
-    if (!nextStateString) {
+    if (nextStateStrings.length == 0) {
       return {
         statePaths: [],
         actions: actionMap,
@@ -565,107 +569,121 @@ class StateNode implements StateNodeConfig {
       };
     }
 
-    const nextStatePath = this.getResolvedPath(nextStateString);
-    let currentState = isStateId(nextStateString) ? this.machine : this.parent;
-    let currentHistory = history;
-    let currentPath = this.key;
+    const finalPaths: string[][] = [];
+    let raisedEvents = [];
 
-    nextStatePath.forEach(subPath => {
-      if (!currentState || !currentState.states) {
-        throw new Error(`Unable to read '${subPath}'`);
-      }
+    nextStateStrings.forEach(nextStateString => {
+      const nextStatePath = this.getResolvedPath(nextStateString);
+      let currentState = isStateId(nextStateString)
+        ? this.machine
+        : this.parent;
+      let currentHistory = history;
+      let currentPath = this.key;
 
-      if (subPath === HISTORY_KEY) {
-        if (currentHistory) {
-          subPath =
-            typeof currentHistory === 'object'
-              ? Object.keys(currentHistory)[0]
-              : currentHistory;
-        } else if (currentState.initial) {
-          subPath = currentState.initial;
-        } else {
+      nextStatePath.forEach(subPath => {
+        if (!currentState || !currentState.states) {
+          throw new Error(`Unable to read '${subPath}'`);
+        }
+
+        if (subPath === HISTORY_KEY) {
+          if (currentHistory) {
+            subPath =
+              typeof currentHistory === 'object'
+                ? Object.keys(currentHistory)[0]
+                : currentHistory;
+          } else if (currentState.initial) {
+            subPath = currentState.initial;
+          } else {
+            throw new Error(
+              `Cannot read '${HISTORY_KEY}' from state '${currentState.id}': missing 'initial'`
+            );
+          }
+        } else if (subPath === NULL_EVENT) {
+          actionMap.onExit = [];
+          currentState = currentState.getStateNode(this.key);
+          return;
+        }
+
+        try {
+          currentState = currentState.getStateNode(subPath);
+        } catch (e) {
           throw new Error(
-            `Cannot read '${HISTORY_KEY}' from state '${currentState.id}': missing 'initial'`
+            `Event '${event}' on state '${currentPath}' leads to undefined state '${nextStatePath.join(
+              STATE_DELIMITER
+            )}'.`
           );
         }
-      } else if (subPath === NULL_EVENT) {
-        actionMap.onExit = [];
-        currentState = currentState.getStateNode(this.key);
-        return;
+
+        if (currentState.onEntry) {
+          actionMap.onEntry = actionMap.onEntry.concat(currentState.onEntry);
+        }
+        if (currentState.activities) {
+          currentState.activities.forEach(activity => {
+            activityMap[getEventType(activity)] = true;
+            actionMap.onEntry = actionMap.onEntry.concat(start(activity));
+          });
+        }
+
+        currentPath = subPath;
+
+        if (currentHistory) {
+          currentHistory = currentHistory[subPath];
+        }
+      });
+
+      if (!currentState) {
+        throw new Error('no state');
       }
 
-      try {
-        currentState = currentState.getStateNode(subPath);
-      } catch (e) {
-        throw new Error(
-          `Event '${event}' on state '${currentPath}' leads to undefined state '${nextStatePath.join(
-            STATE_DELIMITER
-          )}'.`
+      let paths = [currentState.path];
+
+      if (currentState.initial || currentState.parallel) {
+        const { initialState } = currentState;
+        actionMap.onEntry = actionMap.onEntry.concat(initialState.actions);
+        paths = toStatePaths(initialState.value).map(subPath =>
+          currentState!.path.concat(subPath)
         );
       }
 
-      if (currentState.onEntry) {
-        actionMap.onEntry = actionMap.onEntry.concat(currentState.onEntry);
-      }
-      if (currentState.activities) {
-        currentState.activities.forEach(activity => {
-          activityMap[getEventType(activity)] = true;
-          actionMap.onEntry = actionMap.onEntry.concat(start(activity));
-        });
+      for (const path of paths) {
+        finalPaths[finalPaths.length] = path;
       }
 
-      currentPath = subPath;
+      while (currentState.initial) {
+        if (!currentState || !currentState.states) {
+          throw new Error(`Invalid initial state`);
+        }
+        currentState = currentState.states[currentState.initial];
 
-      if (currentHistory) {
-        currentHistory = currentHistory[subPath];
+        // if (currentState.onEntry) {
+        //   actionMap.onEntry = actionMap.onEntry.concat(currentState.onEntry);
+        // }
+        if (currentState.activities) {
+          currentState.activities.forEach(activity => {
+            activityMap[getEventType(activity)] = true;
+            actionMap.onEntry = actionMap.onEntry.concat(start(activity));
+          });
+        }
       }
+      // const myEvents : EventObject[] =
+      (currentState.onEntry
+        ? currentState.onEntry.filter(
+            action =>
+              typeof action === 'object' && action.type === actionTypes.raise
+          )
+        : []
+      ).concat(
+        currentState.on && currentState.on[NULL_EVENT]
+          ? { type: actionTypes.null }
+          : []
+      );
+      //myEvents.map(event => {
+      // TODO types... raisedEvents.push(event);
+      //});
     });
 
-    if (!currentState) {
-      throw new Error('no state');
-    }
-
-    let paths = [currentState.path];
-
-    if (currentState.initial || currentState.parallel) {
-      const { initialState } = currentState;
-      actionMap.onEntry = actionMap.onEntry.concat(initialState.actions);
-      paths = toStatePaths(initialState.value).map(subPath =>
-        currentState!.path.concat(subPath)
-      );
-    }
-
-    while (currentState.initial) {
-      if (!currentState || !currentState.states) {
-        throw new Error(`Invalid initial state`);
-      }
-      currentState = currentState.states[currentState.initial];
-
-      // if (currentState.onEntry) {
-      //   actionMap.onEntry = actionMap.onEntry.concat(currentState.onEntry);
-      // }
-      if (currentState.activities) {
-        currentState.activities.forEach(activity => {
-          activityMap[getEventType(activity)] = true;
-          actionMap.onEntry = actionMap.onEntry.concat(start(activity));
-        });
-      }
-    }
-
-    const raisedEvents = (currentState.onEntry
-      ? currentState.onEntry.filter(
-          action =>
-            typeof action === 'object' && action.type === actionTypes.raise
-        )
-      : []
-    ).concat(
-      currentState.on && currentState.on[NULL_EVENT]
-        ? { type: actionTypes.null }
-        : []
-    );
-
     return {
-      statePaths: paths,
+      statePaths: finalPaths,
       actions: actionMap,
       activities: activityMap,
       events: raisedEvents as EventObject[]

--- a/src/StateNode.ts
+++ b/src/StateNode.ts
@@ -570,7 +570,7 @@ class StateNode implements StateNodeConfig {
     }
 
     const finalPaths: string[][] = [];
-    let raisedEvents = [];
+    let raisedEvents: Action[] = [];
 
     nextStateStrings.forEach(nextStateString => {
       const nextStatePath = this.getResolvedPath(nextStateString);
@@ -669,8 +669,7 @@ class StateNode implements StateNodeConfig {
           });
         }
       }
-      // const myEvents : EventObject[] =
-      (currentState.onEntry
+      const myActions = (currentState.onEntry
         ? currentState.onEntry.filter(
             action =>
               typeof action === 'object' && action.type === actionTypes.raise
@@ -681,9 +680,7 @@ class StateNode implements StateNodeConfig {
           ? { type: actionTypes.null }
           : []
       );
-      //myEvents.map(event => {
-      // TODO types... raisedEvents.push(event);
-      //});
+      myActions.forEach(action => raisedEvents.push(action));
     });
 
     return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,7 +33,7 @@ export interface TransitionConfig {
 }
 
 export interface TargetTransitionConfig extends TransitionConfig {
-  target: string;
+  target: string | string[];
 }
 
 export type ConditionalTransitionConfig = TargetTransitionConfig[];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -102,11 +102,11 @@ export const toStatePaths = (stateValue: StateValue): string[][] => {
 export const pathsToStateValue = (paths: string[][]): StateValue => {
   const result: StateValue = {};
 
-  for (const currentPath of paths) {
-    if (currentPath.length === 1) {
-      return currentPath[0];
-    }
+  if (paths && paths.length === 1 && paths[0].length === 1) {
+    return paths[0][0];
+  }
 
+  for (const currentPath of paths) {
     let marker = result;
     // tslint:disable-next-line:prefer-for-of
     for (let i = 0; i < currentPath.length; i++) {

--- a/test/history.test.ts
+++ b/test/history.test.ts
@@ -140,7 +140,12 @@ describe('parallel history states', () => {
           SWITCH: 'on', // go to the initial states
           POWER: 'on.$history',
           DEEP_POWER: 'on.$history.$history',
-          DEEPEST_POWER: 'on.$history.$history.$history'
+          DEEPEST_POWER: 'on.$history.$history.$history',
+          PARALLEL_HISTORY: [{ target: ['on.A.$history', 'on.K.$history'] }],
+          PARALLEL_SOME_HISTORY: [{ target: ['on.A.C', 'on.K.$history'] }],
+          PARALLEL_DEEP_HISTORY: [
+            { target: ['on.A.$history.$history', 'on.K.$history.$history'] }
+          ]
         }
       },
       on: {
@@ -263,6 +268,36 @@ describe('parallel history states', () => {
       const stateOff = historyMachine.transition(stateACEKMO, 'POWER');
       assert.deepEqual(
         historyMachine.transition(stateOff, 'DEEPEST_POWER').value,
+        {
+          on: { A: { C: 'E' }, K: { M: 'O' } }
+        }
+      );
+    });
+
+    it('should re-enter multiple history states', () => {
+      const stateOff = historyMachine.transition(stateACEKMO, 'POWER');
+      assert.deepEqual(
+        historyMachine.transition(stateOff, 'PARALLEL_HISTORY').value,
+        {
+          on: { A: { C: 'D' }, K: { M: 'N' } }
+        }
+      );
+    });
+
+    it('should re-enter a parallel with partial history', () => {
+      const stateOff = historyMachine.transition(stateACEKMO, 'POWER');
+      assert.deepEqual(
+        historyMachine.transition(stateOff, 'PARALLEL_SOME_HISTORY').value,
+        {
+          on: { A: { C: 'D' }, K: { M: 'N' } }
+        }
+      );
+    });
+
+    it('should re-enter a parallel with full history', () => {
+      const stateOff = historyMachine.transition(stateACEKMO, 'POWER');
+      assert.deepEqual(
+        historyMachine.transition(stateOff, 'PARALLEL_DEEP_HISTORY').value,
         {
           on: { A: { C: 'E' }, K: { M: 'O' } }
         }

--- a/test/multiple.test.ts
+++ b/test/multiple.test.ts
@@ -12,7 +12,24 @@ describe('multiple', () => {
           DEEP_CM: [{ target: ['para.A.C', 'para.K.M'] }],
           DEEP_MR: [{ target: ['para.K.M', 'para.P.R'] }],
           DEEP_CMR: [{ target: ['para.A.C', 'para.K.M', 'para.P.R'] }],
+          BROKEN_SAME_REGION: [{ target: ['para.A.C', 'para.A.B'] }],
+          BROKEN_DIFFERENT_REGIONS: [
+            { target: ['para.A.C', 'para.K.M', 'other'] }
+          ],
+          BROKEN_DIFFERENT_REGIONS_2: [{ target: ['para.A.C', 'para2.K2.M2'] }],
+          BROKEN_DIFFERENT_REGIONS_3: [
+            { target: ['para2.K2.L2.L2A', 'other'] }
+          ],
+          BROKEN_DIFFERENT_REGIONS_4: [
+            { target: ['para2.K2.L2.L2A.L2C', 'para2.K2.M2'] }
+          ],
           INITIAL: 'para'
+        }
+      },
+      other: {
+        initial: 'X',
+        states: {
+          X: {}
         }
       },
       para: {
@@ -37,6 +54,82 @@ describe('multiple', () => {
             states: {
               Q: {},
               R: {}
+            }
+          }
+        }
+      },
+      para2: {
+        parallel: true,
+        states: {
+          A2: {
+            initial: 'B2',
+            states: {
+              B2: {},
+              C2: {}
+            }
+          },
+          K2: {
+            initial: 'L2',
+            states: {
+              L2: {
+                parallel: true,
+                states: {
+                  L2A: {
+                    initial: 'L2B',
+                    states: {
+                      L2B: {},
+                      L2C: {}
+                    }
+                  },
+                  L2K: {
+                    initial: 'L2L',
+                    states: {
+                      L2L: {},
+                      L2M: {}
+                    }
+                  },
+                  L2P: {
+                    initial: 'L2Q',
+                    states: {
+                      L2Q: {},
+                      L2R: {}
+                    }
+                  }
+                }
+              },
+              M2: {
+                parallel: true,
+                states: {
+                  M2A: {
+                    initial: 'M2B',
+                    states: {
+                      M2B: {},
+                      M2C: {}
+                    }
+                  },
+                  M2K: {
+                    initial: 'M2L',
+                    states: {
+                      M2L: {},
+                      M2M: {}
+                    }
+                  },
+                  M2P: {
+                    initial: 'M2Q',
+                    states: {
+                      M2Q: {},
+                      M2R: {}
+                    }
+                  }
+                }
+              }
+            }
+          },
+          P2: {
+            initial: 'Q2',
+            states: {
+              Q2: {},
+              R2: {}
             }
           }
         }
@@ -67,6 +160,48 @@ describe('multiple', () => {
     it('should enter specific states in some regions', () => {
       const stateMR = machine.transition(stateSimple, 'DEEP_MR');
       assert.deepEqual(stateMR.value, { para: { A: 'B', K: 'M', P: 'R' } });
+    });
+
+    it('should reject two targets in the same region', () => {
+      assert.throws(
+        () => machine.transition(stateSimple, 'BROKEN_SAME_REGION'),
+        "Event 'BROKEN_SAME_REGION' on state 'machine.simple' leads to an invalid configuration: Two or more states in the orthogonal region 'machine.para.A'"
+      );
+    });
+
+    it('should reject targets inside and outside a region', () => {
+      assert.throws(
+        () => machine.transition(stateSimple, 'BROKEN_DIFFERENT_REGIONS'),
+        "Event 'BROKEN_DIFFERENT_REGIONS' on state 'machine.simple' leads to an invalid configuration: Two or more states in the orthogonal region 'machine'"
+      );
+    });
+
+    it('should reject two targets in different regions', () => {
+      assert.throws(
+        () => machine.transition(stateSimple, 'BROKEN_DIFFERENT_REGIONS_2'),
+        "Event 'BROKEN_DIFFERENT_REGIONS_2' on state 'machine.simple' leads to an invalid configuration: Two or more states in the orthogonal region 'machine'"
+      );
+    });
+
+    it('should reject two targets in different regions at different levels', () => {
+      assert.throws(
+        () => machine.transition(stateSimple, 'BROKEN_DIFFERENT_REGIONS_3'),
+        "Event 'BROKEN_DIFFERENT_REGIONS_3' on state 'machine.simple' leads to an invalid configuration: Two or more states in the orthogonal region 'machine'"
+      );
+    });
+
+    it('should reject two deep targets in different regions at top level', () => {
+      assert.throws(
+        () => machine.transition(stateSimple, 'BROKEN_DIFFERENT_REGIONS_3'),
+        "Event 'BROKEN_DIFFERENT_REGIONS_3' on state 'machine.simple' leads to an invalid configuration: Two or more states in the orthogonal region 'machine'"
+      );
+    });
+
+    it('should reject two deep targets in different regions at different levels', () => {
+      assert.throws(
+        () => machine.transition(stateSimple, 'BROKEN_DIFFERENT_REGIONS_4'),
+        "Event 'BROKEN_DIFFERENT_REGIONS_4' on state 'machine.simple' leads to an invalid configuration: Two or more states in the orthogonal region 'machine.para2.K2'"
+      );
     });
   });
 });

--- a/test/multiple.test.ts
+++ b/test/multiple.test.ts
@@ -1,0 +1,66 @@
+import { assert } from 'chai';
+import { Machine } from '../src/index';
+
+describe('multiple', () => {
+  const machine = Machine({
+    key: 'machine',
+    initial: 'simple',
+    states: {
+      simple: {
+        on: {
+          DEEP_M: 'para.K.M',
+          //DEEP_CMR_O: { para:  {states: { A: 'C', K: 'M', P: 'R' } } },
+          DEEP_CMR: [{ target: ['para.A.C', 'para.K.M', 'para.P.R'] }],
+          INITIAL: 'para'
+        }
+      },
+      para: {
+        parallel: true,
+        states: {
+          A: {
+            initial: 'B',
+            states: {
+              B: {},
+              C: {}
+            }
+          },
+          K: {
+            initial: 'L',
+            states: {
+              L: {},
+              M: {}
+            }
+          },
+          P: {
+            initial: 'Q',
+            states: {
+              Q: {},
+              R: {}
+            }
+          }
+        }
+      }
+    }
+  });
+
+  describe('transitions to parallel states', () => {
+    const stateSimple = machine.initialState;
+    const stateInitial = machine.transition(stateSimple, 'INITIAL');
+    const stateM = machine.transition(stateSimple, 'DEEP_M');
+
+    it('should enter initial states of parallel states', () => {
+      assert.deepEqual(stateInitial.value, {
+        para: { A: 'B', K: 'L', P: 'Q' }
+      });
+    });
+
+    it('should enter specific states in one region', () => {
+      assert.deepEqual(stateM.value, { para: { A: 'B', K: 'M', P: 'Q' } });
+    });
+
+    it('should enter specific states in all regions', () => {
+      const stateCMR = machine.transition(stateSimple, 'DEEP_CMR');
+      assert.deepEqual(stateCMR.value, { para: { A: 'C', K: 'M', P: 'R' } });
+    });
+  });
+});

--- a/test/multiple.test.ts
+++ b/test/multiple.test.ts
@@ -9,7 +9,8 @@ describe('multiple', () => {
       simple: {
         on: {
           DEEP_M: 'para.K.M',
-          //DEEP_CMR_O: { para:  {states: { A: 'C', K: 'M', P: 'R' } } },
+          DEEP_CM: [{ target: ['para.A.C', 'para.K.M'] }],
+          DEEP_MR: [{ target: ['para.K.M', 'para.P.R'] }],
           DEEP_CMR: [{ target: ['para.A.C', 'para.K.M', 'para.P.R'] }],
           INITIAL: 'para'
         }
@@ -61,6 +62,11 @@ describe('multiple', () => {
     it('should enter specific states in all regions', () => {
       const stateCMR = machine.transition(stateSimple, 'DEEP_CMR');
       assert.deepEqual(stateCMR.value, { para: { A: 'C', K: 'M', P: 'R' } });
+    });
+
+    it('should enter specific states in some regions', () => {
+      const stateMR = machine.transition(stateSimple, 'DEEP_MR');
+      assert.deepEqual(stateMR.value, { para: { A: 'B', K: 'M', P: 'R' } });
     });
   });
 });


### PR DESCRIPTION
This change makes it possible to provide multiple targets instead of a single target in a transition, for example

    event : [ { target : "foo.foo" }, {target: "bar.bar" } ]

This is useful when foo and bar are both orthogonal regions, and that foo.foo and bar.bar is a respectively states in foo and bar.

There is some verification that the targets themselves are in fact non-conflicting, i.e. that you cannot target `foo.foo` _and_ `foo.baz`, since in region foo, only one of substates `foo.foo` and `foo.baz` can be active.  An exception is thrown in those cases.

Most of this diff is actually moving some code into a foreach loop, so the diff should be inspected with whitespace ignored (use ?w=1 on github). 