### PR TITLE
Fix small typo in transient states example

### DIFF
--- a/docs/guides/statenodes.md
+++ b/docs/guides/statenodes.md
@@ -203,8 +203,8 @@ const timeOfDayMachine = Machine({
   }
 });
 
-const timeOfDayService = interpret(timeOfDayMachine
-  .withContext({ time: Date.now() }))
+const timeOfDayService = interpret(timeOfDayMachine)
+  .withContext({ time: Date.now() })
   .onTransition(state => console.log(state.value))
   .start();
 


### PR DESCRIPTION
Fix misplaced parenthesis `)`.