### PR TITLE
Stringify condition name in guards docs

### DIFF
--- a/docs/guides/guards.md
+++ b/docs/guides/guards.md
@@ -46,7 +46,7 @@ const searchMachine = Machine(
             {
               target: 'searching',
               // Only transition to 'searching' if the guard (cond) evaluates to true
-              cond: searchValid // or { type: 'searchValid' }
+              cond: 'searchValid' // or { type: 'searchValid' }
             },
             { target: '.invalid' }
           ]


### PR DESCRIPTION
As a new user of xstate, I ended up defining all of my guard functions as non-strings because of this inconsistency in the docs. This PR makes `searchValid` a string, as it should be, according to the definition found in the same file:

> A condition function (also known as a guard) specified on the .cond property of a transition, as a **string** or condition object with a { type: '...' } property, and takes 3 arguments...