### PR TITLE
Docs: `xstate/react`: Added clarification on `useMachine` Machine Config

### DIFF
--- a/packages/xstate-react/CHANGELOG.md
+++ b/packages/xstate-react/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Machine configuration can now be merged into the options argument of `useMachine(machine, options)`:
+- Machine configuration can now be merged into the options argument of `useMachine(machine, options)`. The following Machine Config options are available: `guards`, `actions`, `activities`, `services`, `delays` and `updates` (NOTE: `context` option is not implemented yet, use `withContext` or `withConfig` instead for the meantime)
 
 ```js
 const [current, send] = useMachine(someMachine, {

--- a/packages/xstate-react/README.md
+++ b/packages/xstate-react/README.md
@@ -49,7 +49,7 @@ A [React hook](https://reactjs.org/hooks) that interprets the given `machine` an
 **Arguments**
 
 - `machine` - An [XState machine](https://xstate.js.org/docs/guides/machines.html).
-- `options` (optional) - [Interpreter options](https://xstate.js.org/docs/guides/interpretation.html#options) that you can pass in.
+- `options` (optional) - [Interpreter options](https://xstate.js.org/docs/guides/interpretation.html#options) OR one of the following Machine Config options: `guards`, `actions`, `activities`, `services`, `delays` and `updates` (NOTE: `context` option is not implemented yet, use `withContext` or `withConfig` instead for the meantime). 
 
 **Returns** a tuple of `[current, send, service]`:
 


### PR DESCRIPTION
options avilability as of version `0.7.0`

Prior Issue: https://github.com/davidkpiano/xstate/issues/558#issuecomment-513241388