### PR TITLE
@xstate/fsm: add types to package.json

### DIFF
--- a/packages/xstate-fsm/package.json
+++ b/packages/xstate-fsm/package.json
@@ -18,6 +18,7 @@
   "homepage": "https://github.com/davidkpiano/xstate/tree/master/packages/xstate-fsm#readme",
   "license": "MIT",
   "main": "dist/xstate.fsm.js",
+  "types": "dist/index.d.ts",
   "sideEffects": false,
   "files": [
     "dist",


### PR DESCRIPTION
Allows @xstate/fsm to work with [Pika Web](https://github.com/pikapkg/web) out of the box :D Thanks for the awesome library!