### PR TITLE
Fix import path for toEventObject in @xstate/graph

### DIFF
--- a/packages/xstate-graph/src/graph.ts
+++ b/packages/xstate-graph/src/graph.ts
@@ -10,7 +10,7 @@ import {
   EventObject,
   StateMachine
 } from 'xstate/lib/types';
-import { toEventObject } from 'xstate/lib/actions';
+import { toEventObject } from 'xstate/lib/utils';
 
 // TODO: remove types once XState is updated
 export interface PathsItem<TContext, TEvent extends EventObject> {


### PR DESCRIPTION
This got broken after recent refactors as `toEventObject` has changed its location.