### PR TITLE
docs: change `json` to `json5`

### DIFF
--- a/docs/packages/xstate-graph/index.md
+++ b/docs/packages/xstate-graph/index.md
@@ -47,7 +47,7 @@ Every path starts with the initial state.
 
 The overall object structure looks like this:
 
-```json
+```json5
 {
   "<SERIALIZED STATE>": {
     "state": State { ... },
@@ -169,7 +169,7 @@ Every path starts with the initial state.
 
 The overall object structure looks like this:
 
-```json
+```json5
 {
   "<SERIALIZED STATE>": {
     "state": State { ... },

--- a/packages/xstate-graph/README.md
+++ b/packages/xstate-graph/README.md
@@ -47,7 +47,7 @@ Every path starts with the initial state.
 
 The overall object structure looks like this:
 
-```json
+```json5
 {
   "<SERIALIZED STATE>": {
     "state": State { ... },
@@ -169,7 +169,7 @@ Every path starts with the initial state.
 
 The overall object structure looks like this:
 
-```json
+```json5
 {
   "<SERIALIZED STATE>": {
     "state": State { ... },


### PR DESCRIPTION
I changed `json` to `json5` for better syntax highlighting.