### PR TITLE
Revises description of sub-state node definition

### DIFF
--- a/docs/guides/statenodes.md
+++ b/docs/guides/statenodes.md
@@ -30,7 +30,7 @@ const nextState = fetchMachine.transition('pending', 'FULFILL');
 
 ## State nodes
 
-In XState, a **state node** specifies a state configuration, and are defined on the machine's `states` property. Substate nodes are recursively defined in the same way.
+In XState, a **state node** specifies a state configuration. They are defined on the machine's `states` property. Likewise, sub-state nodes are hierarchically defined on the `states` property of a state node.
 
 The state determined from `machine.transition(state, event)` represents a combination of state nodes. For example, in the machine below, there's a `success` state node and an `items` substate node. The state value `{ success: 'items' }` represents the combination of those state nodes.
 


### PR DESCRIPTION
I had difficulties to digest the paragraph about nested state nodes.
`Substate` is hard to understand for non native english speakers and can be easily misread as `substrate` or the like. `Sub-` as prefix should be easier to read.
Recursion means basically `running back` from its latin meaning. 
This has nothing to do with recursion. It's just a hierachical tree-like structure.
Maybe stating this as `nested state nodes` would also be fine or describing it as a `tree-like structure`.