### PR TITLE
Fix potential memory leak caused by not always cleaning up children i…

### DIFF
--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -783,10 +783,13 @@ export class Interpreter<
   }
   private stopChild(childId: string): void {
     const child = this.children.get(childId);
-    if (child && isFunction(child.stop)) {
+    if (!child) return;
+
+    this.children.delete(childId);
+    this.forwardTo.delete(childId);
+
+    if (isFunction(child.stop)) {
       child.stop();
-      this.children.delete(childId);
-      this.forwardTo.delete(childId);
     }
   }
   public spawn<TChildContext>(


### PR DESCRIPTION
…nside interpreter

Activities [might not have a `stop` function](https://github.com/davidkpiano/xstate/blob/709947a71b5f557399b5814e4b61ab4a8c2af60c/src/interpreter.ts#L1019) on them (EDIT:// invoked callbacks also have optional stop), so it seems to me that this has caused a minor memory leak.

There are no public APIs to query children (or are there?) so I've skipped writing a test for this (no idea how this could be tested right now).