### PR TITLE
Support array transition configs

### DIFF
--- a/src/StateNode.ts
+++ b/src/StateNode.ts
@@ -522,7 +522,7 @@ class StateNode<
 
             return toArray(resolvedTransition).map(transition => ({
               ...transition,
-              delay
+              delay: !isNaN(+delay) ? +delay : delay
             }));
           })
         );
@@ -538,15 +538,12 @@ class StateNode<
           ...this.machine.options.delays,
           [delayRef]: delay
         };
-      } else if (!isNaN(+delay)) {
-        delayRef = +delay;
       } else {
         delayRef = delay;
       }
 
       const eventType = after(delayRef, this.id);
 
-      // TODO: check if using delayRef here (instead of delay) has fixed a bug
       this.onEntry.push(send(eventType, { delay: delayRef }));
       this.onExit.push(cancel(eventType));
 

--- a/src/StateNode.ts
+++ b/src/StateNode.ts
@@ -22,7 +22,8 @@ import {
   toGuard,
   isMachine,
   toSCXMLEvent,
-  mapContext
+  mapContext,
+  toTransitionConfigArray
 } from './utils';
 import {
   Event,
@@ -41,7 +42,6 @@ import {
   ActivityDefinition,
   StateNodeConfig,
   StateSchema,
-  TransitionsDefinition,
   StatesDefinition,
   StateNodesConfig,
   ActionTypes,
@@ -57,9 +57,7 @@ import {
   GuardMeta,
   MachineConfig,
   PureAction,
-  TransitionTarget,
   InvokeCreator,
-  StateMachine,
   DoneEventObject,
   SingleOrArray,
   LogAction,
@@ -69,7 +67,8 @@ import {
   SCXML,
   RaiseActionObject,
   ActivityActionObject,
-  InvokeActionObject
+  InvokeActionObject,
+  TransitionDefinitionMap
 } from './types';
 import { matchesState } from './utils';
 import { State, stateValuesEqual } from './State';
@@ -235,8 +234,9 @@ class StateNode<
     relativeValue: new Map() as Map<StateNode<TContext>, StateValue>,
     initialStateValue: undefined as StateValue | undefined,
     initialState: undefined as State<TContext, TEvent> | undefined,
+    on: undefined as TransitionDefinitionMap<TContext, TEvent> | undefined,
     transitions: undefined as
-      | TransitionsDefinition<TContext, TEvent>
+      | TransitionDefinition<TContext, TEvent>[]
       | undefined,
     delayedTransitions: undefined as
       | Array<DelayedTransitionDefinition<TContext, TEvent>>
@@ -444,6 +444,7 @@ class StateNode<
         (state: StateNode<TContext, any, TEvent>) => state.definition
       ) as StatesDefinition<TContext, TStateSchema, TEvent>,
       on: this.on,
+      transitions: this.transitions,
       onEntry: this.onEntry,
       onExit: this.onExit,
       activities: this.activities || [],
@@ -461,12 +462,21 @@ class StateNode<
   /**
    * The mapping of events to transitions.
    */
-  public get on(): TransitionsDefinition<TContext, TEvent> {
-    return (
-      this.__cache.transitions ||
-      ((this.__cache.transitions = this.formatTransitions()),
-      this.__cache.transitions)
-    );
+  public get on(): TransitionDefinitionMap<TContext, TEvent> {
+    if (this.__cache.on) {
+      return this.__cache.on;
+    }
+
+    const transitions = this.transitions;
+
+    return (this.__cache.on = transitions.reduce(
+      (map, transition) => {
+        map[transition.eventType] = map[transition.eventType] || [];
+        map[transition.eventType].push(transition as any);
+        return map;
+      },
+      {} as TransitionDefinitionMap<TContext, TEvent>
+    ));
   }
 
   public get after(): Array<DelayedTransitionDefinition<TContext, TEvent>> {
@@ -481,10 +491,10 @@ class StateNode<
    * All the transitions that can be taken from this state node.
    */
   public get transitions(): Array<TransitionDefinition<TContext, TEvent>> {
-    return flatten(
-      keys(this.on).map(
-        event => this.on[event] as Array<TransitionDefinition<TContext, TEvent>>
-      )
+    return (
+      this.__cache.transitions ||
+      ((this.__cache.transitions = this.formatTransitions()),
+      this.__cache.transitions)
     );
   }
 
@@ -501,92 +511,56 @@ class StateNode<
       return [];
     }
 
-    if (isArray(afterConfig)) {
-      return afterConfig.map((delayedTransition, i) => {
-        const { delay, target } = delayedTransition;
-        let delayRef: string | number;
+    const delayedTransitions = isArray(afterConfig)
+      ? afterConfig
+      : flatten(
+          keys(afterConfig).map(delay => {
+            const configTransition = afterConfig[delay];
+            const resolvedTransition = isString(configTransition)
+              ? { target: this.resolveTarget(configTransition) }
+              : configTransition;
 
-        if (isFunction(delay)) {
-          // TODO: util function
-          delayRef = `${this.id}:delay[${i}]`;
-          this.machine.options.delays = {
-            ...this.machine.options.delays,
-            [delayRef]: delay
-          };
-        } else {
-          delayRef = delay;
-        }
+            return toArray(resolvedTransition).map(transition => ({
+              ...transition,
+              delay
+            }));
+          })
+        );
 
-        const eventType = after(delayRef, this.id);
+    return delayedTransitions.map((delayedTransition, i) => {
+      const { delay, target } = delayedTransition;
+      let delayRef: string | number;
 
-        this.onEntry.push(send(eventType, { delay: delayRef }));
-        this.onExit.push(cancel(eventType));
-
-        return {
-          eventType,
-          ...delayedTransition,
-          source: this,
-          target: target === undefined ? undefined : this.resolveTarget(target),
-          cond: toGuard(delayedTransition.cond, guards),
-          actions: toArray(delayedTransition.actions).map(action =>
-            toActionObject(action)
-          )
+      if (isFunction(delay)) {
+        // TODO: util function
+        delayRef = `${this.id}:delay[${i}]`;
+        this.machine.options.delays = {
+          ...this.machine.options.delays,
+          [delayRef]: delay
         };
-      });
-    }
+      } else if (!isNaN(+delay)) {
+        delayRef = +delay;
+      } else {
+        delayRef = delay;
+      }
 
-    const allDelayedTransitions = flatten<
-      DelayedTransitionDefinition<TContext, TEvent>
-    >(
-      keys(afterConfig).map(delayKey => {
-        const delayedTransition = (afterConfig as Record<
-          string,
-          | TransitionConfig<TContext, TEvent>
-          | Array<TransitionConfig<TContext, TEvent>>
-        >)[delayKey];
+      const eventType = after(delayRef, this.id);
 
-        const delay = isNaN(+delayKey) ? delayKey : +delayKey;
-        const eventType = after(delay, this.id);
+      // TODO: check if using delayRef here (instead of delay) has fixed a bug
+      this.onEntry.push(send(eventType, { delay: delayRef }));
+      this.onExit.push(cancel(eventType));
 
-        this.onEntry.push(send<TContext, TEvent>(eventType, { delay }));
-        this.onExit.push(cancel(eventType));
-
-        if (isString(delayedTransition)) {
-          return [
-            {
-              source: this,
-              target: this.resolveTarget(delayedTransition),
-              delay,
-              eventType,
-              actions: []
-            }
-          ];
-        }
-
-        const delayedTransitions = toArray(delayedTransition);
-
-        return delayedTransitions.map(transition => ({
-          eventType,
-          delay,
-          ...transition,
-          source: this,
-          target:
-            transition.target === undefined
-              ? transition.target
-              : this.resolveTarget(transition.target),
-          cond: toGuard(transition.cond, guards),
-          actions: toArray(transition.actions).map(action =>
-            toActionObject(action)
-          )
-        }));
-      })
-    );
-
-    allDelayedTransitions.sort((a, b) =>
-      isString(a) || isString(b) ? 0 : +a.delay - +b.delay
-    );
-
-    return allDelayedTransitions;
+      return {
+        eventType,
+        ...delayedTransition,
+        source: this,
+        target: target === undefined ? undefined : this.resolveTarget(target),
+        cond: toGuard(delayedTransition.cond, guards),
+        actions: toArray(delayedTransition.actions).map(action =>
+          toActionObject(action)
+        )
+      };
+    });
   }
 
   /**
@@ -769,24 +743,25 @@ class StateNode<
     state: State<TContext, TEvent>,
     _event: SCXML.Event<TEvent>
   ): StateTransition<TContext, TEvent> | undefined {
-    const eventName = _event.name;
-    const candidates = this.on[eventName as TEvent['type']] || [];
-    const hasWildcard = this.on[WILDCARD];
-
-    if (!candidates.length && !hasWildcard) {
-      return undefined;
-    }
+    const eventName = _event.name as TEvent['type'];
+    const isTransientEvent = eventName === NULL_EVENT;
 
     const actions: Array<ActionObject<TContext, TEvent>> = [];
 
     let nextStateNodes: Array<StateNode<TContext>> = [];
     let selectedTransition: TransitionDefinition<TContext, TEvent> | undefined;
 
-    const allCandidates = hasWildcard
-      ? candidates.concat(this.on['*'])
-      : candidates;
+    for (const candidate of this.transitions) {
+      const candidateType = candidate.eventType;
+      const isDifferentEventType = candidateType !== eventName;
+      // null events should only match against eventless transitions
+      const shouldSkip = isTransientEvent
+        ? isDifferentEventType
+        : isDifferentEventType && candidateType !== WILDCARD;
 
-    for (const candidate of allCandidates) {
+      if (shouldSkip) {
+        continue;
+      }
       const { cond, in: stateIn } = candidate;
       const resolvedContext = state.context;
 
@@ -1067,7 +1042,7 @@ class StateNode<
     }
 
     if (!IS_PRODUCTION && _event.name === WILDCARD) {
-      throw new Error("An event cannot have the wildcard type ('*')");
+      throw new Error(`An event cannot have the wildcard type ('${WILDCARD}')`);
     }
 
     if (this.strict) {
@@ -1822,16 +1797,15 @@ class StateNode<
    */
   public get ownEvents(): Array<TEvent['type']> {
     const events = new Set(
-      keys(this.on).filter(key => {
-        const transitions = this.on[key];
-        return transitions.some(transition => {
+      this.transitions
+        .filter(transition => {
           return !(
             !transition.target &&
             !transition.actions.length &&
             transition.internal
           );
-        });
-      })
+        })
+        .map(transition => transition.eventType)
     );
 
     return Array.from(events);
@@ -1877,12 +1851,13 @@ class StateNode<
   }
 
   private formatTransition(
-    target: TransitionTarget<TContext> | undefined,
-    transitionConfig: TransitionConfig<TContext, TEvent> | undefined,
-    event: string
+    transitionConfig: TransitionConfig<TContext, TEvent> & {
+      event: TEvent['type'] | NullEvent['type'] | '*';
+    }
   ): TransitionDefinition<TContext, TEvent> {
-    let internal = transitionConfig ? transitionConfig.internal : undefined;
-    const targets = toArray(target);
+    let internal =
+      'internal' in transitionConfig ? transitionConfig.internal : undefined;
+    const targets = toArray(transitionConfig.target);
     const { guards } = this.machine.options;
 
     // Format targets to their full string path
@@ -1912,7 +1887,7 @@ class StateNode<
           return targetStateNode;
         } catch (err) {
           throw new Error(
-            `Invalid transition definition for state node '${this.id}' on event '${event}':\n${err.message}`
+            `Invalid transition definition for state node '${this.id}' on event '${transitionConfig.event}':\n${err.message}`
           );
         }
       } else {
@@ -1920,19 +1895,11 @@ class StateNode<
       }
     });
 
-    if (transitionConfig === undefined) {
-      return {
-        target: target === undefined ? undefined : formattedTargets,
-        source: this,
-        actions: [],
-        internal: target === undefined || internal,
-        eventType: event
-      };
-    }
-
     // Check if there is no target (targetless)
     // An undefined transition signals that the state node should not transition from that event.
-    const isTargetless = target === undefined || target === TARGETLESS_KEY;
+    const isTargetless =
+      transitionConfig.target === undefined ||
+      transitionConfig.target === TARGETLESS_KEY;
 
     return {
       ...transitionConfig,
@@ -1941,111 +1908,64 @@ class StateNode<
       target: isTargetless ? undefined : formattedTargets,
       source: this,
       internal: (isTargetless && internal === undefined) || internal,
-      eventType: event
+      eventType: transitionConfig.event
     };
   }
