### PR TITLE
Support autoForward option in spawned actors

### DIFF
--- a/docs/guides/communication.md
+++ b/docs/guides/communication.md
@@ -24,7 +24,7 @@ An invocation is defined in a state node's configuration with the `invoke` prope
   - a function that returns a "callback handler"
   - a function that returns an observable
 - `id` - the unique identifier for the invoked service
-- `forward` - (optional) `true` if all events sent to this machine should also be sent (or _forwarded_) to the invoked child machine (`false` by default)
+- `autoForward` - (optional) `true` if all events sent to this machine should also be sent (or _forwarded_) to the invoked child machine (`false` by default)
 - `data` - (optional) an object that maps properties of the child machine's [context](./context.md) to a function that returns the corresponding value from the parent machine's `context`.
 - `onDone` - (optional) the [transition](./transitions.md) to be taken when:
   - the child machine reaches its [final state](./final.md), or

--- a/src/types.ts
+++ b/src/types.ts
@@ -212,7 +212,13 @@ export interface InvokeDefinition<TContext, TEvent extends EventObject>
    *
    * Default: `false`
    */
-  forward?: boolean;
+  autoForward?: boolean;
+  /**
+   * @deprecated
+   *
+   *  Use `autoForward` property instead of `forward`. Support for `forward` will get removed in the future.
+   */
+  forward?: boolean
   /**
    * Data from the parent machine's context to set as the (partial or full) context
    * for the invoked child machine.
@@ -321,6 +327,12 @@ export type InvokeConfig<TContext, TEvent extends EventObject> =
        * If `true`, events sent to the parent service will be forwarded to the invoked service.
        *
        * Default: `false`
+       */
+      autoForward?: boolean;
+      /**
+       * @deprecated
+       *
+       *  Use `autoForward` property instead of `forward`. Support for `forward` will get removed in the future.
        */
       forward?: boolean;
       /**

--- a/test/actor.test.ts
+++ b/test/actor.test.ts
@@ -422,7 +422,7 @@ describe('actors', () => {
       assert.equal(pongCounter, 0);
     });
 
-    it('should not forward events to a spawned actor when { autoForward: true }', () => {
+    it('should forward events to a spawned actor when { autoForward: true }', () => {
       let pongCounter = 0;
 
       const machine = Machine<any>({

--- a/test/invoke.test.ts
+++ b/test/invoke.test.ts
@@ -147,7 +147,7 @@ describe('invoke', () => {
             invoke: {
               src: 'child',
               id: 'someService',
-              forward: true
+              autoForward: true
             },
             on: {
               INC: { actions: assign({ count: ctx => ctx.count + 1 }) },
@@ -188,7 +188,7 @@ describe('invoke', () => {
       .start();
   });
 
-  it('should forward events to services if forward: true', () => {
+  it('should forward events to services if autoForward: true', () => {
     const childMachine = Machine({
       id: 'child',
       initial: 'init',
@@ -213,7 +213,7 @@ describe('invoke', () => {
             invoke: {
               src: 'child',
               id: 'someService',
-              forward: true
+              autoForward: true
             },
             on: {
               DEC: { actions: assign({ count: ctx => ctx.count - 1 }) },
@@ -243,7 +243,7 @@ describe('invoke', () => {
       })
       .onDone(() => {
         // 1. The 'parent' machine will not do anything (inert transition)
-        // 2. The 'FORWARD_DEC' event will be forwarded to the 'child' machine (forward: true)
+        // 2. The 'FORWARD_DEC' event will be forwarded to the 'child' machine (autoForward: true)
         // 3. On the 'child' machine, the 'FORWARD_DEC' event sends the 'DEC' action to the 'parent' thrice
         // 4. The context of the 'parent' machine will be updated from 2 to -1
 
@@ -326,7 +326,7 @@ describe('invoke', () => {
             invoke: {
               src: 'child',
               id: 'someService',
-              forward: true
+              autoForward: true
             },
             on: {
               STOP: 'stop'


### PR DESCRIPTION
closes #494 

Not sure how you feel about changing public `forward` option to `autoForward`. I thought it might be a good change because:
- it aligns with SCXML
- it also aligns to what it was converted to under the hood [here](https://github.com/davidkpiano/xstate/blob/167fd5b37fe320f3101b09ac917810bc79c3c475/src/interpreter.ts#L715)

I can easily revert this back and just make `forward` supported in both APIs.