### PR TITLE
Guards can now access the interim states

### DIFF
--- a/src/StateNode.ts
+++ b/src/StateNode.ts
@@ -473,7 +473,7 @@ class StateNode implements StateNodeConfig {
         : true;
 
       if (
-        (!cond || this._evaluateCond(cond, extendedStateObject, eventObject)) &&
+        (!cond || this._evaluateCond(cond, extendedStateObject, eventObject, state.value)) &&
         (!stateIn || isInState)
       ) {
         nextStateStrings = Array.isArray(candidate.target)
@@ -595,7 +595,8 @@ class StateNode implements StateNodeConfig {
   private _evaluateCond(
     condition: Condition,
     extendedState: any,
-    eventObject: EventObject
+    eventObject: EventObject,
+    interimState: StateValue
   ): boolean {
     let condFn: ConditionPredicate;
 
@@ -612,7 +613,7 @@ class StateNode implements StateNodeConfig {
       condFn = condition;
     }
 
-    return condFn(extendedState, eventObject);
+    return condFn(extendedState, eventObject, interimState);
   }
   private _getActions(transition: _StateTransition): Action[] {
     const entryExitStates = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,7 +27,8 @@ export type StateValue = string | StateValueMap;
 
 export type ConditionPredicate = (
   extendedState: any,
-  event: EventObject
+  event: EventObject,
+  microstepState: StateValue
 ) => boolean;
 
 export type Condition = string | ConditionPredicate;


### PR DESCRIPTION
When a transition occurs, and you want to check e.g. if you're in
states X and Y at the same time, and only perform e.g. an automatic
transition when you're in that state, you need to access the states
that are happening as part of a microstep.

The guard function now support a third argument, namely the "interim
state" so to speak, which is a StateValue suitable for using with
matchesState in order to check if you're "in" various states.