-  private formatTransitions(): TransitionsDefinition<TContext, TEvent> {
-    const onConfig = this.config.on;
+  private formatTransitions(): TransitionDefinition<TContext, TEvent>[] {
+    const onConfig = !this.config.on
+      ? []
+      : Array.isArray(this.config.on)
+      ? this.config.on
+      : flatten(
+          keys(this.config.on).map(key =>
+            toTransitionConfigArray(key, this.config.on![key as string])
+          )
+        );
+
     const doneConfig = this.config.onDone
-      ? {
-          [`${done(this.id)}`]: this.config.onDone
-        }
-      : undefined;
-    const invokeConfig = this.invoke.reduce(
-      (acc, invokeDef) => {
+      ? toTransitionConfigArray(String(done(this.id)), this.config.onDone)
+      : [];
+
+    const invokeConfig = flatten(
+      this.invoke.map(invokeDef => {
+        const settleTransitions: any[] = [];
         if (invokeDef.onDone) {
-          acc[doneInvoke(invokeDef.id)] = invokeDef.onDone;
+          settleTransitions.push(
+            ...toTransitionConfigArray(
+              String(doneInvoke(invokeDef.id)),
+              invokeDef.onDone
+            )
+          );
         }
         if (invokeDef.onError) {
-          acc[error(invokeDef.id)] = invokeDef.onError;
+          settleTransitions.push(
+            ...toTransitionConfigArray(
+              String(error(invokeDef.id)),
+              invokeDef.onError
+            )
+          );
         }
-        return acc;
-      },
-      {} as any
+        return settleTransitions;
+      })
     );
 
     const delayedTransitions = this.after;
 
-    const formattedTransitions: TransitionsDefinition<
-      TContext,
-      TEvent
-    > = mapValues(
-      { ...onConfig, ...doneConfig, ...invokeConfig },
-      (
-        value:
-          | TransitionConfig<TContext, TEvent>
-          | string
-          | StateMachine<any, any, any>
-          | undefined,
-        event
-      ) => {
-        if (value === undefined) {
-          return [
-            { target: undefined, eventType: event, actions: [], internal: true }
-          ];
-        }
-
-        const transitions = toArray(value);
-
-        if (!IS_PRODUCTION) {
-          const hasNonLastUnguardedTarget = transitions
-            .slice(0, -1)
-            .some(
-              transition =>
-                isString(transition) ||
-                isMachine(transition) ||
-                (!('cond' in transition) && !('in' in transition))
-            );
-
-          const eventText =
-            event.length === 0 ? 'the transient event' : `event '${event}'`;
-
-          warn(
-            !hasNonLastUnguardedTarget,
-            `One or more transitions for ${eventText} on state '${this.id}' are unreachable. ` +
-              `Make sure that the default transition is the last one defined.`
-          );
-        }
-
-        return transitions.map(transition => {
-          if (isString(transition) || isMachine(transition)) {
-            return this.formatTransition(transition, undefined, event);
+    let formattedTransitions = flatten(
+      [...onConfig, ...doneConfig, ...invokeConfig].map(
+        (
+          transitionConfig: TransitionConfig<TContext, TEvent> & {
+            event: TEvent['type'] | NullEvent['type'] | '*';
           }
-
-          if (!IS_PRODUCTION) {
-            for (const key of keys(transition)) {
-              if (
-                [
-                  'target',
-                  'actions',
-                  'internal',
-                  'in',
-                  'cond',
-                  'event'
-                ].indexOf(key) === -1
-              ) {
-                throw new Error(
-                  // tslint:disable-next-line:max-line-length
-                  `State object mapping of transitions is deprecated. Check the config for event '${event}' on state '${this.id}'.`
-                );
-              }
-            }
-          }
-
-          return this.formatTransition(transition.target, transition, event);
-        });
-      }
-    ) as TransitionsDefinition<TContext, TEvent>;
+        ) =>
+          toArray(transitionConfig).map(transition =>
+            this.formatTransition(transition)
+          )
+      )
+    );
 
     for (const delayedTransition of delayedTransitions) {
-      formattedTransitions[delayedTransition.eventType] =
-        formattedTransitions[delayedTransition.eventType] || [];
-      formattedTransitions[delayedTransition.eventType].push(
-        delayedTransition as TransitionDefinition<
-          TContext,
-          TEvent | EventObject
-        >
-      );
+      formattedTransitions.push(delayedTransition as any);
     }
 
     return formattedTransitions;

--- a/src/StateNode.ts
+++ b/src/StateNode.ts
@@ -329,7 +329,13 @@ class StateNode<
     this.history =
       _config.history === true ? 'shallow' : _config.history || false;
 
-    this._transient = !!(_config.on && _config.on[NULL_EVENT]);
+    this._transient = !_config.on
+      ? false
+      : Array.isArray(_config.on)
+      ? _config.on.some(({ event }: { event: string }) => {
+          return event === NULL_EVENT;
+        })
+      : NULL_EVENT in _config.on;
     this.strict = !!_config.strict;
 
     // TODO: deprecate (entry)

--- a/src/types.ts
+++ b/src/types.ts
@@ -307,23 +307,37 @@ export type StatesDefinition<
   >;
 };
 
-export type TransitionsConfig<TContext, TEvent extends EventObject> = {
+export type TransitionConfigTargetShortcut<
+  TContext,
+  TEvent extends EventObject
+> = string | undefined | StateNode<TContext, any, TEvent>;
+
+type TransitionsConfigMap<TContext, TEvent extends EventObject> = {
   [K in TEvent['type'] | NullEvent['type'] | '*']?: SingleOrArray<
-    | string
-    | number
-    | StateNode<TContext, any, TEvent>
-    | TransitionConfig<
+    | TransitionConfigTargetShortcut<TContext, TEvent>
+    | (TransitionConfig<
         TContext,
         K extends TEvent['type'] ? Extract<TEvent, { type: K }> : EventObject
-      >
+      > & {
+        event?: undefined;
+      })
   >;
 };
 
-export type TransitionsDefinition<TContext, TEvent extends EventObject> = {
-  [K in TEvent['type']]: Array<
-    TransitionDefinition<TContext, Extract<TEvent, { type: K }>>
-  >;
-};
+type TransitionsConfigArray<TContext, TEvent extends EventObject> = Array<
+  {
+    [K in TEvent['type'] | NullEvent['type'] | '*']: TransitionConfig<
+      TContext,
+      K extends TEvent['type'] ? Extract<TEvent, { type: K }> : EventObject
+    > & {
+      event: K;
+    };
+  }[TEvent['type'] | NullEvent['type'] | '*']
+>;
+
+export type TransitionsConfig<TContext, TEvent extends EventObject> =
+  | TransitionsConfigMap<TContext, TEvent>
+  | TransitionsConfigArray<TContext, TEvent>;
 
 export type InvokeConfig<TContext, TEvent extends EventObject> =
   | {
@@ -503,7 +517,8 @@ export interface StateNodeDefinition<
   initial: StateNodeConfig<TContext, TStateSchema, TEvent>['initial'];
   history: boolean | 'shallow' | 'deep' | undefined;
   states: StatesDefinition<TContext, TStateSchema, TEvent>;
-  on: TransitionsDefinition<TContext, TEvent>;
+  on: TransitionDefinitionMap<TContext, TEvent>;
+  transitions: Array<TransitionDefinition<TContext, TEvent>>;
   onEntry: Array<ActionObject<TContext, TEvent>>;
   onExit: Array<ActionObject<TContext, TEvent>>;
   activities: Array<ActivityDefinition<TContext, TEvent>>;
@@ -866,8 +881,17 @@ export interface TransitionDefinition<TContext, TEvent extends EventObject>
   source: StateNode<TContext, any, TEvent>;
   actions: Array<ActionObject<TContext, TEvent>>;
   cond?: Guard<TContext, TEvent>;
-  eventType: string;
+  eventType: TEvent['type'] | NullEvent['type'] | '*';
 }
+
+export type TransitionDefinitionMap<TContext, TEvent extends EventObject> = {
+  [K in TEvent['type'] | NullEvent['type'] | '*']: Array<
+    TransitionDefinition<
+      TContext,
+      K extends TEvent['type'] ? Extract<TEvent, { type: K }> : EventObject
+    >
+  >;
+};
 
 export interface DelayedTransitionDefinition<
   TContext,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -585,25 +585,25 @@ export function toTransitionConfigArray<TContext, TEvent extends EventObject>(
     return { ...transitionLike, event };
   });
 
-  if (!IS_PRODUCTION) {
-    const hasNonLastUnguardedTarget = transitions
-      .slice(0, -1)
-      .some(
-        transition =>
-          isString(transition.target) ||
-          isMachine(transition.target) ||
-          (!('cond' in transition) && !('in' in transition))
-      );
+  // if (!IS_PRODUCTION) {
+  //   const hasNonLastUnguardedTarget = transitions
+  //     .slice(0, -1)
+  //     .some(
+  //       transition =>
+  //         isString(transition.target) ||
+  //         isMachine(transition.target) ||
+  //         (!('cond' in transition) && !('in' in transition))
+  //     );
 
-    const eventText =
-      event.length === 0 ? 'the transient event' : `event '${event}'`;
+  //   const eventText =
+  //     event.length === 0 ? 'the transient event' : `event '${event}'`;
 
-    warn(
-      !hasNonLastUnguardedTarget,
-      `One or more transitions for ${eventText} on state '${this.id}' are unreachable. ` +
-        `Make sure that the default transition is the last one defined.`
-    );
-  }
+  //   warn(
+  //     !hasNonLastUnguardedTarget,
+  //     `One or more transitions for ${eventText} on state '${this.id}' are unreachable. ` +
+  //       `Make sure that the default transition is the last one defined.`
+  //   );
+  // }
 
   return transitions;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -585,25 +585,5 @@ export function toTransitionConfigArray<TContext, TEvent extends EventObject>(
     return { ...transitionLike, event };
   });
 
-  // if (!IS_PRODUCTION) {
-  //   const hasNonLastUnguardedTarget = transitions
-  //     .slice(0, -1)
-  //     .some(
-  //       transition =>
-  //         isString(transition.target) ||
-  //         isMachine(transition.target) ||
-  //         (!('cond' in transition) && !('in' in transition))
-  //     );
-
-  //   const eventText =
-  //     event.length === 0 ? 'the transient event' : `event '${event}'`;
-
-  //   warn(
-  //     !hasNonLastUnguardedTarget,
-  //     `One or more transitions for ${eventText} on state '${this.id}' are unreachable. ` +
-  //       `Make sure that the default transition is the last one defined.`
-  //   );
-  // }
-
   return transitions;
 }

--- a/test/deterministic.test.ts
+++ b/test/deterministic.test.ts
@@ -119,7 +119,9 @@ describe('deterministic machine', () => {
 
     it('should throw an error if not given an event', () => {
       // @ts-ignore
-      expect(() => (lightMachine.transition as any)('red', undefined)).toThrow();
+      expect(() =>
+        (lightMachine.transition as any)('red', undefined)
+      ).toThrow();
     });
 
     it('should transition to nested states as target', () => {
@@ -141,7 +143,9 @@ describe('deterministic machine', () => {
 
   describe('machine.transition() with nested states', () => {
     it('should properly transition a nested state', () => {
-      expect(lightMachine.transition('red.walk', 'PED_COUNTDOWN').value).toEqual({ red: 'wait' });
+      expect(
+        lightMachine.transition('red.walk', 'PED_COUNTDOWN').value
+      ).toEqual({ red: 'wait' });
     });
 
     it('should transition from initial nested states', () => {
@@ -157,14 +161,18 @@ describe('deterministic machine', () => {
     });
 
     it('should bubble up events that nested states cannot handle', () => {
-      expect(lightMachine.transition('red.stop', 'TIMER').value).toEqual('green');
+      expect(lightMachine.transition('red.stop', 'TIMER').value).toEqual(
+        'green'
+      );
     });
 
     it('should not transition from illegal events', () => {
       expect(lightMachine.transition('red.walk', 'FAKE').value).toEqual({
         red: 'walk'
       });
-      expect(lightMachine.transition('red.walk', 'FAKE').actions).toHaveLength(0);
+      expect(lightMachine.transition('red.walk', 'FAKE').actions).toHaveLength(
+        0
+      );
 
       expect(deepMachine.transition('a1', 'FAKE').value).toEqual({
         a1: { a2: { a3: 'a4' } }
@@ -207,7 +215,9 @@ describe('deterministic machine', () => {
     });
 
     it('should work with substate nodes that have the same key', () => {
-      expect(machine.transition(machine.initialState, 'NEXT').value).toEqual('test');
+      expect(machine.transition(machine.initialState, 'NEXT').value).toEqual(
+        'test'
+      );
     });
   });
 

--- a/test/deterministic.test.ts
+++ b/test/deterministic.test.ts
@@ -198,6 +198,21 @@ describe('deterministic machine', () => {
     });
   });
 
+  describe('machine.transition() with array `.on` configs', () => {
+    it('should properly transition based on an event', () => {
+      const machine = Machine({
+        initial: 'a',
+        states: {
+          a: {
+            on: [{ event: 'NEXT', target: 'pass' }]
+          },
+          pass: {}
+        }
+      });
+      expect(machine.transition('a', 'NEXT').value).toBe('pass');
+    });
+  });
+
   describe('state key names', () => {
     const machine = Machine({
       key: 'test',

--- a/test/eventDescriptors.test.ts
+++ b/test/eventDescriptors.test.ts
@@ -21,6 +21,26 @@ describe('event descriptors', () => {
     expect(service.state.value).toBe('C');
   });
 
+  it('should not use wildcard transition over explicit one when using object `.on` config - even if wildcard comes first', () => {
+    const machine = Machine({
+      initial: 'A',
+      states: {
+        A: {
+          on: {
+            '*': 'fail',
+            NEXT: 'pass'
+          }
+        },
+        fail: {},
+        pass: {}
+      }
+    });
+
+    const service = interpret(machine).start();
+    service.send('NEXT');
+    expect(service.state.value).toBe('pass');
+  });
+
   it('should select wildcard over explicit event type for array `.on` config (according to document order)', () => {
     const machine = Machine({
       initial: 'A',

--- a/test/eventDescriptors.test.ts
+++ b/test/eventDescriptors.test.ts
@@ -20,4 +20,24 @@ describe('event descriptors', () => {
     service.send('BAR');
     expect(service.state.value).toBe('C');
   });
+
+  it('should select wildcard over explicit event type for array `.on` config (according to document order)', () => {
+    const machine = Machine({
+      initial: 'A',
+      states: {
+        A: {
+          on: [
+            { event: '*', target: 'pass' },
+            { event: 'NEXT', target: 'fail' }
+          ]
+        },
+        fail: {},
+        pass: {}
+      }
+    });
+
+    const service = interpret(machine).start();
+    service.send('NEXT');
+    expect(service.state.value).toBe('pass');
+  });
 });

--- a/test/scxml.test.ts
+++ b/test/scxml.test.ts
@@ -123,7 +123,12 @@ const testGroups = {
   ],
   // script: ['test0', 'test1', 'test2'], // <script/> conversion not implemented
   // 'script-src': ['test0', 'test1', 'test2', 'test3'], // <script/> conversion not implemented
-  // 'scxml-prefix-event-name-matching': ['star0', 'test0', 'test1'], // prefix event matching not implemented yet
+  'scxml-prefix-event-name-matching': [
+    'star0'
+    // prefix event matching not implemented yet
+    // 'test0',
+    // 'test1'
+  ],
   // 'send-data': ['send1'],
   // 'send-idlocation': ['test0'],
   // 'send-internal': ['test0'],

--- a/test/transient.test.ts
+++ b/test/transient.test.ts
@@ -343,4 +343,22 @@ describe('transient states (eventless transitions)', () => {
     const state = machine.transition('a', 'FOO');
     expect(state.value).toBe('e');
   });
+
+  it('should select eventless transition for array `.on` config', () => {
+    const machine = Machine({
+      initial: 'a',
+      states: {
+        a: {
+          on: { FOO: 'b' }
+        },
+        b: {
+          on: [{ event: '', target: 'pass' }]
+        },
+        pass: {}
+      }
+    });
+
+    const state = machine.transition('a', 'FOO');
+    expect(state.value).toBe('pass');
+  });
 });

--- a/test/transient.test.ts
+++ b/test/transient.test.ts
@@ -361,4 +361,41 @@ describe('transient states (eventless transitions)', () => {
     const state = machine.transition('a', 'FOO');
     expect(state.value).toBe('pass');
   });
+
+  it('should not select wildcard for eventless transition', () => {
+    const machine = Machine({
+      initial: 'a',
+      states: {
+        a: {
+          on: { FOO: 'b' }
+        },
+        b: {
+          on: { '*': 'fail' }
+        },
+        fail: {}
+      }
+    });
+
+    const state = machine.transition('a', 'FOO');
+    expect(state.value).toBe('b');
+  });
+
+  it('should not select wildcard for eventless transition (array `.on`)', () => {
+    const machine = Machine({
+      initial: 'a',
+      states: {
+        a: {
+          on: { FOO: 'b' }
+        },
+        b: {
+          on: [{ event: '*', target: 'fail' }, { event: '', target: 'pass' }]
+        },
+        fail: {},
+        pass: {}
+      }
+    });
+
+    const state = machine.transition('a', 'FOO');
+    expect(state.value).toBe('pass');
+  });
 });


### PR DESCRIPTION
Motivation:

In SCXML document order matters, so i.e.
```
        <transition target="pass" event="*"/>
        <transition target="fail" event="foo"/>
```
and
```
        <transition target="fail" event="foo"/>
        <transition target="pass" event="*"/>
```
are **not** equivalent. When sending `foo` event it has to be matched according to that document order.

TODO:
- [ ] review
- [x] add new tests (existing ones are passing 🎉 )
- [ ] cleanup `TransitionConfig` type drama (at different places it's intersected with `{event: TEvent["type"]}` or `{ event?: undefined }` 
- [x] consider caching possible candidates, right now every event is iterating through whole list each time
- [x] cleanup delays-related stuff (those with TODO comments)
- [ ] look into few `any`s used in this PR, try to fix them
- [x] for object configs put `*` at the end