### PR TITLE
fix(interpretor) add better error message for invalid init state

### DIFF
--- a/src/StateNode.ts
+++ b/src/StateNode.ts
@@ -1346,6 +1346,12 @@ class StateNode<
       return key;
     }
 
+    if (!this.states[this.initial]){
+      throw new Error(
+        `Initial state '${this.initial}' not found on '${key}'`
+      );
+    }
+
     return {
       [key]: this.states[this.initial].resolvedStateValue
     };

--- a/test/interpreter.test.ts
+++ b/test/interpreter.test.ts
@@ -207,6 +207,28 @@ describe('interpreter', () => {
     assert.doesNotThrow(() => service.send('SOME_EVENT'));
   });
 
+  it('should throw an error if initial state sent to interpreter is invalid', () => {
+    const invalidMachine = {
+      id: 'fetchMachine',
+      initial: 'create',
+      states: {
+        edit: {
+          initial: 'idle',
+          states: {
+            idle: {
+              on: {
+                FETCH: 'pending'
+              }
+            }
+          }
+        }
+      }
+    }
+
+    const service = interpret(Machine(invalidMachine))
+    assert.throws(() => service.start(), `Initial state 'create' not found on 'fetchMachine'`);
+  });
+
   it('should not update when stopped', () => {
     let state = lightMachine.initialState;
     const service = interpret(lightMachine).onTransition(s => (state = s));


### PR DESCRIPTION
Fix cryptic message when initial state is invalid:
![image](https://user-images.githubusercontent.com/5770711/48795225-0ca05200-ecb1-11e8-865c-681b8bf636b4.png)
