### PR TITLE
Fixes incorrect placement of console.log

### DIFF
--- a/packages/xstate-fsm/README.md
+++ b/packages/xstate-fsm/README.md
@@ -386,14 +386,14 @@ const lightService = interpret(lightMachine);
 lightService.subscribe(state => {
   console.log(state);
 });
-
-lightService.start();
 // => logs {
 //   value: 'green',
 //   context: { redLights: 0 },
 //   actions: [],
 //   changed: undefined
 // }
+
+lightService.start();
 
 lightService.send('TIMER');
 // => logs {


### PR DESCRIPTION
If one reads the source code for `@xstate/fsm`, one can see that the `service.subscribe()` method immediately calls the listener with the current state. Thus, in the example, the console.log would be called immediately after registering the listener. The `start` method, on the other hand, merely returns the service and would log nothing out. Thus, I moved the log comment up to just below the subscription.

I have made a small example showing this behavior in a sandbox: https://codesandbox.io/s/jovial-dirac-fe4fn. Without even starting the service, you can see that the `unlit` state has been logged to the console.