### PR TITLE
Tweaked Promise support in interpreter to accept any thenable (aka PromiseLike)

### DIFF
--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -27,7 +27,7 @@ import { State } from './State';
 import * as actionTypes from './actionTypes';
 import { toEventObject, doneInvoke, error } from './actions';
 import { IS_PRODUCTION } from './StateNode';
-import { mapContext, bindActionToState, warn } from './utils';
+import { isPromiseLike, mapContext, bindActionToState, warn } from './utils';
 import { Scheduler } from './scheduler';
 
 export type StateListener<TContext, TEvent extends EventObject> = (
@@ -666,8 +666,8 @@ export class Interpreter<
               ? serviceCreator(context, event)
               : serviceCreator;
 
-          if (source instanceof Promise) {
-            this.spawnPromise(id, source);
+          if (isPromiseLike(source)) {
+            this.spawnPromise(id, Promise.resolve(source));
           } else if (typeof source === 'function') {
             this.spawnCallback(id, source);
           } else if (typeof source !== 'string') {
@@ -805,8 +805,8 @@ export class Interpreter<
         listener = newListener;
       });
 
-      if (stop instanceof Promise) {
-        stop.catch(e => {
+      if (isPromiseLike(stop)) {
+        Promise.resolve(stop).catch(e => {
           const errorEvent = error(e, id);
           try {
             this.send(errorEvent);

--- a/src/types.ts
+++ b/src/types.ts
@@ -184,7 +184,7 @@ export type InvokeCreator<TFinalContext, TContext> = (
   context: TContext,
   event: EventObject
 ) =>
-  | Promise<TFinalContext>
+  | PromiseLike<TFinalContext>
   | StateMachine<TFinalContext, any, any>
   | InvokeCallback;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -330,6 +330,21 @@ export function isBuiltInEvent(eventType: EventType): boolean {
   return false;
 }
 
+export function isPromiseLike(value: any): value is PromiseLike<any> {
+  if (value instanceof Promise) {
+    return true;
+  }
+  // Check if shape matches the Promise/A+ specification for a "thenable".
+  if (
+    value !== null &&
+    (typeof value === 'function' || typeof value === 'object') &&
+    typeof value.then === 'function'
+  ) {
+    return true;
+  }
+  return false;
+}
+
 export function partition<T, A extends T, B extends T>(
   items: T[],
   predicate: (item: T) => item is A


### PR DESCRIPTION
* Added `isPromiseLike()` type guard to `utils`.
* Changed invoke/service type requirement from `Promise` to `PromiseLike`.
* Used `Promise.resolve()` to adopt untrusted thenables into trusted Promises.

Related: #412