### PR TITLE
docs(hierarchical): add note about state re-entry

### DIFF
--- a/docs/guides/hierarchical.md
+++ b/docs/guides/hierarchical.md
@@ -97,4 +97,4 @@ console.log(lightMachine.transition('green', 'UNKNOWN').value);
 
 ## Notes
 
-- Transitions to children states exit and re-enter parent state by default (triggering parent's `onExit`/`onEntry` actions and restarting parent's `activities`). To avoid that behaviour use [Internal Transitions](./internal.md).
+- Transitions from parent state to its children will exit and re-enter parent state by default (triggering parent's `onExit`/`onEntry` actions and restarting parent's `activities`). To avoid that behaviour use [Internal Transitions](./internal.md).

--- a/docs/guides/hierarchical.md
+++ b/docs/guides/hierarchical.md
@@ -94,3 +94,7 @@ If neither a state nor any of its ancestor (parent) states handle an event, no t
 console.log(lightMachine.transition('green', 'UNKNOWN').value);
 // => 'green'
 ```
+
+## Notes
+
+- Transitions to children states exit and re-enter parent state by default (triggering parent's `onExit`/`onEntry` actions and restarting parent's `activities`). To avoid that behaviour use [Internal Transitions](./internal.md).


### PR DESCRIPTION
Adding just small note to hierarchical state machines docs, documenting parent state re-entry behaviour and adding link to internal transitions.

Closes #384