### PR TITLE
Fix return type of example hook

### DIFF
--- a/docs/recipes/react.md
+++ b/docs/recipes/react.md
@@ -85,9 +85,11 @@ export function useMachine(machine) {
 
   // Stop the service when the component unmounts
   useEffect(() => {
-    return () => service.stop();
+    return () => {
+      service.stop();
+    }
   }, []);
-
+ 
   return [current, service.send];
 }
 ```


### PR DESCRIPTION
Fixes #375 

The compiler error was due to React's [rules](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L793) on `useEffect` cleanup function return values. Easy fix to just remove the arrow function.

```typescript
// NOTE: callbacks are _only_ allowed to return either void, or a destructor.
// The destructor is itself only allowed to return void.
type EffectCallback = () => (void | (() => void | undefined));
```