### PR TITLE
Tweak assign typings to allow TContext inferring for parameterless assignment function

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -24,7 +24,7 @@ import {
   SendExpr,
   SendActionObject,
   OmniEventObject,
-  PureAction
+  PureAction,
 } from './types';
 import * as actionTypes from './actionTypes';
 import { getEventType, isFunction, isString } from './utils';
@@ -302,9 +302,21 @@ export function stop<TContext, TEvent extends EventObject>(
  *
  * @param assignment An object that represents the partial context to update.
  */
-export const assign = <TContext, TEvent extends EventObject = EventObject>(
+export function assign<
+  T extends ActionObject<any, TEvent> | undefined,
+  TEvent extends EventObject
+>(
+  // trick to make TS inferring TContext based on return type of `assignment` instead of its arguments (microsoft/TypeScript#31933)
+  assignment: T extends ActionObject<infer TContext, TEvent>
+    ? Assigner<TContext, TEvent>
+    : never
+): T;
+export function assign<TContext, TEvent extends EventObject = EventObject>(
   assignment: Assigner<TContext, TEvent> | PropertyAssigner<TContext, TEvent>
-): AssignAction<TContext, TEvent> => {
+): AssignAction<TContext, TEvent>;
+export function assign<TContext, TEvent extends EventObject = EventObject>(
+  assignment: TContext extends any ? (Assigner<TContext, TEvent> | PropertyAssigner<TContext, TEvent>) : never
+): AssignAction<TContext, TEvent> {
   return {
     type: actionTypes.assign,
     assignment

--- a/test/actor.test.ts
+++ b/test/actor.test.ts
@@ -398,7 +398,7 @@ describe('actors', () => {
     it('should not forward events to a spawned actor when { autoForward: false }', () => {
       let pongCounter = 0;
 
-      const machine = Machine<any>({
+      const machine = Machine<{ counter: number, serverRef?: Actor }>({
         id: 'client',
         context: { counter: 0, serverRef: undefined },
         initial: 'initial',


### PR DESCRIPTION
Previously this https://github.com/davidkpiano/xstate/blob/6eea481d82edf448cec9444ecde467e53d573be6/test/actor.test.ts#L407-L409 
was inferred to `assign<{ serverRef: Actor }>` which is not compatible with the desired inferred type of `assign<{ counter: number; serverRef?: Actor }>`. 