### PR TITLE
refactor: Move batch-check to the top of Interpreter.prototype.send

### DIFF
--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -521,6 +521,11 @@ export class Interpreter<
     event: SingleOrArray<Event<TEvent>> | SCXML.Event<TEvent>,
     payload?: EventData
   ): State<TContext, TEvent> => {
+    if (isArray(event)) {
+      this.batch(event);
+      return this.state;
+    }
+
     const _event = toSCXMLEvent(toEventObject(event as Event<TEvent>, payload));
 
     if (this._status === InterpreterStatus.Stopped) {
@@ -535,11 +540,6 @@ export class Interpreter<
           )}`
         );
       }
-      return this.state;
-    }
-
-    if (isArray(event)) {
-      this.batch(event);
       return this.state;
     }
 


### PR DESCRIPTION
Minor optimization. I believe we should remove the possibility of doing this in v5 though - it's better to have explicit methods for both scenarios (send & batch) rather than send also handling both cases.