### PR TITLE
Use import helpers from tslib package

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,5 +44,7 @@
     "webpack": "^3.5.6",
     "xml-js": "^1.6.2"
   },
-  "dependencies": {}
+  "dependencies": {
+    "tslib": "^1.9.2"
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "strictNullChecks": true,
     "outDir": "./lib",
     "moduleResolution": "node",
+    "importHelpers": true,
     "lib": [
       "es6",
       "dom"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2858,6 +2858,10 @@ tslib@^1.7.1:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.8.0.tgz#dc604ebad64bcbf696d613da6c954aa0e7ea1eb6"
 
+tslib@^1.9.2:
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.2.tgz#8be0cc9a1f6dc7727c38deb16c2ebd1a2892988e"
+
 tslint@^5.7.0:
   version "5.8.0"
   resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.8.0.tgz#1f49ad5b2e77c76c3af4ddcae552ae4e3612eb13"
@@ -2898,9 +2902,9 @@ type-detect@^4.0.0:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.5.tgz#d70e5bc81db6de2a381bcaca0c6e0cbdc7635de2"
 
-typescript@^2.7.1:
-  version "2.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.3.tgz#5d817f9b6f31bb871835f4edf0089f21abe6c170"
+typescript@^2.8.3:
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.1.tgz#fdb19d2c67a15d11995fd15640e373e09ab09961"
 
 uglify-js@^2.8.29:
   version "2.8.29"


### PR DESCRIPTION
This should allow bundlers to dedupe typescript helpers across packages using `tslib`.