### PR TITLE
Fix localstorage get to getItem in readme

### DIFF
--- a/packages/xstate-react/README.md
+++ b/packages/xstate-react/README.md
@@ -288,7 +288,7 @@ You can persist and rehydrate state with `useMachine(...)` via `options.state`:
 // ...
 
 // Get the persisted state config object from somewhere, e.g. localStorage
-const persistedState = JSON.parse(localStorage.get('some-persisted-state-key'));
+const persistedState = JSON.parse(localStorage.getItem('some-persisted-state-key'));
 
 const App = () => {
   const [current, send] = useMachine(someMachine, {


### PR DESCRIPTION
Fix the example in Readme to use the 'getItem' for localstorage when getting the persisted state