### PR TITLE
(TS) Support event types for spawn

### DIFF
--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -1186,8 +1186,8 @@ export class Interpreter<
   }
 }
 
-export type Spawnable<TContext> =
-  | StateMachine<TContext, any, any>
+export type Spawnable<TContext, TEvent extends EventObject = EventObject> =
+  | StateMachine<TContext, any, TEvent>
   | Promise<TContext>
   | InvokeCallback
   | Subscribable<TContext>;
@@ -1214,18 +1214,18 @@ const resolveSpawnOptions = (nameOrOptions?: string | SpawnOptions) => {
   };
 };
 
-export function spawn<TContext>(
-  entity: StateMachine<TContext, any, any>,
+export function spawn<TContext, TEvent extends EventObject = EventObject>(
+  entity: StateMachine<TContext, any, TEvent>,
   nameOrOptions?: string | SpawnOptions
-): Interpreter<TContext>;
+): Interpreter<TContext, any, TEvent>;
 export function spawn<TContext>(
   entity: Exclude<Spawnable<TContext>, StateMachine<any, any, any>>,
   nameOrOptions?: string | SpawnOptions
 ): Actor<TContext>;
-export function spawn<TContext>(
-  entity: Spawnable<TContext>,
+export function spawn<TContext, TEvent extends EventObject = EventObject>(
+  entity: Spawnable<TContext, TEvent>,
   nameOrOptions?: string | SpawnOptions
-) {
+): Actor<TContext, TEvent> {
   const resolvedOptions = resolveSpawnOptions(nameOrOptions);
 
   return withServiceScope(undefined, service => {


### PR DESCRIPTION
`spawn` doesn't support event types being set for the resulting interpreter, so you cannot enforce event types when assigned to context. This PR allows events to be defined or inferred from the machine passed to `spawn`.