### PR TITLE
Fixing #131: Transition to self wrongly stops activity

### DIFF
--- a/src/StateNode.ts
+++ b/src/StateNode.ts
@@ -653,16 +653,6 @@ class StateNode {
 
     const activityMap = { ...state.activities };
 
-    Array.from(transition.entryExitStates.entry).forEach(stateNode => {
-      if (!stateNode.activities) {
-        return; // TODO: fixme
-      }
-
-      stateNode.activities.forEach(activity => {
-        activityMap[getActionType(activity)] = true;
-      });
-    });
-
     Array.from(transition.entryExitStates.exit).forEach(stateNode => {
       if (!stateNode.activities) {
         return; // TODO: fixme
@@ -670,6 +660,16 @@ class StateNode {
 
       stateNode.activities.forEach(activity => {
         activityMap[getActionType(activity)] = false;
+      });
+    });
+
+    Array.from(transition.entryExitStates.entry).forEach(stateNode => {
+      if (!stateNode.activities) {
+        return; // TODO: fixme
+      }
+
+      stateNode.activities.forEach(activity => {
+        activityMap[getActionType(activity)] = true;
       });
     });
 

--- a/test/activities.test.ts
+++ b/test/activities.test.ts
@@ -203,6 +203,21 @@ describe('transient activities', () => {
           B1: '.B1',
           B2: '.B2'
         }
+      },
+      C: {
+        initial: 'C1',
+        states: {
+          C1: {
+            activities: ['C1'],
+            on: {
+              C: 'C1',
+              C_SIMILAR: 'C2'
+            }
+          },
+          C2: {
+            activities: ['C1'],
+          },
+        }
       }
     }
   });
@@ -223,10 +238,22 @@ describe('transient activities', () => {
     assert.deepEqual(state.activities.A, true);
   });
 
+  it('should have kept same activities', () => {
+    let state = machine.initialState;
+    state = machine.transition(state, 'C_SIMILAR');
+    assert.deepEqual(state.activities.C1, true);
+  });
+
+  it('should have kept same activities after self transition', () => {
+    let state = machine.initialState;
+    state = machine.transition(state, 'C');
+    assert.deepEqual(state.activities.C1, true);
+  });
+
   it('should have stopped after automatic transitions', () => {
     let state = machine.initialState;
     state = machine.transition(state, 'A');
-    assert.deepEqual(state.value, { A: 'A2', B: 'B2' });
+    assert.deepEqual(state.value, { A: 'A2', B: 'B2', C: 'C1' });
     assert.deepEqual(state.activities.B2, true);
   });
 });


### PR DESCRIPTION
Fixes #131.

StateNode should handle the exit states first before the entry states to determine activities.

Also added two tests:
(1) testing that same activities are maintained during a normal transition
(2) testing that same activities are maintained during a self transition

Btw, 2 tests are failing but that's because of commit f93cb57 which added tests that are meant to fail.
