### PR TITLE
Add warning when attempting to update an undefined context

### DIFF
--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -405,7 +405,9 @@ export function updateContext<TContext, TEvent extends EventObject>(
   assignActions: Array<AssignAction<TContext, TEvent>>,
   state?: State<TContext, TEvent>
 ): TContext {
-  warn(!!context, 'Attempting to update undefined context');
+  if (!IS_PRODUCTION) {
+    warn(!!context, 'Attempting to update undefined context');
+  }
   const updatedContext = context
     ? assignActions.reduce((acc, assignAction) => {
         const { assignment } = assignAction as AssignAction<TContext, TEvent>;

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -405,6 +405,7 @@ export function updateContext<TContext, TEvent extends EventObject>(
   assignActions: Array<AssignAction<TContext, TEvent>>,
   state?: State<TContext, TEvent>
 ): TContext {
+  warn(!!context, 'Attempting to update undefined context');
   const updatedContext = context
     ? assignActions.reduce((acc, assignAction) => {
         const { assignment } = assignAction as AssignAction<TContext, TEvent>;


### PR DESCRIPTION
After spending a long time figuring out why my `assign` actions weren't triggered, I thought this warning might be helpful.