### PR TITLE
Docs - Update with correct property name

### DIFF
--- a/docs/guides/final.md
+++ b/docs/guides/final.md
@@ -119,4 +119,4 @@ Final states correspond to the SCXML spec: [https://www.w3.org/TR/scxml/#final](
 
 - A final state node only indicates that its immediate parent is _done_. It does not affect the _done_ status of any higher parents, except with parallel state nodes, which are _done_ when all of its child compound state nodes are _done_.
 - Final state nodes cannot have any children. They are atomic state nodes.
-- You can specify `entry` and `onExit` actions on final state nodes.
+- You can specify `entry` and `exit` actions on final state nodes.


### PR DESCRIPTION
Updates the docs for final states to use the correct property name for actions on exit