### PR TITLE
Fix Warning issue related to useActor

### DIFF
--- a/packages/xstate-react/src/useActor.ts
+++ b/packages/xstate-react/src/useActor.ts
@@ -10,7 +10,7 @@ export function useActor<TC, TE extends EventObject>(
   useEffect(() => {
     if (actor) {
       actorRef.current = actor;
-      const sub = actor.subscribe(setCurrent);
+      const sub = actor.subscribe((current) => setCurrent(current));
       return () => {
         sub.unsubscribe();
       };


### PR DESCRIPTION
for some unknown reason, react-native doesn't like passing setCurrent directly to subscribe. This PR propose to add an extra anonymous function to prevent the warning.

![Simulator Screen Shot - iPhone X - 2019-11-28 at 22 54 28](https://user-images.githubusercontent.com/967050/69842735-60356c00-1232-11ea-9df3-68cac3070b62.png)
