### PR TITLE
Fix passing of services using withConfig

### DIFF
--- a/src/StateNode.ts
+++ b/src/StateNode.ts
@@ -287,14 +287,15 @@ class StateNode<
     options: MachineOptions<TContext, TEvent>,
     context: TContext | undefined = this.context
   ): StateNode<TContext, TStateSchema, TEvent> {
-    const { actions, activities, guards } = this.options;
+    const { actions, activities, guards, services } = this.options;
 
     return new StateNode(
       this.definition,
       {
         actions: { ...actions, ...options.actions },
         activities: { ...activities, ...options.activities },
-        guards: { ...guards, ...options.guards }
+        guards: { ...guards, ...options.guards },
+        services: { ...services, ...options.services }
       },
       context
     );

--- a/test/invoke.test.ts
+++ b/test/invoke.test.ts
@@ -162,6 +162,24 @@ describe('invoke', () => {
       .send('GO_TO_WAITING_MACHINE');
   });
 
+  it('should use the service overwritten by withConfig', () => {
+    const service = interpret(parentMachine.withConfig({
+      services: {
+        child: Machine({
+          id: 'child',
+          initial: 'init',
+          states: {
+            init: {
+              onEntry: [actions.sendParent('STOP')]
+            }
+          }
+        })
+      }
+    })).start();
+
+    assert.deepEqual(service.state.value, 'stop');
+  });
+
   describe('with promises', () => {
     const invokePromiseMachine = Machine({
       id: 'invokePromise',


### PR DESCRIPTION
This PR fixes a behaviour I bumped into. According [to docs](https://github.com/davidkpiano/xstate/blob/951f7fba4bdd1bc5775023b3c7886095f41a8191/docs/guides/communication.md#testing) and the comment in the `withConfig` function it should be possible to pass the services to the state machine using the `withConfig` function.

I am not sure if I've chosen the right test file to put my test into. The `machine.test.ts` was my first choice but I would have to add a lot of code there to set up the test objects properly. I've chosen to put in `invoke.test.ts` instead as most of the setup is already done there.

P.S. Thank a lot for this awesome project. I am following it for a while and I would like to finally use it for a production app. I've learned a ton from it!