### PR TITLE
[docs:actions] add missing showLoader to result actions

### DIFF
--- a/docs/api/actions.md
+++ b/docs/api/actions.md
@@ -77,6 +77,7 @@ console.log(fetchMachine.transition(fetchMachine.initialState, 'FETCH'));
 //   actions: [
 //     'preloadViews', // onExit action for 'idle' state
 //     'warmCache', // transition action for 'idle' -> 'pending' on 'FETCH'
+//     [Function: showLoader], // transition action for 'idle' -> 'pending' on 'FETCH'
 //     'fetchData' // onEntry action for 'pending' state
 //   ]
 // }


### PR DESCRIPTION
When I run this sample code on the `actions` doc:

```js
const { Machine } = require('xstate');


// example of a named function action
function showLoader(extState, event) {
  // ...
}

const fetchMachine = Machine({
  initial: 'idle',
  states: {
    idle: {
      on: {
        FETCH: {
          pending: {
            // transition actions
            actions: ['warmCache', showLoader]
          }
        }
      },
      // onExit actions
      onExit: ['preloadViews']
    },
    pending: {
      // onEntry actions
      onEntry: ['fetchData']
    }
  }
});

console.log(fetchMachine.transition(fetchMachine.initialState, 'FETCH'));
```

I got:

<img width="626" alt="2018-08-04 1 31 14" src="https://user-images.githubusercontent.com/3382565/43672895-b3e45334-97ea-11e8-8dbe-0d18e49be189.png">
