### PR TITLE
add note about not using keyofStringsOnly

### DIFF
--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -85,3 +85,11 @@ Providing the context, state schema, and events as generic parameters for the `M
 - The context type/interface (`TContext`) is passed on to action `exec` functions, guard `cond` functions, and more. It is also passed to deeply nested states.
 - The state schema type/interface (`TStateSchema`) ensures that only state keys defined on the schema are allowed in the actual config object. Nested state schemas are recursively passed down to their representative child states.
 - The event type (`TEvent`) ensures that only specified events (and built-in XState-specific ones) are used in transition configs. The provided event object shapes are also passed on to action `exec` functions, guard `cond` functions, and more. This can prevent unnecessary `event.somePayload === undefined` checks.
+
+Note if you are seeing this error:
+
+```
+Type error: Type 'string | number' does not satisfy the constraint 'string'.
+  Type 'number' is not assignable to type 'string'.  TS2344
+```
+Ensure that your tsconfig file can does not include `"keyofStringsOnly": true,`.


### PR DESCRIPTION
Typescript compilation error: Using the example from https://xstate.js.org/docs/guides/typescript.html#using-typescript with typescript 3.2.4I get an error in `/node_modules/xstate/lib/types.d.ts` line 134 

```
Type error: Type 'string | number' does not satisfy the constraint 'string'.
  Type 'number' is not assignable to type 'string'.  TS2344

    132 |     delay: number;
    133 | }
  > 134 | export declare type DelayedTransitions<TContext, TEvent extends EventObject> = Record<string | number, string | TransitionConfig<TContext, TEvent> | Array<TransitionConfig<TContext, TEvent>>> | Array<TransitionConfig<TContext, TEvent> & {
        |                                                                                       ^
    135 |     delay: number;
    136 | }>;
    137 | export declare type StateTypes = 'atomic' | 'compound' | 'parallel' | 'final' | 'history' | string;
```


This was due to my tsconfig having the flag `"keyofStringsOnly": true,` set to true. Setting it to false resolved the problem