### PR TITLE
WIP: Separate stop and nonstop actions from exitActions

### DIFF
--- a/src/StateNode.ts
+++ b/src/StateNode.ts
@@ -1000,8 +1000,31 @@ class StateNode<
       )
     ];
 
+    // Separating actions of type xstate.stop from the rest
+    // Why? transition actions can have `send` actions to specific invoked
+    // service children, so invoked services need to stay alive until the
+    // transition.are executed
+    // https://github.com/davidkpiano/xstate/issues/470
+    const stopExitActions: Array<
+      ActionObject<any, OmniEventObject<EventObject>>
+    > = [];
+    const nonStopExitActions: Array<
+      ActionObject<any, OmniEventObject<EventObject>>
+    > = [];
+
+    exitActions.forEach(act => {
+      if (act.type === ActionTypes.Stop) {
+        stopExitActions.push(act);
+      } else {
+        nonStopExitActions.push(act);
+      }
+    });
+
     const actions = toActionObjects(
-      exitActions.concat(transition.actions).concat(entryActions),
+      nonStopExitActions
+        .concat(transition.actions)
+        .concat(stopExitActions)
+        .concat(entryActions),
       this.machine.options.actions
     );
 


### PR DESCRIPTION
Fixes https://github.com/davidkpiano/xstate/issues/470

## Why?

In case transition actions need to `send` events to children which are invoked services/machines.

## Solution

Since the action execution order is `exit actions -> transition actions -> entry actions`, when the interpreter tries to execute transition actions, the child is already stopped in exit actions, therefore, `sendTo` will fail.

This solution separates exit actions of type `xstate.stop` from the rest and changes the order from `rest of the exit actions -> transition actions -> exit actions of type xstate.stop -> entry actions`. This way, invoked children will be alive for transition actions and will stop after those are executed. Since stopping the invoked services is an internal act, it should not affect user-specific actions as long as the user follows the old order.

@davidkpiano Let me know what you think about this.

[ ] Write a test for the bug
[ ] Fix tests