### PR TITLE
Update index.ts, export Interpreter class

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ import {
   after,
   done
 } from './actions';
-import { interpret } from './interpreter';
+import { interpret, Interpreter } from './interpreter';
 import { matchState } from './match';
 
 const actions = {
@@ -42,6 +42,7 @@ export {
   send,
   sendParent,
   interpret,
+  Interpreter, 
   matchState
 };
 


### PR DESCRIPTION
It's not exported, so can't be used in TS code. interpret() : Interpreter, the function is exported though, and I was kind of under the impression that this would be a tsc compile error, but I guess not.