### PR TITLE
Test case for #364

### DIFF
--- a/test/invoke.test.ts
+++ b/test/invoke.test.ts
@@ -530,67 +530,6 @@ describe('invoke', () => {
         .start();
     });
 
-    it('should be invoked with a promise factory and resolve through onDone for parallel state nodes', done => {
-      const promiseMachine = Machine({
-        id: 'promise',
-        initial: 'parent',
-        states: {
-          parent: {
-            type: 'parallel',
-            states: {
-              pending: {
-                invoke: {
-                  src: () => Promise.resolve(),
-                  onDone: 'done'
-                }
-              },
-              done: {
-                type: 'final'
-              }
-            }
-          }
-        }
-      });
-
-      interpret(promiseMachine)
-        .onDone(() => done())
-        .start();
-    });
-
-    it('should be invoked with a promise service and resolve through onDone for parallel state nodes', done => {
-      const promiseMachine = Machine(
-        {
-          id: 'promise',
-          initial: 'parent',
-          states: {
-            parent: {
-              initial: 'pending',
-              states: {
-                pending: {
-                  invoke: {
-                    src: 'somePromise',
-                    onDone: 'done'
-                  }
-                },
-                done: {
-                  type: 'final'
-                }
-              }
-            }
-          }
-        },
-        {
-          services: {
-            somePromise: () => Promise.resolve()
-          }
-        }
-      );
-
-      interpret(promiseMachine)
-        .onDone(() => done())
-        .start();
-    });
-
     it('should provide the resolved data when invoked with a promise factory', done => {
       const resolvedData = { foo: true };
 

--- a/test/invoke.test.ts
+++ b/test/invoke.test.ts
@@ -469,6 +469,67 @@ describe('invoke', () => {
         .start();
     });
 
+    it('should be provide the resolved data when invoked with a promise factory', done => {
+      const resolvedData = { foo: true };
+
+      const promiseMachine = Machine({
+        id: 'promise',
+        initial: 'pending',
+        states: {
+          pending: {
+            invoke: {
+              src: () => Promise.resolve(resolvedData),
+              onDone: 'done'
+            }
+          },
+          done: {
+            type: 'final'
+          }
+        }
+      });
+
+      interpret(promiseMachine)
+        .onDone(event => {
+          assert.deepEqual(event.data, resolvedData);
+          done();
+        })
+        .start();
+    });
+
+    it('should be provide the resolved data when invoked with a promise service', done => {
+      const resolvedData = { foo: true };
+
+      const promiseMachine = Machine(
+        {
+          id: 'promise',
+          initial: 'pending',
+          states: {
+            pending: {
+              invoke: {
+                src: 'somePromise',
+                onDone: 'done'
+              }
+            },
+            done: {
+              type: 'final'
+            }
+          }
+        },
+        {
+          services: {
+            somePromise: () => Promise.resolve(resolvedData)
+          }
+        }
+      );
+
+      interpret(promiseMachine)
+        .onDone(event => {
+          assert.deepEqual(event.data, resolvedData);
+          done();
+        })
+        .start();
+    });
+
     it('should be able to specify a Promise as a service', done => {
       const promiseMachine = Machine(
         {

--- a/test/invoke.test.ts
+++ b/test/invoke.test.ts
@@ -480,13 +480,17 @@ describe('invoke', () => {
               pending: {
                 invoke: {
                   src: () => Promise.resolve(),
-                  onDone: 'done'
+                  onDone: 'success'
                 }
               },
-              done: {
+              success: {
                 type: 'final'
               }
-            }
+            },
+            onDone: 'success'
+          },
+          success: {
+            type: 'final'
           }
         }
       });
@@ -508,13 +512,17 @@ describe('invoke', () => {
                 pending: {
                   invoke: {
                     src: 'somePromise',
-                    onDone: 'done'
+                    onDone: 'success'
                   }
                 },
-                done: {
+                success: {
                   type: 'final'
                 }
-              }
+              },
+              onDone: 'success'
+            },
+            success: {
+              type: 'final'
             }
           }
         },
@@ -540,10 +548,10 @@ describe('invoke', () => {
           pending: {
             invoke: {
               src: () => Promise.resolve(resolvedData),
-              onDone: 'done'
+              onDone: 'success'
             }
           },
-          done: {
+          success: {
             type: 'final'
           }
         }
@@ -568,10 +576,10 @@ describe('invoke', () => {
             pending: {
               invoke: {
                 src: 'somePromise',
-                onDone: 'done'
+                onDone: 'success'
               }
             },
-            done: {
+            success: {
               type: 'final'
             }
           }

--- a/test/invoke.test.ts
+++ b/test/invoke.test.ts
@@ -469,7 +469,7 @@ describe('invoke', () => {
         .start();
     });
 
-    it('should be provide the resolved data when invoked with a promise factory', done => {
+    it('should provide the resolved data when invoked with a promise factory', done => {
       const resolvedData = { foo: true };
 
       const promiseMachine = Machine({
@@ -496,7 +496,7 @@ describe('invoke', () => {
         .start();
     });
 
-    it('should be provide the resolved data when invoked with a promise service', done => {
+    it('should provide the resolved data when invoked with a promise service', done => {
       const resolvedData = { foo: true };
 
       const promiseMachine = Machine(


### PR DESCRIPTION
I'm not sure I wrote the tests correctly, but I tried. 😅

### First Issue

Promise factory invocations are not working for build `v4.3.1`.

```
No service found for invocation 'promise.parent.pending:invocation[0]' in machine 'promise'. 
```

You can reproduce by visiting https://codesandbox.io/s/w0zqnkz5jl (check CodeSandbox console)

Only the npm build is failing, so I believe it was fixed in the master branch. The tests I wrote for that issue are passing.

---

### Second Issue

Seems like `v4.2.4` broke `event.data` for `invoke.onDone.actions` (custom actions only): https://codesandbox.io/s/o46qov4mx9 (check CodeSandbox console).

I believe https://github.com/davidkpiano/xstate/commit/9674b614be342fde84680f8bcd668d74ca9eaef8 broke it because it was working in `v4.2.3`: https://codesandbox.io/s/3v418p65vp (check CodeSandbox console).


I also wrote test cases for testing `event.data` both for built-in actions like `assign` and for custom actions. Only custom actions are failing.
