### PR TITLE
Return `/es` built assets to the publication

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "types": "lib/index.d.ts",
   "files": [
     "dist",
-    "lib"
+    "lib",
+    "es"
   ],
   "keywords": [
     "statechart",


### PR DESCRIPTION
Fixes #241 

Corrects the mismatch in the publication setting found in `package.json` to match those previously deployed at the intersection of the `.gitignore` and `.npmignore` files.