### PR TITLE
fix(docs): use `onReceive` consistently as callback handler's 2nd argument

### DIFF
--- a/docs/guides/actors.md
+++ b/docs/guides/actors.md
@@ -37,7 +37,7 @@ They may have optional methods:
 All the existing invoked service patterns fit this interface:
 
 - [Invoked promises](./communication.md#invoking-promises) are actors that ignore any received events and send at most one event back to the parent
-- [Invoked callbacks](./communication.md#invoking-callbacks) are actors that can send events to the parent (first `callback` argument), receive events (second `onReceive` argument), and act on them
+- [Invoked callbacks](./communication.md#invoking-callbacks) are actors that can send events to the parent (first `callback` argument), receive events (second `onEvent` argument), and act on them
 - [Invoked machines](./communication.md#invoking-machines) are actors that can send events to the parent (`sendParent(...)` action) or other actors it has references to (`send(...)` action), receive events, act on them (state transitions and actions), spawn new actors (`spawn(...)` function), and stop actors.
 - [Invoked observables](./communication.md#invoking-observables) are actors whose emitted values represent events to be sent back to the parent.
 

--- a/docs/guides/actors.md
+++ b/docs/guides/actors.md
@@ -37,7 +37,7 @@ They may have optional methods:
 All the existing invoked service patterns fit this interface:
 
 - [Invoked promises](./communication.md#invoking-promises) are actors that ignore any received events and send at most one event back to the parent
-- [Invoked callbacks](./communication.md#invoking-callbacks) are actors that can send events to the parent (first `callback` argument), receive events (second `onEvent` argument), and act on them
+- [Invoked callbacks](./communication.md#invoking-callbacks) are actors that can send events to the parent (first `callback` argument), receive events (second `onReceive` argument), and act on them
 - [Invoked machines](./communication.md#invoking-machines) are actors that can send events to the parent (`sendParent(...)` action) or other actors it has references to (`send(...)` action), receive events, act on them (state transitions and actions), spawn new actors (`spawn(...)` function), and stop actors.
 - [Invoked observables](./communication.md#invoking-observables) are actors whose emitted values represent events to be sent back to the parent.
 

--- a/docs/guides/communication.md
+++ b/docs/guides/communication.md
@@ -188,7 +188,7 @@ If the `onError` transition is missing and the Promise is rejected, the error wi
 Streams of events sent to the parent machine can be modeled via a callback handler, which is a function that takes in two arguments:
 
 - `callback` - called with the event to be sent
-- `onEvent` - called with a listener that [listens to events from the parent](#listening-to-parent-events)
+- `onReceive` - called with a listener that [listens to events from the parent](#listening-to-parent-events)
 
 The (optional) return value should be a function that performs cleanup (i.e., unsubscribing, preventing memory leaks, etc.) on the invoked service when the current state is exited.
 
@@ -197,7 +197,7 @@ The (optional) return value should be a function that performs cleanup (i.e., un
 counting: {
   invoke: {
     id: 'incInterval',
-    src: (context, event) => (callback, onEvent) => {
+    src: (context, event) => (callback, onReceive) => {
       // This will send the 'INC' event to the parent every second
       const id = setInterval(() => callback('INC'), 1000);
 
@@ -214,9 +214,9 @@ counting: {
 
 ### Listening to Parent Events
 
-Invoked callback handlers are also given a second argument, `onEvent`, which registers listeners for events sent to the callback handler from the parent. This allows for parent-child communication between the parent machine and the invoked callback service.
+Invoked callback handlers are also given a second argument, `onReceive`, which registers listeners for events sent to the callback handler from the parent. This allows for parent-child communication between the parent machine and the invoked callback service.
 
-For example, the parent machine sends the child `'ponger'` service a `'PING'` event. The child service can listen for that event using `onEvent(listener)`, and send a `'PONG'` event back to the parent in response:
+For example, the parent machine sends the child `'ponger'` service a `'PING'` event. The child service can listen for that event using `onReceive(listener)`, and send a `'PONG'` event back to the parent in response:
 
 ```js
 const pingPongMachine = Machine({
@@ -226,10 +226,10 @@ const pingPongMachine = Machine({
     active: {
       invoke: {
         id: 'ponger',
-        src: (context, event) => (callback, onEvent) => {
+        src: (context, event) => (callback, onReceive) => {
           // Whenever parent sends 'PING',
           // send parent 'PONG' event
-          onEvent(e => {
+          onReceive(e => {
             if (e.type === 'PING') {
               callback('PONG');
             }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -193,7 +193,7 @@ export type Receiver<TEvent extends EventObject> = (
 ) => void;
 
 export type InvokeCallback = (
-  sender: Sender<any>,
+  callback: Sender<any>,
   onReceive: Receiver<EventObject>
 ) => any;
 
@@ -205,7 +205,7 @@ export type InvokeCallback = (
  * - `done.invoke.<id>` with the `data` containing the resolved payload when the promise resolves, or:
  * - `error.platform.<id>` with the `data` containing the caught error, and `src` containing the service `id`.
  *
- * For callback handlers, the `sender` will be provided, which will send events to the parent service.
+ * For callback handlers, the `callback` will be provided, which will send events to the parent service.
  *
  * @param context The current machine `context`
  * @param event The event that invoked the service

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -194,7 +194,7 @@ export type Receiver<TEvent extends EventObject> = (
 
 export type InvokeCallback = (
   sender: Sender<any>,
-  onEvent: Receiver<EventObject>
+  onReceive: Receiver<EventObject>
 ) => any;
 
 /**

--- a/packages/core/test/invoke.test.ts
+++ b/packages/core/test/invoke.test.ts
@@ -1492,10 +1492,10 @@ describe('invoke', () => {
           active: {
             invoke: {
               id: 'child',
-              src: () => (next, onEvent) => {
-                onEvent(e => {
+              src: () => (callback, onReceive) => {
+                onReceive(e => {
                   if (e.type === 'PING') {
-                    next('PONG');
+                    callback('PONG');
                   }
                 });
               }


### PR DESCRIPTION
Just a tiny error: Actor doc refers to callback actor's  2nd argument as `onReceive`, but it is `onEvent` in the linked entry about invoking callback ([link](https://xstate.js.org/docs/guides/communication.html#invoking-callbacks))