### PR TITLE
fix: support multiple simultaneous services

### DIFF
--- a/src/StateNode.ts
+++ b/src/StateNode.ts
@@ -286,7 +286,7 @@ class StateNode<
         const invokeSrc = `${this.id}:invocation[${i}]`; // TODO: util function
         this.machine.options.services = {
           [invokeSrc]: invokeConfig.src,
-          ...(this.parent || this).options.services
+          ...(this.machine.options.services || {})
         };
 
         return {


### PR DESCRIPTION
Fixes #367 

This adds test cases for the two failing examples in #367 and also adds a variation of the fix I suggested. After more staring at `StateNode.ts` I think the original object being spread there might've been a copy-paste error, I can't come up with a reason why you'd want to set `machine.options.services` to the node or parent's `options.services`. If that's wrong and that is desired behavior it's easy to add that line back.

All tests new & old are passing for me locally with the change to `StateNode.ts` though, so if it is necessary it probably needs a test for that behavior 😃 