### PR TITLE
Drop immediate option from useMachine

### DIFF
--- a/.changeset/orange-fans-retire.md
+++ b/.changeset/orange-fans-retire.md
@@ -1,0 +1,5 @@
+---
+'@xstate/react': major
+---
+
+Drop `immediate` option from the `useMachine` hook. It wasn't safe for async React. If you need to send events to your created machine before it has a chance to start in React's commit phase for your component then you have to implement queuing of events appropriate for your use case.

--- a/packages/xstate-react/src/index.ts
+++ b/packages/xstate-react/src/index.ts
@@ -15,25 +15,17 @@ interface UseMachineOptions<TContext, TEvent extends EventObject> {
    */
   context?: Partial<TContext>;
   /**
-   * If `true`, service will start immediately (before mount).
-   */
-  immediate: boolean;
-  /**
    * The state to rehydrate the machine to. The machine will
    * start at this state instead of its `initialState`.
    */
   state?: StateConfig<TContext, TEvent>;
 }
 
-const defaultOptions = {
-  immediate: false
-};
-
 export function useMachine<TContext, TEvent extends EventObject>(
   machine: StateMachine<TContext, any, TEvent>,
   options: Partial<InterpreterOptions> &
     Partial<UseMachineOptions<TContext, TEvent>> &
-    Partial<MachineOptions<TContext, TEvent>> = defaultOptions
+    Partial<MachineOptions<TContext, TEvent>> = {}
 ): [
   State<TContext, TEvent>,
   Interpreter<TContext, any, TEvent>['send'],
@@ -46,7 +38,6 @@ export function useMachine<TContext, TEvent extends EventObject>(
     activities,
     services,
     delays,
-    immediate,
     state: rehydratedState,
     ...interpreterOptions
   } = options;
@@ -105,11 +96,6 @@ export function useMachine<TContext, TEvent extends EventObject>(
   const [current, setCurrent] = useState(() =>
     rehydratedState ? State.create(rehydratedState) : service.initialState
   );
-
-  // Start service immediately (before mount) if specified in options
-  if (immediate) {
-    service.start();
-  }
 
   useLayoutEffect(() => {
     // Start the service when the component mounts.

--- a/packages/xstate-react/test/useMachine.test.tsx
+++ b/packages/xstate-react/test/useMachine.test.tsx
@@ -146,52 +146,6 @@ describe('useMachine hook', () => {
     render(<Test />);
   });
 
-  it('should start the service immediately if the immediate option is enabled', () => {
-    const testMachine = Machine({
-      initial: 'idle',
-      states: {
-        idle: {}
-      }
-    });
-
-    const Test = () => {
-      const [, , service] = useMachine(testMachine, { immediate: true });
-
-      expect(service.initialized).toBe(true);
-
-      return null;
-    };
-
-    render(<Test />);
-  });
-
-  it('should support the immediate option when the initial state has a transient transition', () => {
-    const testMachine = Machine({
-      initial: 'bootstrap',
-      states: {
-        bootstrap: {
-          on: {
-            '': {
-              target: 'idle'
-            }
-          }
-        },
-        idle: {}
-      }
-    });
-
-    const Test = () => {
-      const [state, , service] = useMachine(testMachine, { immediate: true });
-
-      expect(service.initialized).toBe(true);
-      expect(state.value).toBe('idle');
-
-      return null;
-    };
-
-    render(<Test />);
-  });
-
   it('should merge machine context with options.context', () => {
     const testMachine = Machine<{ foo: string; test: boolean }>({
       context: {


### PR DESCRIPTION
I have some more changes planned to `@xstate/react` - don't want to make them all at once so they can be more easily reviewed. Also can't quite make parallel PRs as they would probably conflict with each other quite a bit.

There are not that many of them though - so if we review & merge them at a good pace then we would be able to release v1 of that package in the next week. That being said - it maybe would be a good thing to create a base branch from the master for those changes, so we don't block releasing of other packages while we work on `@xstate/react` (assuming we release things automatically using changesets versioning PRs - because once we merge this to master it will be immediately added to the next release batch).