### PR TITLE
Filter out source maps from published files

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,8 +8,10 @@
   "sideEffects": false,
   "files": [
     "dist",
-    "lib",
-    "es"
+    "lib/**/*.js",
+    "lib/**/*.d.ts",
+    "es/**/*.js",
+    "es/**/*.d.ts"
   ],
   "keywords": [
     "statechart",

--- a/packages/xstate-fsm/package.json
+++ b/packages/xstate-fsm/package.json
@@ -21,8 +21,10 @@
   "types": "dist/index.d.ts",
   "sideEffects": false,
   "files": [
-    "dist",
-    "lib"
+    "dist/**/*.js",
+    "dist/**/*.d.ts",
+    "lib/**/*.js",
+    "lib/**/*.d.ts"
   ],
   "repository": {
     "type": "git",

--- a/packages/xstate-graph/package.json
+++ b/packages/xstate-graph/package.json
@@ -16,7 +16,8 @@
   "main": "lib/index.js",
   "sideEffects": false,
   "files": [
-    "lib"
+    "lib/**/*.js",
+    "lib/**/*.d.ts"
   ],
   "repository": {
     "type": "git",

--- a/packages/xstate-immer/package.json
+++ b/packages/xstate-immer/package.json
@@ -19,7 +19,8 @@
     "test": "__tests__"
   },
   "files": [
-    "lib"
+    "lib/**/*.js",
+    "lib/**/*.d.ts"
   ],
   "repository": {
     "type": "git",

--- a/packages/xstate-react/package.json
+++ b/packages/xstate-react/package.json
@@ -22,7 +22,8 @@
     "test": "test"
   },
   "files": [
-    "lib"
+    "lib/**/*.js",
+    "lib/**/*.d.ts"
   ],
   "repository": {
     "type": "git",

--- a/packages/xstate-scxml/package.json
+++ b/packages/xstate-scxml/package.json
@@ -15,7 +15,8 @@
   "main": "lib/index.js",
   "sideEffects": false,
   "files": [
-    "lib"
+    "lib/**/*.js",
+    "lib/**/*.d.ts"
   ],
   "repository": {
     "type": "git",

--- a/packages/xstate-test/package.json
+++ b/packages/xstate-test/package.json
@@ -19,7 +19,8 @@
   "main": "lib/index.js",
   "sideEffects": false,
   "files": [
-    "lib"
+    "lib/**/*.js",
+    "lib/**/*.d.ts"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
fixes #707

I might revamp build system later to unify (and verify) it across all packages - it's somewhere on my todo list, but not with the highest priority 😉 