### PR TITLE
fix(build): Stop generating source maps

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,22 +1,18 @@
 {
-    "compilerOptions": {
-        "allowSyntheticDefaultImports": true,
-        "composite": true,
-        "target": "es5",
-        "declaration": true,
-        "declarationMap": true,
-        "moduleResolution": "node",
-        "noUnusedLocals": true,
-        "noUnusedParameters": true,
-        "strictNullChecks": true,
-        "downlevelIteration": true,
-        "experimentalDecorators": true,
-        "jsx": "react",
-        "lib": [
-            "es6",
-            "dom"
-        ],
-        "sourceMap": true,
-        "strictPropertyInitialization": true
-    }
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "composite": true,
+    "target": "es5",
+    "declaration": true,
+    "declarationMap": true,
+    "moduleResolution": "node",
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "strictNullChecks": true,
+    "downlevelIteration": true,
+    "experimentalDecorators": true,
+    "jsx": "react",
+    "lib": ["es6", "dom"],
+    "strictPropertyInitialization": true
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10103,6 +10103,11 @@ xmlchars@^2.1.1:
   version "2.2.0"
   resolved "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
 
+xstate@next:
+  version "4.7.0-rc6"
+  resolved "https://registry.npmjs.org/xstate/-/xstate-4.7.0-rc6.tgz#fa91810586ad0222ac00128ec2e0b889a5bcc937"
+  integrity sha512-dojJ2P8jd1HZwpW1v0L7Eoi+uaWID6chsh41mebdT/di20TML4o0Svt4K17vDLIKeA92E5c2UJOsfRQ1B6CB3w==
+
 xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"


### PR DESCRIPTION
fixes https://github.com/davidkpiano/xstate/issues/790

We still want to generate declaration maps - but when we upgrade to TS@3.7 that will probably go away as well.