### PR TITLE
Fix description text if no meta description given

### DIFF
--- a/.changeset/moody-buttons-double.md
+++ b/.changeset/moody-buttons-double.md
@@ -1,0 +1,5 @@
+---
+'@xstate/test': patch
+---
+
+Fix description text if no meta description is given

--- a/packages/xstate-test/src/index.ts
+++ b/packages/xstate-test/src/index.ts
@@ -359,9 +359,11 @@ function getDescription<T, TContext>(state: State<TContext, any>): string {
 
       const { description } = meta;
 
-      return typeof description === 'function'
-        ? description(state)
-        : `"${description}"` || `"${JSON.stringify(state.value)}"`;
+      if (typeof description === 'function') {
+        return description(state);
+      }
+
+      return description ? `"${description}"` : JSON.stringify(state.value);
     });
 
   return (

--- a/packages/xstate-test/test/index.test.ts
+++ b/packages/xstate-test/test/index.test.ts
@@ -523,7 +523,13 @@ describe('plan description', () => {
               description: 'two description'
             }
           }
+        },
+        on: {
+          NEXT: 'noMetaDescription'
         }
+      },
+      noMetaDescription: {
+        meta: {}
       }
     }
   });
@@ -540,6 +546,7 @@ describe('plan description', () => {
         "reaches state: \\"#test.compound.child\\" ({\\"count\\":0})",
         "reaches state: \\"child with meta\\" ({\\"count\\":0})",
         "reaches states: \\"#test.parallel.one\\", \\"two description\\" ({\\"count\\":0})",
+        "reaches state: \\"noMetaDescription\\" ({\\"count\\":0})",
       ]
     `);
   });


### PR DESCRIPTION
7f7672e8a67451b7e0c3c4285dd8061decb385e8 introduced a bug where without
a `meta.description`, the test description text is
`reaches state: "undefined"`.

This is because even if `meta.description` is `undefined`,
`"${description}"` becoming `"undefined"` is truthy and the code after
`||` can never be reached.

Also double quoting with `JSON.stringify` was fixed.

See https://github.com/davidkpiano/xstate/commit/7f7672e8a67451b7e0c3c4285dd8061decb385e8#diff-8e162acfb6f0732195f10a5f0592fdb3L325-R332