### PR TITLE
chore: add two TypeScript tests for parallel machines

### DIFF
--- a/packages/xstate-graph/package-lock.json
+++ b/packages/xstate-graph/package-lock.json
@@ -4806,7 +4806,8 @@
     "xstate": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.5.0.tgz",
-      "integrity": "sha512-7vShhDqfYUWTb1NXZFjk61KTIg6Gi3r21P0M6ApAPCYTJP+pLtbu+uD5Vxaae8Nz21cSu3/OZfvMqN88AkJpHw=="
+      "integrity": "sha512-7vShhDqfYUWTb1NXZFjk61KTIg6Gi3r21P0M6ApAPCYTJP+pLtbu+uD5Vxaae8Nz21cSu3/OZfvMqN88AkJpHw==",
+      "dev": true
     },
     "y18n": {
       "version": "4.0.0",

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -1,5 +1,5 @@
 import { assert } from 'chai';
-import { Machine } from '../src/index';
+import { Machine, assign } from '../src/index';
 
 function noop(_x) {
   return;
@@ -88,6 +88,113 @@ describe('StateSchema', () => {
   noop(lightMachine);
 
   it('should work with a StateSchema defined', () => {
+    assert.ok(true, 'Tests will not compile if types are wrong');
+  });
+});
+
+describe('Parallel StateSchema', () => {
+  interface ParallelStateSchema {
+    states: {
+      foo: {};
+      bar: {};
+      baz: {
+        states: {
+          one: {};
+          two: {};
+        };
+      };
+    };
+  }
+
+  type ParallelEvent =
+    | { type: 'TIMER' }
+    | { type: 'POWER_OUTAGE' }
+    | { type: 'E' }
+    | { type: 'PED_COUNTDOWN'; duration: number };
+
+  interface ParallelContext {
+    elapsed: number;
+  }
+
+  const parallelMachine = Machine<
+    ParallelContext,
+    ParallelStateSchema,
+    ParallelEvent
+  >({
+    type: 'parallel',
+    states: {
+      foo: {},
+      bar: {},
+      baz: {
+        initial: 'one',
+        states: {
+          one: { on: { E: 'two' } },
+          two: {}
+        }
+      }
+    }
+  });
+
+  noop(parallelMachine);
+
+  it('should work with a parallel StateSchema defined', () => {
+    assert.ok(true, 'Tests will not compile if types are wrong');
+  });
+});
+
+describe('Nested parallel stateSchema', () => {
+  interface ParallelStateSchema {
+    states: {
+      foo: {};
+      bar: {};
+      baz: {
+        states: {
+          blockUpdates: {};
+          activeParallelNode: {};
+        };
+      };
+    };
+  }
+
+  type ParallelEvent = { type: 'UPDATE.CONTEXT' };
+
+  interface ParallelContext {
+    lastDate: Date;
+  }
+
+  const nestedParallelMachine = Machine<
+    ParallelContext,
+    ParallelStateSchema,
+    ParallelEvent
+  >({
+    initial: 'foo',
+    states: {
+      foo: {},
+      bar: {},
+      baz: {
+        type: 'parallel',
+        initial: 'blockUpdates',
+        states: {
+          blockUpdates: { type: 'final' },
+          activeParallelNode: {
+            on: {
+              'UPDATE.CONTEXT': {
+                actions: [
+                  assign({
+                    lastDate: new Date()
+                  })
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  });
+
+  noop(nestedParallelMachine);
+
+  it('should work with a parallel StateSchema defined', () => {
     assert.ok(true, 'Tests will not compile if types are wrong');
   });
 });


### PR DESCRIPTION
I thought there was a `TypeError` with parallel machines. I tried to replicate the issue by writing two simple tests and was very surprised to see them pass. I then figured that my implementation was off and xstate types fully worked 🎉. I simply forgot to define `states` on the `StateSchema` on one of my machines. 😁 	

I'm not sure how extensive you want to have TypeScript tests but I figured having two more tests can't hurt.