### PR TITLE
Adds missing import for example

### DIFF
--- a/packages/xstate-fsm/README.md
+++ b/packages/xstate-fsm/README.md
@@ -352,7 +352,7 @@ userService.subscribe(state => {
 ## Example
 
 ```js
-import { createMachine, assign } from '@xstate/fsm';
+import { createMachine, assign, interpret } from '@xstate/fsm';
 
 const lightMachine = createMachine({
   id: 'light',


### PR DESCRIPTION
The `interpret` function is missing in this import. Used when creating the service.