### PR TITLE
Clear scheduled jobs on .stop() call

### DIFF
--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -453,6 +453,7 @@ export class Interpreter<
       this.clock.clearTimeout(this.delayedEventsMap[key]);
     }
 
+    this.scheduler.clear();
     this.initialized = false;
 
     return this;

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -49,6 +49,10 @@ export class Scheduler {
     this.flushEvents();
   }
 
+  public clear(): void {
+    this.queue = [];
+  }
+
   private flushEvents() {
     let nextCallback: (() => void) | undefined = this.queue.shift();
     while (nextCallback) {
@@ -64,7 +68,7 @@ export class Scheduler {
     } catch (e) {
       // there is no use to keep the future events
       // as the situation is not anymore the same
-      this.queue = [];
+      this.clear();
       throw e;
     } finally {
       this.processingEvent = false;


### PR DESCRIPTION
Events might get scheduled (internally by send or externally) when interpreter is initialized and interpreter might reach a final state WHILE processing the event queue.

I think we should just drop unprocessed jobs in such case, otherwise we try to process them when interpreter is in uninitialized state and it starts to warn about it a user.
