### PR TITLE
Cleanup where created delayRef gets inserted

### DIFF
--- a/src/StateNode.ts
+++ b/src/StateNode.ts
@@ -117,7 +117,7 @@ const createDefaultOptions = <TContext>(): MachineOptions<TContext, any> => ({
   guards: {},
   services: {},
   activities: {},
-  delays: {},
+  delays: {}
 });
 
 class StateNode<
@@ -506,15 +506,19 @@ class StateNode<
         let delayRef: string | number;
 
         if (isFunction(delay)) {
+          // TODO: util function
           delayRef = `${this.id}:delay[${i}]`;
-          this.options.delays[delayRef] = delay; // TODO: util function
+          this.machine.options.delays = {
+            ...this.machine.options.delays,
+            [delayRef]: delay
+          };
         } else {
           delayRef = delay;
         }
 
         const eventType = after(delayRef, this.id);
 
-        this.onEntry.push(send(eventType, { delay }));
+        this.onEntry.push(send(eventType, { delay: delayRef }));
         this.onExit.push(cancel(eventType));
 
         return {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -207,12 +207,12 @@ export function resolveSend<TContext, TEvent extends EventObject>(
       : action.event
   );
 
-  let resolvedDelay: number | string | undefined;
+  let resolvedDelay: number | undefined;
   if (isString(action.delay)) {
     const configDelay = delaysMap && delaysMap[action.delay];
     resolvedDelay = isFunction(configDelay)
       ? configDelay(ctx, _event.data, meta)
-      : configDelay || action.delay;
+      : configDelay;
   } else {
     resolvedDelay = isFunction(action.delay)
       ? action.delay(ctx, _event.data, meta)

--- a/src/types.ts
+++ b/src/types.ts
@@ -782,7 +782,7 @@ export interface SendActionObject<TContext, TEvent extends EventObject>
   to: string | number | Actor | undefined;
   _event: SCXML.Event<TEvent>;
   event: TEvent;
-  delay?: number | string;
+  delay?: number;
   id: string | number;
 }
 

--- a/test/after.test.ts
+++ b/test/after.test.ts
@@ -157,7 +157,7 @@ describe('delayed transitions', () => {
       expect(sendActions[0].delay).toEqual(1000 + 500);
     });
 
-    it('should send the expression (string) as delay if expression not found', () => {
+    it('should set delay to undefined if expression not found', () => {
       const { initialState } = delayExprMachine;
       const activeState = delayExprMachine.transition(initialState, {
         type: 'NOEXPR',
@@ -170,7 +170,7 @@ describe('delayed transitions', () => {
 
       expect(sendActions.length).toBe(1);
 
-      expect(sendActions[0].delay).toEqual('nonExistantDelay');
+      expect(sendActions[0].delay).toEqual(undefined);
     });
   });
 });


### PR DESCRIPTION
Regarding - https://github.com/davidkpiano/xstate/pull/647#discussion_r320881094

I'm not the biggest fan of spreading those things onto existing options, but this technique is used at other places, so the same should be done here.

It has worked with that "bug" because function delay got passed down and later resolveSend knew how to deal with a simple function as it has to deal with them for "regular" send actions with delay as function expression. It has never been found in machine.options as it was never added to it.

