### PR TITLE
(docs) added the recommended way to restore states with machine.resolveState()

### DIFF
--- a/docs/guides/states.md
+++ b/docs/guides/states.md
@@ -138,7 +138,7 @@ try {
 }
 ```
 
-State can be restored (i.e., rehydrated) using the static `State.create(...)` method and resolved using the public `machine.resolveState(...)` method:
+State can be restored using the static `State.create(...)` method and resolved using the public `machine.resolveState(...)` method:
 
 ```js
 import { State, interpret } from 'xstate';
@@ -154,7 +154,7 @@ const restoredState = State.create(stateDefinition);
 const resolvedState = myMachine.resolveState(restoredStateDef);
 ```
 
-You can then interpret the machine from this restored state by passing the `State` into the `.start(...)` method of the interpreted service:
+You can then interpret the machine from this resolved state by passing the `State` into the `.start(...)` method of the interpreted service:
 
 ```js
 // ...

--- a/docs/guides/states.md
+++ b/docs/guides/states.md
@@ -138,17 +138,17 @@ try {
 }
 ```
 
-State can be rehydrated (i.e., restored) using the static `State.create(...)` method:
+State can be rehydrated (i.e., restored) using the public `machine.resolveState(...)` method:
 
 ```js
 import { State, interpret } from 'xstate';
 import { myMachine } from '../path/to/myMachine';
 
-// Retrieving state from localStorage
+// Retrieving the state definition from localStorage
 const restoredStateDef = JSON.parse(localStorage.getItem('app-state'));
 
-// Use State.create() to restore state from a plain object
-const restoredState = State.create(restoredStateDef);
+// Use machine.resolveState() to resolve the state definition to a new State instance relative to the machine
+const restoredState = myMachine.resolveState(restoredStateDef);
 ```
 
 You can then interpret the machine from this restored state by passing the `State` into the `.start(...)` method of the interpreted service:
@@ -160,7 +160,7 @@ You can then interpret the machine from this restored state by passing the `Stat
 const service = interpret(myMachine).start(restoredState);
 ```
 
-This will also maintain and restore previous [history states](./history.md).
+This will also maintain and restore previous [history states](./history.md) and ensures that `.events` and `.nextEvents` represent the correct values.
 
 ## State Meta Data
 

--- a/docs/guides/states.md
+++ b/docs/guides/states.md
@@ -138,17 +138,20 @@ try {
 }
 ```
 
-State can be rehydrated (i.e., restored) using the public `machine.resolveState(...)` method:
+State can be restored (i.e., rehydrated) using the static `State.create(...)` method and resolved using the public `machine.resolveState(...)` method:
 
 ```js
 import { State, interpret } from 'xstate';
 import { myMachine } from '../path/to/myMachine';
 
 // Retrieving the state definition from localStorage
-const restoredStateDef = JSON.parse(localStorage.getItem('app-state'));
+const stateDefinition = JSON.parse(localStorage.getItem('app-state'));
+
+// Use State.create() to restore state from a plain object
+const restoredState = State.create(stateDefinition);
 
 // Use machine.resolveState() to resolve the state definition to a new State instance relative to the machine
-const restoredState = myMachine.resolveState(restoredStateDef);
+const resolvedState = myMachine.resolveState(restoredStateDef);
 ```
 
 You can then interpret the machine from this restored state by passing the `State` into the `.start(...)` method of the interpreted service:
@@ -157,7 +160,7 @@ You can then interpret the machine from this restored state by passing the `Stat
 // ...
 
 // This will start the service at the specified State
-const service = interpret(myMachine).start(restoredState);
+const service = interpret(myMachine).start(resolvedState);
 ```
 
 This will also maintain and restore previous [history states](./history.md) and ensures that `.events` and `.nextEvents` represent the correct values.


### PR DESCRIPTION
In [#316](https://github.com/davidkpiano/xstate/issues/316) it was identified a problem with the rehydration of `State`s. The fix is already implemented with `machine.resolveState(...)` so I modified the documentation reflecting this changes.