### PR TITLE
perf(@xstate/react): Avoid excessive .initialState reads in useMachine

### DIFF
--- a/packages/xstate-react/src/index.ts
+++ b/packages/xstate-react/src/index.ts
@@ -102,11 +102,9 @@ export function useMachine<TContext, TEvent extends EventObject>(
   }, [services]);
 
   // Keep track of the current machine state
-  const initialState = rehydratedState
-    ? State.create(rehydratedState)
-    : service.initialState;
-
-  const [current, setCurrent] = useState(() => initialState);
+  const [current, setCurrent] = useState(() =>
+    rehydratedState ? State.create(rehydratedState) : service.initialState
+  );
 
   // Start service immediately (before mount) if specified in options
   if (immediate) {
@@ -118,7 +116,7 @@ export function useMachine<TContext, TEvent extends EventObject>(
     // Note: the service will start only if it hasn't started already.
     //
     // If a rehydrated state was provided, use the resolved `initialState`.
-    service.start(rehydratedState ? initialState : undefined);
+    service.start(rehydratedState ? current : undefined);
 
     return () => {
       // Stop the service when the component unmounts


### PR DESCRIPTION
relates to https://github.com/davidkpiano/xstate/issues/838

I had no chance to test this properly, it's nearly 1 AM at my place and I have 3% of my battery left 😅 

The idea is to read this lazily in state's initializer and use the computed value from that created state instead of the closure variable which gets recreated each render. Hooks ESLint rule would yell at us here, but we know what we are doing, so 🤷‍♂ 