### PR TITLE
Make actionTypes a namespace module instead of an object

### DIFF
--- a/src/StateNode.ts
+++ b/src/StateNode.ts
@@ -44,11 +44,11 @@ import {
 } from './types';
 import { matchesState } from './matchesState';
 import { State } from './State';
+import * as actionTypes from './actionTypes';
 import {
   start,
   stop,
   toEventObject,
-  actionTypes,
   AssignAction
 } from './actions';
 

--- a/src/actionTypes.ts
+++ b/src/actionTypes.ts
@@ -1,0 +1,13 @@
+const PREFIX = 'xstate';
+
+// xstate-specific action types
+export const start = `${PREFIX}.start`;
+export const stop = `${PREFIX}.stop`;
+export const raise = `${PREFIX}.raise`;
+export const send = `${PREFIX}.send`;
+export const cancel = `${PREFIX}.cancel`;
+export const _null = `${PREFIX}.null`;
+export { _null as null };
+export const assign = `${PREFIX}.assign`;
+
+

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -11,20 +11,10 @@ import {
   ActionType,
   DefaultExtState
 } from './types';
+import * as actionTypes from './actionTypes';
 import { getEventType } from './utils';
 
-const PREFIX = 'xstate';
-
-// xstate-specific action types
-export const actionTypes = {
-  start: `${PREFIX}.start`,
-  stop: `${PREFIX}.stop`,
-  raise: `${PREFIX}.raise`,
-  send: `${PREFIX}.send`,
-  cancel: `${PREFIX}.cancel`,
-  null: `${PREFIX}.null`,
-  assign: `${PREFIX}.assign`
-};
+export { actionTypes };
 
 const createActivityAction = (actionType: string) => (
   activity: ActionType | ActionObject

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -8,7 +8,8 @@ import {
   DefaultExtState
 } from './types';
 import { State } from './State';
-import { toEventObject, actionTypes, toActionObject } from './actions';
+import * as actionTypes from './actionTypes';
+import { toEventObject, toActionObject } from './actions';
 
 export type StateListener = <TExtState = DefaultExtState>(
   state: State<TExtState>


### PR DESCRIPTION
This allows bundlers to inline references to those types as variables and not as object properties. 

Bundling an empty project importing xstate with webpack before this PR results in 5772 bytes (minified, gzipped), after this PR - 5729 bytes. Not the biggest savings 😉 I'll let you to decide if you want to merge this based on that.