### PR TITLE
fixing batch calls for interpreter state machines

### DIFF
--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -584,15 +584,16 @@ export class Interpreter<
 
     this.scheduler.schedule(() => {
       let nextState = this.state;
+      let batchChanged = false;
       for (const event of events) {
-        const { changed } = nextState;
         const _event = toSCXMLEvent(event);
         const actions = nextState.actions.map(a =>
           bindActionToState(a, nextState)
         ) as Array<ActionObject<TContext, TEvent>>;
         nextState = this.machine.transition(nextState, _event);
         nextState.actions.unshift(...actions);
-        nextState.changed = nextState.changed || !!changed;
+        batchChanged = nextState.changed || !!batchChanged;
+        nextState.changed = batchChanged;
 
         this.forward(_event);
       }


### PR DESCRIPTION
if any call to `send()` made `state.changed` true, then all calls afterwards would also be true even if the state didn't actually change.

a codepen example of the existing bug can be found [here](https://codepen.io/afrehner/pen/oNNaQJm) (open the console)