### PR TITLE
Delete build folder and recreate on build command

### DIFF
--- a/docs-src/package.json
+++ b/docs-src/package.json
@@ -38,9 +38,9 @@
   "license": "MIT",
   "scripts": {
     "start": "gatsby develop",
-    "build": "rimraf ../docs && gatsby build && mv public ../docs",
+    "build": "rimraf ../docs && gatsby build --prefix-paths && mv public ../docs",
     "develop": "gatsby develop",
-    "deploy": "gatsby build --prefix-paths && gh-pages -d public",
+    "deploy": "npm run build && gh-pages -d public",
     "format": "prettier --write '**/*.js'",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/docs-src/package.json
+++ b/docs-src/package.json
@@ -38,7 +38,7 @@
   "license": "MIT",
   "scripts": {
     "start": "gatsby develop",
-    "build": "gatsby build",
+    "build": "rimraf ../docs && gatsby build && mv public ../docs",
     "develop": "gatsby develop",
     "deploy": "gatsby build --prefix-paths && gh-pages -d public",
     "format": "prettier --write '**/*.js'",


### PR DESCRIPTION
Instead of manually moving the docs folder over on build, hook in through npm scripts.