### PR TITLE
InvokeCreator: Improving types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -192,7 +192,7 @@ export type InvokeCallback = ((
  * @param context The current machine `context`
  * @param event The event that invoked the service
  */
-export type InvokeCreator<TFinalContext, TContext> = (
+export type InvokeCreator<TContext, TFinalContext = Partial<TContext>> = (
   context: TContext,
   event: EventObject
 ) =>
@@ -538,7 +538,7 @@ export type ActionFunctionMap<TContext, TEvent extends EventObject> = Record<
 export type ServiceConfig<TContext> =
   | string
   | StateMachine<any, any, any>
-  | InvokeCreator<any, TContext>;
+  | InvokeCreator<TContext>;
 
 export type DelayConfig<TContext, TEvent extends EventObject> =
   | number


### PR DESCRIPTION
After being using heavily for the last months this project, this particular type has been particulary annoying as when you're defining the initialization the service call typing gets lost.

This modification allows to keep the possibility of using the type expansively, but does set a default type that makes more sense than `any`. 

I hope you find this improvement useful.

**ATTENTION:** For this change I had to change the order of the generics, which can lead to breaking changes on the types if this is merged.