### PR TITLE
Add documentation for the array of state transitions mappings

### DIFF
--- a/docs/guides/guards.md
+++ b/docs/guides/guards.md
@@ -111,7 +111,7 @@ If you want to have a single event transition to different states in certain sit
 For example you can model a door that listens for an `OPEN` event, and opens if you are an admin and error if you are not:
 
 ```js
-var machine = new Machine({
+const machine = new Machine({
   id: 'door',
   initial: 'closed',
   states: {
@@ -136,18 +136,18 @@ var machine = new Machine({
   }
 });
 
-var fullState = { isAdmin: true };
+const fullState = { isAdmin: true };
 
-var state = machine.initialState;
-var state = machine.transition(state, 'OPEN', fullState);
-console.log(state.value); // 'opened'
+const firstState = machine.initialState;
+const secondState = machine.transition(state, 'OPEN', fullState);
+console.log(secondState.value); // 'opened'
 
-var state = machine.transition(state, 'CLOSE', fullState);
-console.log(state.value); // { closed: 'idle' }
+const thirdState = machine.transition(state, 'CLOSE', fullState);
+console.log(thirdState.value); // { closed: 'idle' }
 
 fullState.isAdmin = false;
-var state = machine.transition(state, 'OPEN', fullState);
-console.log(state.value); // { closed: 'error' }
+const fouthState = machine.transition(state, 'OPEN', fullState);
+console.log(fouthState.value); // { closed: 'error' }
 ```
 
 **Notes:**

--- a/docs/guides/guards.md
+++ b/docs/guides/guards.md
@@ -106,6 +106,50 @@ console.log(searchAttempt3.actions);
 // => ['executeSearch']
 ```
 
+If you want to have a single event transition to different states in certain sitations you can supply an array of targets with conditions.
+
+For example you can model a door that listens for an `OPEN` event, and opens if you are an admin and error if you are not:
+
+```js
+var machine = new Machine({
+  id: 'door',
+  initial: 'closed',
+  states: {
+    closed: {
+      initial: 'idle',
+      states: {
+        'idle': {},
+        'error': {}
+      },
+      on: {
+        OPEN: [
+          { target: 'opened', cond: (extState) => extState.isAdmin },
+          { target: 'closed.error' }
+        ]
+      }
+    },
+    opened: {
+      on: {
+        CLOSE: 'closed',
+      }
+    },
+  }
+});
+
+var fullState = { isAdmin: true };
+
+var state = machine.initialState;
+var state = machine.transition(state, 'OPEN', fullState);
+console.log(state.value); // 'opened'
+
+var state = machine.transition(state, 'CLOSE', fullState);
+console.log(state.value); // { closed: 'idle' }
+
+fullState.isAdmin = false;
+var state = machine.transition(state, 'OPEN', fullState);
+console.log(state.value); // { closed: 'error' }
+```
+
 **Notes:**
 - The `cond` function should always be a pure function that only references the `extendedState` and `eventObject` arguments.
 - Functions are not (easily) serializable in JSON. In future versions of `xstate`, alternative syntax for `cond` statements as plain strings or structured objects will be introduced to make it serializable.


### PR DESCRIPTION
This PR updates the documentation to show that you can pass an ordered array of state transition mappings to support transitioning to different states from a single event based on external state.

Based on a quick discussion with @davidkpiano at https://github.com/davidkpiano/xstate/issues/88#issuecomment-380880232