### PR TITLE
Add test for onEntry defined on parallel state

### DIFF
--- a/test/actions.test.ts
+++ b/test/actions.test.ts
@@ -495,6 +495,42 @@ describe('onEntry/onExit actions', () => {
       );
     });
   });
+
+  describe('parallel states', () => {
+    it('should return entry action defined on parallel state', () => {
+      const parallelMachineWithOnEntry = Machine({
+        id: 'fetch',
+        context: { attempts: 0 },
+        initial: 'start',
+        states: {
+          start: {
+            on: { ENTER_PARALLEL: 'p1' },
+          },
+          p1: {
+            type: 'parallel',
+            onEntry: 'enter_p1',
+            states: {
+              nested: {
+                initial: 'inner',
+                states: {
+                  inner: {
+                    onEntry: 'enter_inner',
+                  }
+                },
+              },
+            },
+          },
+        },
+      });
+
+      assert.deepEqual(
+        parallelMachineWithOnEntry
+          .transition('start', 'ENTER_PARALLEL')
+          .actions.map(a => a.type),
+        ['enter_p1', 'enter_inner']
+      );
+    });
+  });
 });
 
 describe('actions on invalid transition', () => {


### PR DESCRIPTION
While reading SCXML spec I've found out that this is supposed to work, I then got curious if xstate implements it - and it does 😉 There was no test to cover this, so I've added one.