### PR TITLE
Improve the typing of StateListener

### DIFF
--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -25,7 +25,7 @@ import { StateNode, IS_PRODUCTION } from './StateNode';
 import { mapContext } from './utils';
 
 export type StateListener<TContext, TEvent extends EventObject> = (
-  state: State<TContext>,
+  state: State<TContext, TEvent>,
   event: OmniEventObject<TEvent>
 ) => void;
 


### PR DESCRIPTION
In the current state (unintended pun), the `onTransition` method in the default interpreter gives a `StateListener` type which is defined like this:

```Typescript
export declare type StateListener<TContext, TEvent extends EventObject> = (state: State<TContext>, event: OmniEventObject<TEvent>) => void;
```

As you can see, the `state` type is `State<TContext>` which equals to `State<TContext, EventObject>`. We can set it to `State<TContext, TEvent>` to give a more strict type.