### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/guides/states.md
+++ b/docs/guides/states.md
@@ -151,7 +151,7 @@ const stateDefinition = JSON.parse(localStorage.getItem('app-state'));
 const restoredState = State.create(stateDefinition);
 
 // Use machine.resolveState() to resolve the state definition to a new State instance relative to the machine
-const resolvedState = myMachine.resolveState(restoredStateDef);
+const resolvedState = myMachine.resolveState(restoredState);
 ```
 
 You can then interpret the machine from this resolved state by passing the `State` into the `.start(...)` method of the interpreted service:

--- a/docs/guides/states.md
+++ b/docs/guides/states.md
@@ -148,10 +148,10 @@ import { myMachine } from '../path/to/myMachine';
 const stateDefinition = JSON.parse(localStorage.getItem('app-state'));
 
 // Use State.create() to restore state from a plain object
-const restoredState = State.create(stateDefinition);
+const previousState = State.create(stateDefinition);
 
 // Use machine.resolveState() to resolve the state definition to a new State instance relative to the machine
-const resolvedState = myMachine.resolveState(restoredState);
+const resolvedState = myMachine.resolveState(previousState);
 ```
 
 You can then interpret the machine from this resolved state by passing the `State` into the `.start(...)` method of the interpreted service:


### PR DESCRIPTION
In the states guide, the Persisting State example references a restoredStateDef variable which is not defined.
restoredStateDef used to be the result of parsing the persisted state definition but in #393 the example was updated to use State.create and the resolveState call remained referencing the old declaration. This PR fixes the inconsistency.

Something to consider is that now `restoredState` and `resolvedState` are very similar variable names and this might be a little bit confusing. Making restoredState more verbose (restoredStateDef or restoredStateDefinition) to emphasise it is the state *definition*, not the resolved state, could make it clearer IMO.