### PR TITLE
test: fix build failure

### DIFF
--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,6 +1,6 @@
 import { StateNode, State } from '../src/index';
 import { assert } from 'chai';
-import { matchesState } from '../lib';
+import { matchesState } from '../src';
 
 export function testMultiTransition<TExt>(
   machine: StateNode<TExt>,


### PR DESCRIPTION
It fails when run `npm install`:
```
test/utils.ts:3:30 - error TS2307: Cannot find module '../lib'.

3 import { matchesState } from '../lib';
                               ~~~~~~~~
```
