### PR TITLE
chore(deps): Fix packages referencing external versions of monorepoed packages

### DIFF
--- a/packages/xstate-analytics/package.json
+++ b/packages/xstate-analytics/package.json
@@ -43,7 +43,7 @@
     "lerna-alias": "3.0.3-0",
     "ts-jest": "^24.0.2",
     "typescript": "^3.6.2",
-    "xstate": "^4.6.7"
+    "xstate": "^4.7.0-rc1"
   },
   "dependencies": {}
 }

--- a/packages/xstate-react/package.json
+++ b/packages/xstate-react/package.json
@@ -49,7 +49,7 @@
     "@types/jsdom": "^12.2.3",
     "@types/react": "^16.9.0",
     "@types/react-dom": "^16.8.5",
-    "@xstate/fsm": "1.0.3",
+    "@xstate/fsm": "^1.0.3",
     "jest": "^24.8.0",
     "jsdom": "^14.0.0",
     "jsdom-global": "^3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1432,11 +1432,6 @@
     "@webassemblyjs/wast-parser" "1.8.5"
     "@xtuc/long" "4.2.2"
 
-"@xstate/fsm@1.0.3":
-  version "1.0.3"
-  resolved "https://registry.npmjs.org/@xstate/fsm/-/fsm-1.0.3.tgz#3042aaf09e7dc6a478d6d23e0b8b39855bc4f1ba"
-  integrity sha512-6QIFf0+92BbujHtEejjh6c596/2NG3mrhiT6yamEGxv7Dz4qyeuh4UZI2C0cDtpNhzSOhWaHfo+Zupt1bn9QPA==
-
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"
@@ -10107,11 +10102,6 @@ xml-name-validator@^3.0.0:
 xmlchars@^2.1.1:
   version "2.2.0"
   resolved "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
-
-xstate@^4.6.7:
-  version "4.6.7"
-  resolved "https://registry.npmjs.org/xstate/-/xstate-4.6.7.tgz#1f325df07d75676c90d65b17a3a56692f259fd41"
-  integrity sha512-mqgtH6BXOgjOHVDxZPyW/h6QUC5kfEggh5IN8uOitjzrdCScE/a/cwcRvgcH8CGAXYReDNvasOKD0aFBWAZ1fg==
 
 xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
We should always reference our local versions. Gonna add build checks for this in the future, but for now just fixing this.