### PR TITLE
docs : fix example in actors.md

### DIFF
--- a/docs/guides/actors.md
+++ b/docs/guides/actors.md
@@ -71,7 +71,7 @@ const todosMachine = Machine({
           {
             todo: event.todo,
             // add a new todoMachine actor with a unique name
-            ref: spawn(todoMachine, `todo-${event.id}`)
+            ref: () => spawn(todoMachine, `todo-${event.id}`)
           }
         ]
       })


### PR DESCRIPTION
Hello,

It is a small fix to an example in the guide for `Actors` . It seems that the service `todoMachine`should be spawned in a function 