### PR TITLE
Fixed issue with _init not covering nested nodes

### DIFF
--- a/src/StateNode.ts
+++ b/src/StateNode.ts
@@ -93,6 +93,7 @@ import {
   getConfiguration,
   has,
   getChildren,
+  getAllStateNodes,
   isInFinalState
 } from './stateUtils';
 
@@ -381,9 +382,7 @@ class StateNode<
     if (this.__cache.transitions) {
       return;
     }
-    ([this] as StateNode[])
-      .concat(getChildren(this))
-      .forEach(child => child.on);
+    getAllStateNodes(this).forEach(stateNode => stateNode.on);
   }
 
   /**
@@ -1916,7 +1915,7 @@ class StateNode<
     };
   }
   private formatTransitions(): TransitionsDefinition<TContext, TEvent> {
-    const onConfig = this.config.on || EMPTY_OBJECT;
+    const onConfig = this.config.on;
     const doneConfig = this.config.onDone
       ? {
           [`${done(this.id)}`]: this.config.onDone

--- a/src/stateUtils.ts
+++ b/src/stateUtils.ts
@@ -16,6 +16,21 @@ export function getChildren<TC, TE extends EventObject>(
   return keys(stateNode.states).map(key => stateNode.states[key]);
 }
 
+export function getAllStateNodes<TC, TE extends EventObject>(
+  stateNode: StateNode<TC, any, TE>
+): Array<StateNode<TC, any, TE>> {
+  const stateNodes = [stateNode];
+  const isLeaf = stateNode.type === 'atomic' || stateNode.type === 'final';
+
+  if (isLeaf) {
+    return stateNodes;
+  }
+
+  return stateNodes.concat(
+    flatten(getChildren(stateNode).map(getAllStateNodes))
+  );
+}
+
 export function getConfiguration<TC, TE extends EventObject>(
   prevStateNodes: Iterable<StateNode<TC, any, TE>>,
   stateNodes: Iterable<StateNode<TC, any, TE>>

--- a/test/after.test.ts
+++ b/test/after.test.ts
@@ -1,4 +1,4 @@
-import { Machine } from '../src/index';
+import { Machine, interpret } from '../src';
 import { after, cancel, send, actionTypes } from '../src/actions';
 
 const lightMachine = Machine({
@@ -43,9 +43,35 @@ describe('delayed transitions', () => {
 
     const transitions = greenNode.transitions;
 
-    expect(transitions.map(t => t.event)).toEqual([
-      after(1000, greenNode.id)
-    ]);
+    expect(transitions.map(t => t.event)).toEqual([after(1000, greenNode.id)]);
+  });
+
+  it('should be able to transition with delay from nested initial state', done => {
+    const machine = Machine({
+      initial: 'nested',
+      states: {
+        nested: {
+          initial: 'wait',
+          states: {
+            wait: {
+              after: {
+                10: '#end'
+              }
+            }
+          }
+        },
+        end: {
+          id: 'end',
+          type: 'final'
+        }
+      }
+    });
+
+    interpret(machine)
+      .onDone(() => {
+        done();
+      })
+      .start();
   });
 
   describe('delay expressions', () => {

--- a/test/interpreter.test.ts
+++ b/test/interpreter.test.ts
@@ -521,7 +521,8 @@ Event: {\\"type\\":\\"SOME_EVENT\\"}"
               on: {
                 FETCH: 'pending'
               }
-            }
+            },
+            pending: {}
           }
         }
       }


### PR DESCRIPTION
I believe this had to have more severe consequences than the use case I've fixed in the added test, but don't have enough expertise yet to think of other failing tests I could add quickly.

Maybe you could point me in the right direction? If not I'll probably dig into this at a later point in time.