### PR TITLE
Provide rollup-compatible esm bundle version for @xstate/fsm

### DIFF
--- a/packages/xstate-fsm/package.json
+++ b/packages/xstate-fsm/package.json
@@ -19,6 +19,7 @@
   "license": "MIT",
   "main": "dist/xstate.fsm.js",
   "types": "dist/index.d.ts",
+  "module": "es/index.js",
   "sideEffects": false,
   "files": [
     "dist/**/*.js",

--- a/packages/xstate-fsm/rollup.config.js
+++ b/packages/xstate-fsm/rollup.config.js
@@ -32,11 +32,18 @@ export default [
   }),
   createConfig({
     input: 'src/index.ts',
-    output: {
-      file: 'dist/xstate.fsm.compat.js',
-      format: 'umd',
-      name: 'XStateFSM'
-    },
+    output: [
+      {
+        file: 'dist/xstate.fsm.compat.js',
+        format: 'umd',
+        name: 'XStateFSM'
+      },
+      {
+        dir: 'es',
+        format: 'esm',
+        name: 'XStateFSM'
+      }
+    ],
     tsconfig: 'tsconfig.compat.json'
   })
 ];


### PR DESCRIPTION
Provide rollup-compatible naked esm es5 @xstate/fsm build (like [this](https://github.com/davidkpiano/xstate/commit/c1f094d1695c62ddd0135442c478a9c4006ffb89) commit for core Xstate) 