### PR TITLE
Fixes #114

### DIFF
--- a/src/State.ts
+++ b/src/State.ts
@@ -20,7 +20,12 @@ export class State implements StateInterface {
       if (!stateValue.actions.length) {
         return stateValue;
       }
-      return new State(stateValue.value, stateValue.history, []);
+      return new State(
+        stateValue.value,
+        stateValue.history,
+        [],
+        stateValue.activities
+      );
     }
 
     return State.from(stateValue);

--- a/test/activities.test.ts
+++ b/test/activities.test.ts
@@ -35,7 +35,7 @@ const lightMachine = Machine({
   }
 });
 
-describe('something activities', () => {
+describe('activities with guarded transitions', () => {
   const machine = Machine({
     initial: 'A',
     states: {
@@ -56,6 +56,32 @@ describe('something activities', () => {
   it('should activate even if there are subsequent automatic, but blocked transitions', () => {
     let state = machine.initialState;
     state = machine.transition(state, 'E');
+    assert.deepEqual(state.activities, { B_ACTIVITY: true });
+  });
+});
+
+describe('remembering activities', () => {
+  const machine = Machine({
+    initial: 'A',
+    states: {
+      A: {
+        on: {
+          E: 'B'
+        }
+      },
+      B: {
+        on: {
+          E: 'A'
+        },
+        activities: ['B_ACTIVITY']
+      }
+    }
+  });
+
+  it('should remember the activities even after an event', () => {
+    let state = machine.initialState;
+    state = machine.transition(state, 'E');
+    state = machine.transition(state, 'IGNORE');
     assert.deepEqual(state.activities, { B_ACTIVITY: true });
   });
 });


### PR DESCRIPTION
Fixes #114.

State.inert didn't copy over any activites from the old state.

This is not the best way to deal with activities; ideally it should go through the current configuration of states and build up a correct view of all of the running activities based on which states are active, instead of relying on input like this.

But it gets the job done for normal use cases, no need to protect people from shooting themselves in the foot, eh?  Jolly good!