### PR TITLE
Enter changeset pre mode

### DIFF
--- a/.changeset/eighty-coins-tease.md
+++ b/.changeset/eighty-coins-tease.md
@@ -1,0 +1,5 @@
+---
+'xstate': major
+---
+
+Removed third parameter (context) from Machine's transition method. If you want to transition with a particular context value you should create appropriate `State` using `State.from`. So instead of this - `machine.transition('green', 'TIMER', { elapsed: 100 })`, you should do this - `machine.transition(State.from('green', { elapsed: 100 }), 'TIMER')`.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,17 @@
+{
+  "mode": "pre",
+  "tag": "next",
+  "initialVersions": {
+    "xstate": "4.7.3",
+    "@xstate/analytics": "0.0.1",
+    "@xstate/fsm": "1.1.0",
+    "@xstate/graph": "1.0.0",
+    "@xstate/immer": "0.0.1",
+    "@xstate/react": "1.0.0-rc.0",
+    "@xstate/scxml": "0.2.1",
+    "@xstate/test": "0.1.0",
+    "@xstate/viz": "0.1.0",
+    "@xstate/viz-example": "1.0.0"
+  },
+  "changesets": []
+}

--- a/.changeset/shy-walls-develop.md
+++ b/.changeset/shy-walls-develop.md
@@ -1,0 +1,5 @@
+---
+'xstate': major
+---
+
+Support for compound string state values has been dropped from Machine's transition method. It's no longer allowed to call transition like this - `machine.transition('a.b', 'NEXT')`, instead it's required to use "state value" representation like this - `machine.transition({ a: 'b' }, 'NEXT')`.

--- a/.changeset/slow-apples-dance.md
+++ b/.changeset/slow-apples-dance.md
@@ -1,0 +1,5 @@
+---
+'xstate': major
+---
+
+Removed previously deprecated config properties: `onEntry`, `onExit`, `parallel` and `forward`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - next
 
 jobs:
   release:


### PR DESCRIPTION
This will allow us to track everything done on `next` branch using changesets and while in the prerelease mode we can automatically release beta versions of xstate@5 to npm (in the very same way as it can be done with changesets when working on the master branch)