### PR TITLE
Fixup env checks

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,7 +3,7 @@ import { terser } from 'rollup-plugin-terser';
 import rollupReplace from 'rollup-plugin-replace';
 import fileSize from 'rollup-plugin-filesize';
 
-const createConfig = ({ input, output }) => ({
+const createConfig = ({ input, output, target }) => ({
   input,
   output,
   plugins: [
@@ -14,11 +14,14 @@ const createConfig = ({ input, output }) => ({
       clean: true,
       tsconfigOverride: {
         compilerOptions: {
-          declaration: false
+          declaration: false,
+          ...(target ? { target } : {})
         }
       }
     }),
-    terser(),
+    terser({
+      toplevel: true,
+    }),
     fileSize()
   ]
 });
@@ -47,5 +50,13 @@ export default [
       format: 'umd',
       name: 'XStateInterpreter'
     }
+  }),
+  createConfig({
+    input: 'src/index.ts',
+    output: {
+      file: 'dist/xstate.web.js',
+      format: 'esm'
+    },
+    target: 'ES2015'
   })
 ];

--- a/src/StateNode.ts
+++ b/src/StateNode.ts
@@ -89,8 +89,7 @@ const createDefaultOptions = <TContext>(): MachineOptions<TContext, any> => ({
   guards: EMPTY_OBJECT
 });
 
-export const IS_PRODUCTION =
-  typeof process !== 'undefined' ? process.env.NODE_ENV === 'production' : true;
+export const IS_PRODUCTION = process.env.NODE_ENV === 'production';
 
 class StateNode<
   TContext = DefaultContext,


### PR DESCRIPTION
Regarding - https://twitter.com/DavidKPiano/status/1098437300550336512 😉 

When performing env checks you should never reference `process` directly - replacing plugins are only concerned with replacing `process.env.NODE_ENV` lookup. Referencing `process` causes i.e. webpack to include a polyfill for this object.

Because of that developer-friendly warning which were meant to be removed in production bundles stayed in the bundles.

This has no dramatic effect but it allow bundlers to remove those unwanted strings in production, the UMD bundle went from 10.87 KB to 10.54 KB 

In general I don't recommend storing env check result in a variable (inline check is easier for minifiers to remove), and I strongly would advise against exporting it from a file - especially given a fact that you don't flat bundle and depending on the consumer's setup it might not be possible to check this value across module-boundary. 

This also provides a browser-friendly build which was actually requested originally ( https://github.com/davidkpiano/xstate/issues/227 ) but the fix was done differently. cc @TimvdLippe