### PR TITLE
Delay docs: remove unnecessary Notes section

### DIFF
--- a/docs/guides/delays.md
+++ b/docs/guides/delays.md
@@ -325,5 +325,3 @@ states: {
 ```
 
 The interpreted statechart will `send(...)` the `after(...)` events after their `delay`, unless the state node is exited, which will `cancel(...)` those delayed `send(...)` events.
-
-## Notes


### PR DESCRIPTION
When reading delay docs it seems like Notes section is missing some text.