### PR TITLE
Fix TypeScript example

### DIFF
--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -71,7 +71,7 @@ const lightMachine = Machine<LightContext, LightStateSchema, LightEvent>({
         stop: {
           on: {
             // Transient transition
-            '': { target: 'green' }
+            '': { target: '$light.green' }
           }
         }
       }


### PR DESCRIPTION
I got an error message `Child state 'green' does not exist on 'light.red'` when running the example.
The target of transient transition should be `#light.green`.