### PR TITLE
Proposed fix for #755 "setCurrent is not a function"

### DIFF
--- a/packages/xstate-react/src/index.ts
+++ b/packages/xstate-react/src/index.ts
@@ -71,12 +71,9 @@ export function useMachine<TContext, TEvent extends EventObject>(
   const serviceRef = useRef<Interpreter<TContext, any, TEvent> | null>(null);
 
   // Create the service only once
-  const creatingService = serviceRef.current === null
-  if (creatingService) {
-    serviceRef.current = interpret(
-      machineRef.current,
-      interpreterOptions
-    )
+  const creatingService = serviceRef.current === null;
+  if (serviceRef.current === null) {
+    serviceRef.current = interpret(machineRef.current, interpreterOptions);
   }
 
   const service = serviceRef.current;

--- a/packages/xstate-react/test/useMachine.test.tsx
+++ b/packages/xstate-react/test/useMachine.test.tsx
@@ -98,7 +98,54 @@ describe('useMachine hook', () => {
         execute: false
       });
 
+      expect(service.initialized).toBe(false);
       expect(service.options.execute).toBe(false);
+
+      return null;
+    };
+
+    render(<Test />);
+  });
+
+  it('should start the service immediately if the immediate option is enabled', () => {
+    const testMachine = Machine({
+      initial: 'idle',
+      states: {
+        idle: {}
+      }
+    });
+
+    const Test = () => {
+      const [, , service] = useMachine(testMachine, { immediate: true });
+
+      expect(service.initialized).toBe(true);
+
+      return null;
+    };
+
+    render(<Test />);
+  });
+
+  it('should support the immediate option when the initial state has a transient transition', () => {
+    const testMachine = Machine({
+      initial: 'idle',
+      states: {
+        bootstrap: {
+          on: {
+            '': {
+              target: 'idle'
+            }
+          }
+        },
+        idle: {}
+      }
+    });
+
+    const Test = () => {
+      const [state, , service] = useMachine(testMachine, { immediate: true });
+
+      expect(service.initialized).toBe(true);
+      expect(state.value).toBe('idle');
 
       return null;
     };

--- a/packages/xstate-react/test/useMachine.test.tsx
+++ b/packages/xstate-react/test/useMachine.test.tsx
@@ -128,7 +128,7 @@ describe('useMachine hook', () => {
 
   it('should support the immediate option when the initial state has a transient transition', () => {
     const testMachine = Machine({
-      initial: 'idle',
+      initial: 'bootstrap',
       states: {
         bootstrap: {
           on: {


### PR DESCRIPTION
Prior to this change, if the `immediate: true` option was supplied for `useMachine()` and the service had a transient transition in its initial state, the `onTransition()` handler’s reference to `setCurrent` was `undefined` because `useState()` had not yet been executed to populate it, resulting in a "setCurrent is not a function" runtime error on `service.start()`.

I propose resolving this by splitting up the service creation logic such that the `onTransition()` handler is not added until after `useState()` has been executed and `setCurrent` is defined.

See: #755