### PR TITLE
Fix hierarchical doc broken url

### DIFF
--- a/docs/src/pages/guides/hierarchical.mdx
+++ b/docs/src/pages/guides/hierarchical.mdx
@@ -86,7 +86,7 @@ console.log(lightMachine.transition({ red: 'stop' }, 'TIMER').value);
 // => 'green'
 ```
 
-If neither a state nor any of its ancestor (parent) states handle an event, no transition happens. In `strict` mode (specified in the [machine configuration](api/config.md)), this will throw an error.
+If neither a state nor any of its ancestor (parent) states handle an event, no transition happens. In `strict` mode (specified in the [machine configuration](../api/config.md)), this will throw an error.
 
 ```js
 console.log(lightMachine.transition('green', 'UNKNOWN').value);


### PR DESCRIPTION
The url at the bottom that references to strict mode config doc is broken ([see here](https://xstate.js.org/docs/guides/hierarchical/)). I'm not really sure the change I'm proposing solves it since I'm writing it from the browser without testing it.