### PR TITLE
Fix typo describing the purpose of onExit actions

### DIFF
--- a/docs/api/actions.md
+++ b/docs/api/actions.md
@@ -24,7 +24,7 @@ An `Action` can be a:
 
 ## `stateNode.onExit`
 
-(`Action | Action[]`) The action(s) to be executed upon entering the state.
+(`Action | Action[]`) The action(s) to be executed upon exiting the state.
 
 **Usage:** A state's `onExit` actions will be executed in the following scenarios:
 - When the state is a leaf state and is exited to go to a different state


### PR DESCRIPTION
The onExit indicates that they run when entering a state instead of when leaving a state.