### PR TITLE
docs: remove .message accessor from promise rejection docs

### DIFF
--- a/docs/guides/communication.md
+++ b/docs/guides/communication.md
@@ -161,7 +161,7 @@ const searchMachine = Machine({
             errorMessage: (context, event) => {
               // event is:
               // { type: 'error.execution', data: 'No query specified' }
-              return event.data.message;
+              return event.data;
             }
           })
         },


### PR DESCRIPTION
The [Promise Rejection](https://xstate.js.org/docs/guides/communication.html#invoking-promises) docs have a typo in the `onError` function:

```javascript
onError: {
  target: 'failure',
  actions: assign({
    errorMessage: (context, event) => {
      // event is:
      // { type: 'error.execution', data: 'No query specified' }
      return event.data.message;
    }
  })
```

The `.message` accessor is not correct. The error string, as specified a few lines above that in English, is the `data` object itself. This PR replaces the last line line of the function with this:

```javascript
return event.data;
```