### PR TITLE
fix(core): cache initial state in interpreter instance. Fixes #838

### DIFF
--- a/.changeset/rare-pillows-fold.md
+++ b/.changeset/rare-pillows-fold.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+The initial state is now cached inside of the service instance instead of the machine, which was the previous (faulty) strategy. This will prevent entry actions on initial states from being called more than once, which is important for ensuring that actors are not spawned more than once.

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -144,6 +144,7 @@ export class Interpreter<
    * The current state of the interpreted machine.
    */
   private _state?: State<TContext, TEvent>;
+  private _initialState?: State<TContext, TEvent>;
   /**
    * The clock that is responsible for setting and clearing timeouts, such as delayed events and transitions.
    */
@@ -214,7 +215,15 @@ export class Interpreter<
       sessionId !== undefined ? sessionId : registry.register(this as Actor);
   }
   public get initialState(): State<TContext, TEvent> {
-    return withServiceScope(this, () => this.machine.initialState);
+    if (this._initialState) {
+      return this._initialState;
+    }
+
+    return withServiceScope(this, () => {
+      this._initialState = this.machine.initialState;
+
+      return this._initialState;
+    });
   }
   public get state(): State<TContext, TEvent> {
     if (!IS_PRODUCTION) {
@@ -451,15 +460,16 @@ export class Interpreter<
     this.initialized = true;
     this._status = InterpreterStatus.Running;
 
-    const resolvedState = withServiceScope(this, () => {
-      return initialState === undefined
-        ? this.machine.initialState
-        : isState<TContext, TEvent>(initialState)
-        ? this.machine.resolveState(initialState)
-        : this.machine.resolveState(
-            State.from(initialState, this.machine.context)
-          );
-    });
+    const resolvedState =
+      initialState === undefined
+        ? this.initialState
+        : withServiceScope(this, () => {
+            return isState<TContext, TEvent>(initialState)
+              ? this.machine.resolveState(initialState)
+              : this.machine.resolveState(
+                  State.from(initialState, this.machine.context)
+                );
+          });
 
     if (this.options.devTools) {
       this.attachDev();
@@ -913,6 +923,9 @@ export class Interpreter<
     }
   }
   public spawn(entity: Spawnable, name: string, options?: SpawnOptions): Actor {
+    if (this._status !== InterpreterStatus.Running) {
+      return createNullActor(name);
+    }
     if (isPromiseLike(entity)) {
       return this.spawnPromise(Promise.resolve(entity), name);
     } else if (isFunction(entity)) {

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -923,9 +923,6 @@ export class Interpreter<
     }
   }
   public spawn(entity: Spawnable, name: string, options?: SpawnOptions): Actor {
-    if (this._status !== InterpreterStatus.Running) {
-      return createNullActor(name);
-    }
     if (isPromiseLike(entity)) {
       return this.spawnPromise(Promise.resolve(entity), name);
     } else if (isFunction(entity)) {

--- a/packages/core/test/interpreter.test.ts
+++ b/packages/core/test/interpreter.test.ts
@@ -74,8 +74,10 @@ describe('interpreter', () => {
       expect(service.initialState.value).toEqual(idMachine.initialState.value);
     });
 
-    it('initial state should be cached', () => {
+    it('initial state should be cached', done => {
       let entryCalled = 0;
+      let promiseSpawned = 0;
+
       const machine = createMachine<any>({
         initial: 'idle',
         context: {
@@ -86,7 +88,11 @@ describe('interpreter', () => {
             entry: assign({
               actor: () => {
                 entryCalled++;
-                return spawn(new Promise(() => void 0));
+                return spawn(
+                  new Promise(() => {
+                    promiseSpawned++;
+                  })
+                );
               }
             })
           }
@@ -94,6 +100,10 @@ describe('interpreter', () => {
       });
 
       const service = interpret(machine);
+
+      expect(entryCalled).toEqual(0);
+      expect(promiseSpawned).toEqual(0);
+
       const callInitialState = () => service.initialState;
       callInitialState();
       callInitialState();
@@ -102,6 +112,11 @@ describe('interpreter', () => {
       service.start();
 
       expect(entryCalled).toEqual(1);
+
+      setTimeout(() => {
+        expect(promiseSpawned).toEqual(1);
+        done();
+      }, 100);
     });
   });
 


### PR DESCRIPTION
This PR caches `initialState` in the service instead of in the machine (which was problematic but an initial "solution").