### PR TITLE
Exposed but with activities and automatic transitions

### DIFF
--- a/test/activities.test.ts
+++ b/test/activities.test.ts
@@ -35,6 +35,31 @@ const lightMachine = Machine({
   }
 });
 
+describe('something activities', () => {
+  const machine = Machine({
+    initial: 'A',
+    states: {
+      A: {
+        on: {
+          E: 'B'
+        }
+      },
+      B: {
+        on: {
+          '': [{ cond: () => false, target: 'A' }]
+        },
+        activities: ['B_ACTIVITY']
+      }
+    }
+  });
+
+  it('should activate even if there are subsequent automatic, but blocked transitions', () => {
+    let state = machine.initialState;
+    state = machine.transition(state, 'E');
+    assert.deepEqual(state.activities, { B_ACTIVITY: true });
+  });
+});
+
 describe('activities', () => {
   it('identifies initial activities', () => {
     const { initialState } = lightMachine;


### PR DESCRIPTION
If you have an activity in a state, but the state has an automatic
transition to another state, but the guard fails, the activity is
forgotten; the 'activities' no longer indicates the activity as it
should.