### PR TITLE
Remove explicit yarn installation on CI

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -12,15 +12,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
+
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Install Yarn
-        run: npm install --global yarn
+
       - name: Install dependencies
         run: yarn install
+
       - name: Build
         run: yarn build
+
       - name: Test
         run: yarn test


### PR DESCRIPTION
This is already handled by `actions/setup-node`