### PR TITLE
fix: Add optional peer dependency for @xstate/fsm in @xstate/react

### DIFF
--- a/packages/xstate-react/package.json
+++ b/packages/xstate-react/package.json
@@ -40,8 +40,17 @@
     "url": "https://github.com/davidkpiano/xstate/issues"
   },
   "peerDependencies": {
+    "@xstate/fsm": "^1.0.0",
     "react": "^16.8.0",
     "xstate": "^4.7.0"
+  },
+  "peerDependenciesMeta": {
+    "@xstate/fsm": {
+      "optional": true
+    },
+    "xstate": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@testing-library/react": "^8.0.9",


### PR DESCRIPTION
Strict package managers (like yarn v2 or pnpm) don't you require/import stuff unspecified in deps/peerDeps - all your dependencies have to be explicitly defined.

This change can result in false positive peer dep warnings during installations done by older package managers (or ones that just don't implement optional peer deps), but if we want to keep both of those in a single package (`@xstate/react`) then this is very much needed.

Not sure about all package managers, but yarn supports optional peer deps for quite some time (but maybe just a few months? not sure, would have to be tracked if this has been added this year or sometime before that) and npm has added this very recently.