### PR TITLE
Rename Machine interface to StateMachine

### DIFF
--- a/src/Machine.ts
+++ b/src/Machine.ts
@@ -1,5 +1,5 @@
 import {
-  Machine,
+  StateMachine,
   MachineOptions,
   DefaultContext,
   MachineConfig,
@@ -16,10 +16,10 @@ export function Machine<
   config: MachineConfig<TContext, TStateSchema, TEvent>,
   options?: MachineOptions<TContext, TEvent>,
   initialContext: TContext | undefined = config.context
-): Machine<TContext, TStateSchema, TEvent> {
+): StateMachine<TContext, TStateSchema, TEvent> {
   return new StateNode<TContext, TStateSchema, TEvent>(
     config,
     options,
     initialContext
-  ) as Machine<TContext, TStateSchema, TEvent>;
+  ) as StateMachine<TContext, TStateSchema, TEvent>;
 }

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -18,7 +18,7 @@ import {
   SpecialTargets,
   InvokeDefinition,
   RaiseEvent,
-  Machine,
+  StateMachine,
   DoneEvent,
   InvokeConfig,
   ErrorExecutionEvent,
@@ -354,7 +354,7 @@ export function invoke<TContext, TEvent extends EventObject>(
   invokeConfig:
     | string
     | InvokeConfig<TContext, TEvent>
-    | Machine<any, any, any>,
+    | StateMachine<any, any, any>,
   options?: Partial<InvokeDefinition<TContext, TEvent>>
 ): InvokeDefinition<TContext, TEvent> {
   if (typeof invokeConfig === 'string') {
@@ -367,7 +367,7 @@ export function invoke<TContext, TEvent extends EventObject>(
   }
 
   if (!('src' in invokeConfig)) {
-    const machine = invokeConfig as Machine<any, any, any>;
+    const machine = invokeConfig as StateMachine<any, any, any>;
 
     return {
       type: ActionTypes.Invoke,

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -1,5 +1,5 @@
 import {
-  Machine as XSMachine,
+  StateMachine,
   Event,
   EventObject,
   SendAction,
@@ -160,7 +160,7 @@ export class Interpreter<
    * @param options Interpreter options
    */
   constructor(
-    public machine: XSMachine<TContext, TStateSchema, TEvent>,
+    public machine: StateMachine<TContext, TStateSchema, TEvent>,
     options: Partial<InterpreterOptions> = Interpreter.defaultOptions
   ) {
     const resolvedOptions: InterpreterOptions = {
@@ -574,7 +574,7 @@ export class Interpreter<
     TChildStateSchema,
     TChildEvents extends EventObject
   >(
-    machine: XSMachine<TChildContext, TChildStateSchema, TChildEvents>,
+    machine: StateMachine<TChildContext, TChildStateSchema, TChildEvents>,
     options: { id?: string; autoForward?: boolean } = {}
   ): Interpreter<TChildContext, TChildStateSchema, TChildEvents> {
     const childInterpreter = new Interpreter(machine, {
@@ -609,7 +609,7 @@ export function interpret<
   TStateSchema extends StateSchema = any,
   TEvent extends EventObject = EventObject
 >(
-  machine: XSMachine<TContext, TStateSchema, TEvent>,
+  machine: StateMachine<TContext, TStateSchema, TEvent>,
   options?: Partial<InterpreterOptions>
 ) {
   const interpreter = new Interpreter(machine, options);

--- a/src/types.ts
+++ b/src/types.ts
@@ -141,7 +141,7 @@ export interface InvokeDefinition<TContext, TEvent extends EventObject>
   /**
    * The source of the machine to be invoked, or the machine itself.
    */
-  src: string | Machine<any, any, any> | InvokeCreator<any, TContext>;
+  src: string | StateMachine<any, any, any> | InvokeCreator<any, TContext>;
   /**
    * Whether any events sent to the parent are forwarded to the invoked child machine.
    */
@@ -251,7 +251,7 @@ export type InvokeConfig<TContext, TEvent extends EventObject> =
       /**
        * The source of the machine to be invoked, or the machine itself.
        */
-      src: string | Machine<any, any, any> | InvokeCreator<any, TContext>;
+      src: string | StateMachine<any, any, any> | InvokeCreator<any, TContext>;
       /**
        * Whether any events sent to the parent are forwarded to the invoked child machine.
        */
@@ -276,7 +276,7 @@ export type InvokeConfig<TContext, TEvent extends EventObject> =
         | string
         | SingleOrArray<TransitionConfig<TContext, DoneInvokeEvent<any>>>;
     }
-  | Machine<any, any, any>;
+  | StateMachine<any, any, any>;
 
 export type InvokesConfig<TContext, TEvent extends EventObject> =
   | InvokeConfig<TContext, TEvent>
@@ -502,7 +502,7 @@ export interface HistoryStateNode<TContext> extends StateNode<TContext> {
   target: StateValue | undefined;
 }
 
-export interface Machine<
+export interface StateMachine<
   TContext,
   TStateSchema extends StateSchema,
   TEvent extends EventObject


### PR DESCRIPTION
This avoids the name collision with the `Machine` function and removes the need
to alias the interface in places where both are imported.