### PR TITLE
Sets default value for target

### DIFF
--- a/packages/xstate-fsm/src/index.ts
+++ b/packages/xstate-fsm/src/index.ts
@@ -95,7 +95,7 @@ export function createMachine<
             };
           }
 
-          const { target, actions = [], cond = () => true } =
+          const { target = value, actions = [], cond = () => true } =
             typeof transition === 'string'
               ? { target: transition }
               : transition;
@@ -103,9 +103,7 @@ export function createMachine<
           let nextContext = context;
 
           if (cond(context, eventObject)) {
-            const nextStateConfig = target
-              ? fsmConfig.states[target]
-              : stateConfig;
+            const nextStateConfig = fsmConfig.states[target]
             let assigned = false;
             const allActions = ([] as any[])
               .concat(stateConfig.exit, actions, nextStateConfig.entry)
@@ -132,13 +130,13 @@ export function createMachine<
                 }
                 return true;
               });
-            const nextValue = target ? target : value;
+
             return {
-              value: nextValue,
+              value: target,
               context: nextContext,
               actions: allActions,
-              changed: nextValue !== value || allActions.length > 0 || assigned,
-              matches: createMatcher(nextValue)
+              changed: target !== value || allActions.length > 0 || assigned,
+              matches: createMatcher(target)
             };
           }
         }


### PR DESCRIPTION
In the case where a transition exists with no defined `target` (such as a transition with only actions), then we eventually set that value to `value`, which is the `value` from the state passed into `transition`. We can avoid this with default assignment of `target` to `value` if it's `undefined`.

This handles setting the `nextStateConfig` correctly, and removes the need for the `nextValue` variable.