### PR TITLE
Fix issue with targetless delayed transition reentering current state

### DIFF
--- a/src/StateNode.ts
+++ b/src/StateNode.ts
@@ -835,8 +835,8 @@ class StateNode<
     if (!nextStateNodes.length) {
       return {
         transitions: [selectedTransition],
-        entrySet: selectedTransition.internal ? [] : [this],
-        exitSet: selectedTransition.internal ? [] : [this],
+        entrySet: [],
+        exitSet: [],
         configuration: state.value ? [this] : [],
         source: state,
         actions

--- a/src/scxml.ts
+++ b/src/scxml.ts
@@ -404,18 +404,20 @@ function scxmlToMachine(
   )[0];
 
   const extState = dataModelEl
-    ? dataModelEl.elements!.reduce((acc, element) => {
-        if (element.attributes!.src) {
-          throw new Error(
-            "Conversion of `src` attribute on datamodel's <data> elements is not supported."
-          );
-        }
-        acc[element.attributes!.id!] = element.attributes!.expr
-          ? // tslint:disable-next-line:no-eval
-            eval(`(${element.attributes!.expr})`)
-          : undefined;
-        return acc;
-      }, {})
+    ? dataModelEl
+        .elements!.filter(element => element.name === 'data')
+        .reduce((acc, element) => {
+          if (element.attributes!.src) {
+            throw new Error(
+              "Conversion of `src` attribute on datamodel's <data> elements is not supported."
+            );
+          }
+          acc[element.attributes!.id!] = element.attributes!.expr
+            ? // tslint:disable-next-line:no-eval
+              eval(`(${element.attributes!.expr})`)
+            : undefined;
+          return acc;
+        }, {})
     : undefined;
 
   return Machine({

--- a/test/actions.test.ts
+++ b/test/actions.test.ts
@@ -536,7 +536,7 @@ describe('onEntry/onExit actions', () => {
           },
           two: {
             exit: () => {
-              actual.push('exitted two');
+              actual.push('exited two');
             }
           }
         }
@@ -553,6 +553,38 @@ describe('onEntry/onExit actions', () => {
           done();
         })
         .catch(done);
+    });
+
+    it("shouldn't exit (and reenter) state on targetless delayed transition", done => {
+      const actual: string[] = [];
+
+      const machine = Machine({
+        initial: 'one',
+        states: {
+          one: {
+            entry: () => {
+              actual.push('entered one');
+            },
+            exit: () => {
+              actual.push('exited one');
+            },
+            after: {
+              10: {
+                actions: () => {
+                  actual.push('got FOO');
+                }
+              }
+            }
+          }
+        }
+      });
+
+      interpret(machine).start();
+
+      setTimeout(() => {
+        expect(actual).toEqual(['entered one', 'got FOO']);
+        done();
+      }, 50);
     });
   });
 });

--- a/test/scxml.test.ts
+++ b/test/scxml.test.ts
@@ -291,7 +291,7 @@ const testGroups = {
     // 'test496.txml',
     // 'test500.txml',
     // 'test501.txml',
-    // 'test503.txml',
+    'test503.txml',
     // 'test504.txml',
     // 'test505.txml',
     // 'test506.txml',


### PR DESCRIPTION
fixes #679 - this actually was a regression, the issue has popped up in 4.7 (wasn't there in 4.6)

According to SCXML (and enabled test):
> [Definition: The exit set of a transition in configuration C is the set of states that are exited when the transition is taken when the state machine is in C. If the transition does not contain a 'target', its exit set is empty.