### PR TITLE
Read initialState when initializing state lazily

### DIFF
--- a/packages/xstate-react/src/index.ts
+++ b/packages/xstate-react/src/index.ts
@@ -98,7 +98,7 @@ export function useMachine<TContext, TEvent extends EventObject>(
   }
 
   // Keep track of the current machine state
-  const [current, setCurrent] = useState(service.initialState);
+  const [current, setCurrent] = useState(() => service.initialState);
 
   useEffect(() => {
     // Start the service when the component mounts.


### PR DESCRIPTION
`.initialState` is a getter which fires some work/computations and might cause `assign` actions to be executed (when being part of entry content) which comes really confusing while inspecting what gets executed etc. 