### PR TITLE
Cleanup/scxml event

### DIFF
--- a/packages/xstate-immer/src/index.ts
+++ b/packages/xstate-immer/src/index.ts
@@ -1,4 +1,4 @@
-import { EventObject, ActionObject } from 'xstate';
+import { EventObject, ActionObject, SCXML } from 'xstate';
 import { produce, Draft } from 'immer';
 import { actionTypes } from 'xstate/lib/actions';
 
@@ -23,7 +23,7 @@ export function assign<TContext, TEvent extends EventObject = EventObject>(
 
 export function updater<TContext, TEvent extends EventObject>(
   context: TContext,
-  event: TEvent,
+  _event: SCXML.Event<TEvent>,
   assignActions: Array<ImmerAssignAction<TContext, TEvent>>
 ): TContext {
   const updatedContext = context
@@ -33,7 +33,7 @@ export function updater<TContext, TEvent extends EventObject>(
           TEvent
         >;
 
-        const update = produce(acc, interim => void assignment(interim, event));
+        const update = produce(acc, interim => void assignment(interim, _event.data));
 
         return update;
       }, context)

--- a/packages/xstate-immer/test/immer.test.ts
+++ b/packages/xstate-immer/test/immer.test.ts
@@ -1,5 +1,5 @@
 import { Machine } from 'xstate';
-import { updater, assign } from '../src/index';
+import { updater, assign } from '../src';
 
 describe('@xstate/immer', () => {
   it('should update the context without modifying previous contexts', () => {

--- a/src/State.ts
+++ b/src/State.ts
@@ -7,15 +7,15 @@ import {
   EventType,
   StateValueMap,
   StateConfig,
-  ActionTypes,
   SCXML,
   StateSchema,
   ExtractStateValue
 } from './types';
 import { EMPTY_ACTIVITY_MAP } from './constants';
-import { matchesState, keys, isString, toSCXMLEvent } from './utils';
+import { matchesState, keys, isString } from './utils';
 import { StateNode } from './StateNode';
 import { nextEvents } from './stateUtils';
+import { initEvent } from './actions';
 
 export function stateValuesEqual(
   a: StateValue | undefined,
@@ -63,7 +63,7 @@ export function bindActionToState<TC, TE extends EventObject>(
             exec(state.context, state.event as TE, {
               action,
               state,
-              _event: toSCXMLEvent(state.event)
+              _event: state._event
             })
         : undefined
   };
@@ -118,7 +118,6 @@ export class State<
         return new State<TC, TE>({
           value: stateValue.value,
           context: context as TC,
-          event: stateValue.event,
           _event: stateValue._event,
           historyValue: stateValue.historyValue,
           history: stateValue.history,
@@ -133,13 +132,12 @@ export class State<
       return stateValue;
     }
 
-    const event = { type: ActionTypes.Init } as TE;
+    const _event = initEvent as SCXML.Event<TE>;
 
     return new State<TC, TE>({
       value: stateValue,
       context: context as TC,
-      event,
-      _event: toSCXMLEvent(event),
+      _event,
       historyValue: undefined,
       history: undefined,
       actions: [],
@@ -171,13 +169,12 @@ export class State<
       if (!stateValue.actions.length) {
         return stateValue as State<TC, TE>;
       }
-      const event = { type: ActionTypes.Init } as TE;
+      const _event = initEvent as SCXML.Event<TE>;
 
       return new State<TC, TE>({
         value: stateValue.value,
         context,
-        event,
-        _event: toSCXMLEvent(event),
+        _event,
         historyValue: stateValue.historyValue,
         history: stateValue.history,
         activities: stateValue.activities,
@@ -203,8 +200,8 @@ export class State<
   constructor(config: StateConfig<TContext, TEvent>) {
     this.value = config.value;
     this.context = config.context;
-    this.event = config.event;
-    this._event = toSCXMLEvent(config.event);
+    this._event = config._event;
+    this.event = this._event.data;
     this.historyValue = config.historyValue;
     this.history = config.history;
     this.actions = config.actions || [];

--- a/src/StateNode.ts
+++ b/src/StateNode.ts
@@ -22,7 +22,6 @@ import {
   toGuard,
   isMachine,
   toSCXMLEvent,
-  toEventObject,
   mapContext
 } from './utils';
 import {
@@ -32,7 +31,6 @@ import {
   StateTransition,
   StateValueMap,
   MachineOptions,
-  ConditionPredicate,
   EventObject,
   HistoryStateNodeConfig,
   HistoryValue,
@@ -68,7 +66,9 @@ import {
   LogAction,
   SendActionObject,
   SpecialTargets,
-  RaiseAction
+  RaiseAction,
+  SCXML,
+  RaiseActionObject
 } from './types';
 import { matchesState } from './utils';
 import { State, stateValuesEqual } from './State';
@@ -88,7 +88,8 @@ import {
   resolveSend,
   initEvent,
   toActionObjects,
-  resolveLog
+  resolveLog,
+  resolveRaise
 } from './actions';
 import { IS_PRODUCTION } from './environment';
 import { DEFAULT_GUARD_TYPE } from './constants';
@@ -657,13 +658,13 @@ class StateNode<
   private transitionLeafNode(
     stateValue: string,
     state: State<TContext, TEvent>,
-    eventObject: TEvent
+    _event: SCXML.Event<TEvent>
   ): StateTransition<TContext, TEvent> | undefined {
     const stateNode = this.getStateNode(stateValue);
-    const next = stateNode.next(state, eventObject);
+    const next = stateNode.next(state, _event);
 
     if (!next || !next.transitions.length) {
-      return this.next(state, eventObject);
+      return this.next(state, _event);
     }
 
     return next;
@@ -671,7 +672,7 @@ class StateNode<
   private transitionCompoundNode(
     stateValue: StateValueMap,
     state: State<TContext, TEvent>,
-    eventObject: TEvent
+    _event: SCXML.Event<TEvent>
   ): StateTransition<TContext, TEvent> | undefined {
     const subStateKeys = keys(stateValue);
 
@@ -679,11 +680,11 @@ class StateNode<
     const next = stateNode._transition(
       stateValue[subStateKeys[0]],
       state,
-      eventObject
+      _event
     );
 
     if (!next || !next.transitions.length) {
-      return this.next(state, eventObject);
+      return this.next(state, _event);
     }
 
     return next;
@@ -691,7 +692,7 @@ class StateNode<
   private transitionParallelNode(
     stateValue: StateValueMap,
     state: State<TContext, TEvent>,
-    eventObject: TEvent
+    _event: SCXML.Event<TEvent>
   ): StateTransition<TContext, TEvent> | undefined {
     const transitionMap: Record<string, StateTransition<TContext, TEvent>> = {};
 
@@ -703,7 +704,7 @@ class StateNode<
       }
 
       const subStateNode = this.getStateNode(subStateKey);
-      const next = subStateNode._transition(subStateValue, state, eventObject);
+      const next = subStateNode._transition(subStateValue, state, _event);
       if (next) {
         transitionMap[subStateKey] = next;
       }
@@ -719,7 +720,7 @@ class StateNode<
     );
 
     if (!willTransition) {
-      return this.next(state, eventObject);
+      return this.next(state, _event);
     }
     const entryNodes = flatten(stateTransitions.map(t => t.entrySet));
 
@@ -743,27 +744,27 @@ class StateNode<
   private _transition(
     stateValue: StateValue,
     state: State<TContext, TEvent>,
-    event: TEvent
+    _event: SCXML.Event<TEvent>
   ): StateTransition<TContext, TEvent> | undefined {
     // leaf node
     if (isString(stateValue)) {
-      return this.transitionLeafNode(stateValue, state, event);
+      return this.transitionLeafNode(stateValue, state, _event);
     }
 
     // hierarchical node
     if (keys(stateValue).length === 1) {
-      return this.transitionCompoundNode(stateValue, state, event);
+      return this.transitionCompoundNode(stateValue, state, _event);
     }
 
     // orthogonal node
-    return this.transitionParallelNode(stateValue, state, event);
+    return this.transitionParallelNode(stateValue, state, _event);
   }
   private next(
     state: State<TContext, TEvent>,
-    eventObject: TEvent
+    _event: SCXML.Event<TEvent>
   ): StateTransition<TContext, TEvent> | undefined {
-    const eventType = eventObject.type;
-    const candidates = this.on[eventType as TEvent['type']] || [];
+    const eventName = _event.name;
+    const candidates = this.on[eventName as TEvent['type']] || [];
     const hasWildcard = this.on[WILDCARD];
 
     if (!candidates.length && !hasWildcard) {
@@ -807,13 +808,12 @@ class StateNode<
 
       try {
         guardPassed =
-          !cond ||
-          this.evaluateGuard(cond, resolvedContext, eventObject, state);
+          !cond || this.evaluateGuard(cond, resolvedContext, _event, state);
       } catch (err) {
         throw new Error(
           `Unable to evaluate guard '${cond!.name ||
             cond!
-              .type}' in transition for event '${eventType}' in state node '${
+              .type}' in transition for event '${eventName}' in state node '${
             this.id
           }':\n${err.message}`
         );
@@ -910,41 +910,40 @@ class StateNode<
   private evaluateGuard(
     guard: Guard<TContext, TEvent>,
     context: TContext,
-    eventObject: TEvent,
+    _event: SCXML.Event<TEvent>,
     state: State<TContext, TEvent>
   ): boolean {
-    let condFn: ConditionPredicate<TContext, TEvent>;
     const { guards } = this.machine.options;
     const guardMeta: GuardMeta<TContext, TEvent> = {
       state,
       cond: guard,
-      _event: toSCXMLEvent(eventObject)
+      _event
     };
 
     // TODO: do not hardcode!
     if (guard.type === DEFAULT_GUARD_TYPE) {
       return (guard as GuardPredicate<TContext, TEvent>).predicate(
         context,
-        eventObject,
+        _event.data,
         guardMeta
       );
     }
 
-    if (!guards[guard.type]) {
+    const condFn = guards[guard.type];
+
+    if (!condFn) {
       throw new Error(
         `Guard '${guard.type}' is not implemented on machine '${this.machine.id}'.`
       );
     }
 
-    condFn = guards[guard.type];
-
-    return condFn(context, eventObject, guardMeta);
+    return condFn(context, _event.data, guardMeta);
   }
 
   private getActions(
     transition: StateTransition<TContext, TEvent>,
     currentContext: TContext,
-    eventObject: TEvent,
+    _event: SCXML.Event<TEvent>,
     prevState?: State<TContext>
   ): Array<ActionObject<TContext, TEvent>> {
     const prevConfig = prevState
@@ -986,9 +985,7 @@ class StateNode<
           done(sn.id, sn.data), // TODO: deprecate - final states should not emit done events for their own state.
           done(
             parent.id,
-            sn.data
-              ? mapContext(sn.data, currentContext, eventObject)
-              : undefined
+            sn.data ? mapContext(sn.data, currentContext, _event) : undefined
           )
         );
 
@@ -1050,9 +1047,10 @@ class StateNode<
    */
   public transition(
     state: StateValue | State<TContext, TEvent>,
-    event: TEvent | TEvent['type'],
+    event: Event<TEvent> | SCXML.Event<TEvent>,
     context?: TContext
   ): State<TContext, TEvent, TStateSchema> {
+    const _event = toSCXMLEvent(event);
     let currentState: State<TContext, TEvent>;
 
     if (state instanceof State) {
@@ -1071,17 +1069,17 @@ class StateNode<
       );
     }
 
-    const eventObject = toEventObject(event);
-    const eventType = eventObject.type;
-
-    if (!IS_PRODUCTION && eventType === WILDCARD) {
+    if (!IS_PRODUCTION && _event.name === WILDCARD) {
       throw new Error("An event cannot have the wildcard type ('*')");
     }
 
     if (this.strict) {
-      if (this.events.indexOf(eventType) === -1 && !isBuiltInEvent(eventType)) {
+      if (
+        this.events.indexOf(_event.name) === -1 &&
+        !isBuiltInEvent(_event.name)
+      ) {
         throw new Error(
-          `Machine '${this.id}' does not accept event '${eventType}'`
+          `Machine '${this.id}' does not accept event '${_event.name}'`
         );
       }
     }
@@ -1089,7 +1087,7 @@ class StateNode<
     const stateTransition = this._transition(
       currentState.value,
       currentState,
-      eventObject
+      _event
     ) || {
       transitions: [],
       configuration: [],
@@ -1109,19 +1107,24 @@ class StateNode<
 
     stateTransition.configuration = [...resolvedConfig];
 
-    return this.resolveTransition(stateTransition, currentState, eventObject);
+    return this.resolveTransition(stateTransition, currentState, _event);
   }
 
   private resolveRaisedTransition(
     state: State<TContext, TEvent>,
-    raisedEvent: TEvent | NullEvent,
-    eventObject: TEvent
+    _event: SCXML.Event<TEvent> | NullEvent,
+    originalEvent: SCXML.Event<TEvent>
   ): State<TContext, TEvent> {
     const currentActions = state.actions;
 
-    state = this.transition(state, raisedEvent as TEvent, state.context);
+    state = this.transition(
+      state,
+      _event as SCXML.Event<TEvent>,
+      state.context
+    );
     // Save original event to state
-    state.event = eventObject;
+    state._event = originalEvent;
+    state.event = originalEvent.data;
     state.actions.unshift(...currentActions);
     return state;
   }
@@ -1129,7 +1132,7 @@ class StateNode<
   private resolveTransition(
     stateTransition: StateTransition<TContext, TEvent>,
     currentState?: State<TContext, TEvent>,
-    _eventObject?: TEvent,
+    _event: SCXML.Event<TEvent> = initEvent as SCXML.Event<TEvent>,
     context: TContext = this.machine.context!
   ): State<TContext, TEvent> {
     const { configuration } = stateTransition;
@@ -1149,11 +1152,10 @@ class StateNode<
         : undefined
       : undefined;
     const currentContext = currentState ? currentState.context : context;
-    const eventObject = _eventObject || (initEvent as TEvent);
     const actions = this.getActions(
       stateTransition,
       currentContext,
-      eventObject,
+      _event,
       currentState
     );
     const activities = currentState ? { ...currentState.activities } : {};
@@ -1177,7 +1179,7 @@ class StateNode<
     const updatedContext = assignActions.length
       ? this.options.updater(
           currentContext,
-          eventObject,
+          _event,
           assignActions,
           currentState
         )
@@ -1187,12 +1189,12 @@ class StateNode<
       otherActions.map(actionObject => {
         switch (actionObject.type) {
           case actionTypes.raise:
-            return actionObject;
+            return resolveRaise(actionObject as RaiseAction<TEvent>);
           case actionTypes.send:
             const sendAction = resolveSend(
               actionObject as SendAction<TContext, TEvent>,
               updatedContext,
-              eventObject,
+              _event,
               this.machine.options.delays
             ) as ActionObject<TContext, TEvent>; // TODO: fix ActionTypes.Init
 
@@ -1211,13 +1213,13 @@ class StateNode<
             return resolveLog(
               actionObject as LogAction<TContext, TEvent>,
               updatedContext,
-              eventObject
+              _event
             );
           case ActionTypes.Pure:
             return (
               (actionObject as PureAction<TContext, TEvent>).get(
                 updatedContext,
-                eventObject
+                _event.data
               ) || []
             );
           default:
@@ -1230,7 +1232,9 @@ class StateNode<
       resolvedActions,
       (
         action
-      ): action is RaiseAction<TEvent> | SendActionObject<TContext, TEvent> =>
+      ): action is
+        | RaiseActionObject<TEvent>
+        | SendActionObject<TContext, TEvent> =>
         action.type === actionTypes.raise ||
         (action.type === actionTypes.send &&
           (action as SendActionObject<TContext, TEvent>).to ===
@@ -1254,8 +1258,7 @@ class StateNode<
     const nextState = new State<TContext, TEvent>({
       value: resolvedStateValue || currentState!.value,
       context: updatedContext,
-      event: eventObject,
-      _event: toSCXMLEvent(eventObject),
+      _event,
       historyValue: resolvedStateValue
         ? historyValue
           ? updateHistoryValue(historyValue, resolvedStateValue)
@@ -1287,7 +1290,7 @@ class StateNode<
     });
 
     nextState.changed =
-      eventObject.type === actionTypes.update || !!assignActions.length;
+      _event.name === actionTypes.update || !!assignActions.length;
 
     // Dispose of penultimate histories to prevent memory leaks
     const { history } = nextState;
@@ -1308,7 +1311,7 @@ class StateNode<
         {
           type: actionTypes.nullEvent
         },
-        eventObject
+        _event
       );
     }
 
@@ -1316,10 +1319,8 @@ class StateNode<
       const raisedEvent = raisedEvents.shift()!;
       maybeNextState = this.resolveRaisedTransition(
         maybeNextState,
-        raisedEvent.type === actionTypes.raise
-          ? toEventObject((raisedEvent as RaiseAction<TEvent>).event)
-          : (raisedEvent as SendActionObject<TContext, TEvent>).event,
-        eventObject
+        raisedEvent._event,
+        _event
       );
     }
 

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -18,6 +18,7 @@ import {
   ActivityDefinition,
   SpecialTargets,
   RaiseAction,
+  RaiseActionObject,
   DoneEvent,
   ErrorPlatformEvent,
   DoneEventObject,
@@ -27,7 +28,8 @@ import {
   LogExpr,
   LogAction,
   LogActionObject,
-  DelayFunctionMap
+  DelayFunctionMap,
+  SCXML
 } from './types';
 import * as actionTypes from './actionTypes';
 import {
@@ -41,9 +43,7 @@ import { isArray } from './utils';
 
 export { actionTypes };
 
-export const initEvent = { type: actionTypes.init } as {
-  type: ActionTypes.Init;
-};
+export const initEvent = toSCXMLEvent({ type: actionTypes.init });
 
 export function getActionFunction<TContext, TEvent extends EventObject>(
   actionType: ActionType,
@@ -153,6 +153,15 @@ export function raise<TContext, TEvent extends EventObject>(
   };
 }
 
+export function resolveRaise<TEvent extends EventObject>(
+  action: RaiseAction<TEvent>
+): RaiseActionObject<TEvent> {
+  return {
+    type: actionTypes.raise,
+    _event: toSCXMLEvent(action.event)
+  };
+}
+
 /**
  * Sends an event. This returns an action that will be read by an interpreter to
  * send the event in the next step, after the current step is finished executing.
@@ -184,38 +193,41 @@ export function send<TContext, TEvent extends EventObject>(
 export function resolveSend<TContext, TEvent extends EventObject>(
   action: SendAction<TContext, TEvent>,
   ctx: TContext,
-  event: TEvent,
+  _event: SCXML.Event<TEvent>,
   delaysMap?: DelayFunctionMap<TContext, TEvent>
 ): SendActionObject<TContext, TEvent> {
   const meta = {
-    _event: toSCXMLEvent(event)
+    _event
   };
 
   // TODO: helper function for resolving Expr
-  const resolvedEvent = isFunction(action.event)
-    ? action.event(ctx, event, meta)
-    : action.event;
+  const resolvedEvent = toSCXMLEvent(
+    isFunction(action.event)
+      ? action.event(ctx, _event.data, meta)
+      : action.event
+  );
 
   let resolvedDelay: number | string | undefined;
   if (isString(action.delay)) {
     const configDelay = delaysMap && delaysMap[action.delay];
     resolvedDelay = isFunction(configDelay)
-      ? configDelay(ctx, event, meta)
+      ? configDelay(ctx, _event.data, meta)
       : configDelay || action.delay;
   } else {
     resolvedDelay = isFunction(action.delay)
-      ? action.delay(ctx, event, meta)
+      ? action.delay(ctx, _event.data, meta)
       : action.delay;
   }
 
   const resolvedTarget = isFunction(action.to)
-    ? action.to(ctx, event, meta)
+    ? action.to(ctx, _event.data, meta)
     : action.to;
 
   return {
     ...action,
     to: resolvedTarget,
-    event: resolvedEvent,
+    _event: resolvedEvent,
+    event: resolvedEvent.data,
     delay: resolvedDelay
   };
 }
@@ -284,12 +296,12 @@ export function log<TContext, TEvent extends EventObject>(
 export const resolveLog = <TContext, TEvent extends EventObject>(
   action: LogAction<TContext, TEvent>,
   ctx: TContext,
-  event: TEvent
+  _event: SCXML.Event<TEvent>
 ): LogActionObject<TContext, TEvent> => ({
   // TODO: remove .expr from resulting object
   ...action,
-  value: action.expr(ctx, event, {
-    _event: toSCXMLEvent(event)
+  value: action.expr(ctx, _event.data, {
+    _event
   })
 });
 

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -17,7 +17,7 @@ import {
   ActionTypes,
   ActivityDefinition,
   SpecialTargets,
-  RaiseEvent,
+  RaiseAction,
   DoneEvent,
   ErrorPlatformEvent,
   DoneEventObject,
@@ -143,7 +143,10 @@ export function toActivityDefinition<TContext, TEvent extends EventObject>(
  */
 export function raise<TContext, TEvent extends EventObject>(
   event: Event<TEvent>
-): RaiseEvent<TContext, TEvent> {
+): RaiseAction<TEvent> | SendAction<TContext, TEvent> {
+  if (!isString(event)) {
+    return send(event, { to: SpecialTargets.Internal });
+  }
   return {
     type: actionTypes.raise,
     event

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -590,7 +590,7 @@ export class Interpreter<
     // add SCXML event
     const eventWithSCXML = {
       ...event,
-      __scxml: toSCXMLEvent(event, { origin: this.id, type: 'external' })
+      __scxml: toSCXMLEvent(event, { origin: this.id })
     };
 
     target.send(eventWithSCXML);
@@ -889,7 +889,7 @@ export class Interpreter<
         if (!canceled) {
           const errorEvent = error(id, errorData);
           try {
-            // Send "error.execution" to this (parent).
+            // Send "error.platform.id" to this (parent).
             this.send(errorEvent as any);
           } catch (error) {
             this.reportUnhandledExceptionOnInvocation(errorData, error, id);

--- a/src/stateUtils.ts
+++ b/src/stateUtils.ts
@@ -1,5 +1,5 @@
 import { EventObject, StateNode, StateValue } from '.';
-import { keys, flatten, mapContext } from './utils';
+import { keys, flatten } from './utils';
 
 type Configuration<TC, TE extends EventObject> = Iterable<
   StateNode<TC, any, TE>
@@ -189,21 +189,4 @@ export function isInFinalState(
   }
 
   return false;
-}
-
-export function getDoneData<TContext>(
-  context: TContext,
-  event: EventObject
-): any {
-  if (this.stateNode.type === 'compound') {
-    const childNode = this.nodes[keys(this.nodes)[0]];
-
-    if (!childNode.stateNode.data) {
-      return undefined;
-    }
-
-    return mapContext(childNode.stateNode.data, context, event);
-  }
-
-  return undefined;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -307,7 +307,7 @@ export type StatesDefinition<
 };
 
 export type TransitionsConfig<TContext, TEvent extends EventObject> = {
-  [K in TEvent['type'] | BuiltInEvent<TEvent>['type']]?: SingleOrArray<
+  [K in TEvent['type'] | NullEvent['type'] | '*']?: SingleOrArray<
     | string
     | number
     | StateNode<TContext, any, TEvent>
@@ -690,13 +690,9 @@ export enum ActionTypes {
   Pure = 'xstate.pure'
 }
 
-export interface RaisedEvent<TEvent extends EventObject> {
+export interface RaiseAction<TEvent extends EventObject> {
   type: ActionTypes.Raise;
-  event: TEvent;
-}
-export interface RaiseEvent<TContext, TEvent extends EventObject>
-  extends ActionObject<TContext, TEvent> {
-  event: Event<TEvent>;
+  event: TEvent['type'];
 }
 
 export interface DoneInvokeEvent<TData> extends EventObject {
@@ -726,12 +722,6 @@ export interface UpdateObject extends EventObject {
 export type DoneEvent = DoneEventObject & string;
 
 export type NullEvent = { type: ActionTypes.NullEvent };
-
-export type BuiltInEvent<TEvent extends EventObject> =
-  | NullEvent
-  | { type: ActionTypes.Init }
-  | RaisedEvent<TEvent>
-  | ErrorExecutionEvent;
 
 export interface ActivityActionObject<TContext, TEvent extends EventObject>
   extends ActionObject<TContext, TEvent> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,8 @@ export interface ActionObject<TContext, TEvent extends EventObject> {
 
 export type DefaultContext = Record<string, any> | undefined;
 
+export type EventData = Record<string, any> & { type?: never };
+
 /**
  * The specified string event types or the specified event objects.
  */
@@ -198,7 +200,7 @@ export type InvokeCallback = (
  *
  * For Promises, the only events emitted to the parent will be:
  * - `done.invoke.<id>` with the `data` containing the resolved payload when the promise resolves, or:
- * - `error.execution` with the `data` containing the caught error, and `src` containing the service `id`.
+ * - `error.platform.<id>` with the `data` containing the caught error, and `src` containing the service `id`.
  *
  * For callback handlers, the `sender` will be provided, which will send events to the parent service.
  *
@@ -695,6 +697,11 @@ export interface RaiseAction<TEvent extends EventObject> {
   event: TEvent['type'];
 }
 
+export interface RaiseActionObject<TEvent extends EventObject> {
+  type: ActionTypes.Raise;
+  _event: SCXML.Event<TEvent>;
+}
+
 export interface DoneInvokeEvent<TData> extends EventObject {
   data: TData;
 }
@@ -769,6 +776,7 @@ export interface SendAction<TContext, TEvent extends EventObject>
 export interface SendActionObject<TContext, TEvent extends EventObject>
   extends SendAction<TContext, TEvent> {
   to: string | number | Actor | undefined;
+  _event: SCXML.Event<TEvent>;
   event: TEvent;
   delay?: number | string;
   id: string | number;
@@ -840,7 +848,7 @@ export type Updater<
   >
 > = (
   context: TContext,
-  event: TEvent,
+  _event: SCXML.Event<TEvent>,
   assignActions: TAssignAction[],
   state?: State<TContext, TEvent>
 ) => TContext;
@@ -961,7 +969,6 @@ export interface StateLike<TContext> {
 export interface StateConfig<TContext, TEvent extends EventObject> {
   value: StateValue;
   context: TContext;
-  event: TEvent;
   _event: SCXML.Event<TEvent>;
   historyValue?: HistoryValue | undefined;
   history?: State<TContext, TEvent>;

--- a/test/actionCreators.test.ts
+++ b/test/actionCreators.test.ts
@@ -1,4 +1,5 @@
 import * as actions from '../src/actions';
+import { toSCXMLEvent } from '../src/utils';
 
 const { actionTypes } = actions;
 
@@ -110,7 +111,7 @@ describe('action creators', () => {
       const resolvedAction = actions.resolveSend(
         action,
         { delay: 100 },
-        { type: 'EVENT', value: 50 }
+        toSCXMLEvent({ type: 'EVENT', value: 50 })
       );
 
       expect(resolvedAction.delay).toEqual(150);

--- a/test/after.test.ts
+++ b/test/after.test.ts
@@ -1,5 +1,6 @@
 import { Machine, interpret } from '../src';
 import { after, cancel, send, actionTypes } from '../src/actions';
+import { toSCXMLEvent } from '../src/utils';
 
 const lightMachine = Machine({
   id: 'light',
@@ -34,7 +35,10 @@ describe('delayed transitions', () => {
     expect(nextState.value).toEqual('yellow');
     expect(nextState.actions).toEqual([
       cancel(after(1000, 'light.green')),
-      send(after(1000, 'light.yellow'), { delay: 1000 })
+      {
+        ...send(after(1000, 'light.yellow'), { delay: 1000 }),
+        _event: toSCXMLEvent(after(1000, 'light.yellow'))
+      }
     ]);
   });
 

--- a/test/invoke.test.ts
+++ b/test/invoke.test.ts
@@ -432,7 +432,7 @@ describe('invoke', () => {
         },
         success: {
           id: 'success',
-          type: 'final',
+          type: 'final'
         }
       },
       on: {

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -289,7 +289,9 @@ describe('State', () => {
     it('should preserve the given State if there are no actions', () => {
       const naturallyInertState = State.from('foo');
 
-      expect(State.inert(naturallyInertState, undefined)).toEqual(naturallyInertState);
+      expect(State.inert(naturallyInertState, undefined)).toEqual(
+        naturallyInertState
+      );
     });
   });
 
@@ -313,10 +315,10 @@ describe('State', () => {
       expect(nextState.event).toEqual({ type: 'TO_TWO', foo: 'bar' });
     });
 
-    it('the .event prop should be the initial event for the initial state', () => {
+    it('the ._event prop should be the initial event for the initial state', () => {
       const { initialState } = machine;
 
-      expect(initialState.event).toEqual(initEvent);
+      expect(initialState._event).toEqual(initEvent);
     });
   });
 
@@ -337,9 +339,7 @@ describe('State', () => {
         foo: 'bar'
       });
 
-      expect(
-        nextState._event
-      ).toEqual(
+      expect(nextState._event).toEqual(
         toSCXMLEvent({ type: 'TO_TWO', foo: 'bar' })
       );
     });
@@ -353,10 +353,9 @@ describe('State', () => {
     it('the ._event prop should be the SCXML event (SCXML metadata) that caused the transition', () => {
       const { initialState } = machine;
 
-      const nextState = machine.transition(initialState, {
-        type: 'TO_TWO',
-        foo: 'bar',
-        __scxml: toSCXMLEvent(
+      const nextState = machine.transition(
+        initialState,
+        toSCXMLEvent(
           {
             type: 'TO_TWO',
             foo: 'bar'
@@ -365,11 +364,9 @@ describe('State', () => {
             sendid: 'test'
           }
         )
-      });
+      );
 
-      expect(
-        nextState._event
-      ).toEqual(
+      expect(nextState._event).toEqual(
         toSCXMLEvent(
           { type: 'TO_TWO', foo: 'bar' },
           {
@@ -393,11 +390,7 @@ describe('State', () => {
     it('should return all state paths as strings', () => {
       const twoState = machine.transition('one', 'TO_TWO');
 
-      expect(twoState.toStrings()).toEqual([
-        'two',
-        'two.deep',
-        'two.deep.foo'
-      ]);
+      expect(twoState.toStrings()).toEqual(['two', 'two.deep', 'two.deep.foo']);
     });
 
     it('should keep reference to state instance after destructuring', () => {


### PR DESCRIPTION
2 reasons for that:

1. conversion from SCXML.Event to TEvent is always losing information, so it's better to operate internally on the former as it allows us to have better SCXML compat and only "cast" it to TEvent (by accessing `_event.data`) when we expose it to the world - so we don't lose backward compatibility
2. avoids needless conversion from TEvent to SCXML.Event all over the place

This refactor has been done hopefully without breaking changes - whole test suite passes and I haven't touched tests (besides really few lines which were testing rather private stuff.
