### PR TITLE
Fix State instance loosing it's context

### DIFF
--- a/src/State.ts
+++ b/src/State.ts
@@ -178,6 +178,8 @@ export class State<TContext, TEvent extends EventObject = EventObject>
       value: config.tree,
       enumerable: false
     });
+    this.matches = this.matches.bind(this);
+    this.toStrings = this.toStrings.bind(this);
   }
 
   /**

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -270,4 +270,22 @@ describe('State', () => {
       assert.deepEqual(initialState.event, initEvent);
     });
   });
+
+  describe('State.prototype.matches', () => {
+    it('should keep reference to state instance after destcurting', () => {
+      const { initialState } = machine;
+      const { matches } = initialState;
+
+      assert.isTrue(matches('one'));
+    });
+  });
+
+  describe('State.prototype.toStrings', () => {
+    it('should keep reference to state instance after destcurting', () => {
+      const { initialState } = machine;
+      const { toStrings } = initialState;
+
+      assert.deepEqual(toStrings(), ['one']);
+    });
+  });
 });


### PR DESCRIPTION
## The problem

Currently, since the `matches` and `toStrings` methods are added to the prototype of State, the context of `this` will be lost in case of reassignment or object destructing.

```js
const { matches } = machineState;

console.log(matches('some_state'));
```

<img width="1307" alt="Screenshot 2019-04-28 at 23 40 21" src="https://user-images.githubusercontent.com/8332043/56869864-1de34c80-6a0f-11e9-9194-ddd18e4577ce.png">