### PR TITLE
Implemented 3rd argument for `useMachine`: `onStop`

### DIFF
--- a/packages/xstate-react/README.md
+++ b/packages/xstate-react/README.md
@@ -152,9 +152,9 @@ const Fetcher = ({ onResolve }) => {
 };
 ```
 
-## Provide a cleanup callback on Unmount lifecycle
+## Provide a Cleanup Callback to be Executed Before Service Stops
 
-The `onStop` function argument allows to perform a cleanup of subscriptions before the component unmounts.
+The `onStop` callback argument allows to perform a cleanup of subscriptions before the service is stopped.
 
 ```js
 const timerMachine = Machine({

--- a/packages/xstate-react/src/index.ts
+++ b/packages/xstate-react/src/index.ts
@@ -24,7 +24,8 @@ export function useMachine<TContext, TEvent extends EventObject>(
   machine: StateMachine<TContext, any, TEvent>,
   options: Partial<InterpreterOptions> &
     Partial<UseMachineOptions> &
-    Partial<MachineOptions<TContext, TEvent>> = defaultOptions
+    Partial<MachineOptions<TContext, TEvent>> = defaultOptions,
+    onStop?: Function
 ): [
   State<TContext, TEvent>,
   Interpreter<TContext, any, TEvent>['send'],
@@ -71,6 +72,9 @@ export function useMachine<TContext, TEvent extends EventObject>(
     service.start();
 
     return () => {
+      if (onStop !== undefined) {
+        onStop();
+      }
       // Stop the service when the component unmounts
       service.stop();
     };


### PR DESCRIPTION
I modelled a process for subscribing and unsubscribing from a long-running service as a state machine.
However, when integrating the machine with a React component, the unmount lifecycle was problematic with `@xstate/react` 's `useMachine`:

A warning appeared on the console notifying me that an event has been sent to a service that isn't running, and that I need to `service.start()` first before I can send the event. Basically the service was already stopped by [`useMachine`'s `React.useEffect` implementation](https://github.com/davidkpiano/xstate/blob/master/packages/xstate-react/src/index.ts#L75).

I tried to solve that in user-space by using `React.useEffect` (see [Attempt](https://github.com/amitnovick/todo-app/blob/public/src/containers/Todos/TodosContainerCloud/TodosContainerCloud.js#L178)) but I noticed that the event is not being sent to the service.

I added an example to the `README` that shows a similar scenario for unsubscribing from an interval event.

This is the easiest way I could think of to implement cleanup of the subscription.
That said, **it's not an elegant solution in my opinion**.
It's also possible to add an `onStart` argument (for completeness?), a function that would be called after the service has started.

Please share your thoughts on this! :hand: 
