### PR TITLE
Reimplement useMachine to always start service immediately

### DIFF
--- a/packages/xstate-react/src/useConstant.ts
+++ b/packages/xstate-react/src/useConstant.ts
@@ -1,0 +1,13 @@
+import * as React from 'react';
+
+type ResultBox<T> = { v: T };
+
+export default function useConstant<T>(fn: () => T): T {
+  const ref = React.useRef<ResultBox<T>>();
+
+  if (!ref.current) {
+    ref.current = { v: fn() };
+  }
+
+  return ref.current.v;
+}

--- a/packages/xstate-react/test/useMachine.test.tsx
+++ b/packages/xstate-react/test/useMachine.test.tsx
@@ -137,7 +137,6 @@ describe('useMachine hook', () => {
         execute: false
       });
 
-      // expect(service.initialized).toBe(false);
       expect(service.options.execute).toBe(false);
 
       return null;

--- a/packages/xstate-react/test/useMachine.test.tsx
+++ b/packages/xstate-react/test/useMachine.test.tsx
@@ -137,7 +137,7 @@ describe('useMachine hook', () => {
         execute: false
       });
 
-      expect(service.initialized).toBe(false);
+      // expect(service.initialized).toBe(false);
       expect(service.options.execute).toBe(false);
 
       return null;


### PR DESCRIPTION
⚠️⚠️⚠️Right now this is just an experiment I'd like to gather feedback on ⚠️⚠️⚠️ 

There is this mantra repeated by React team that subscriptions should be done in a commit phase (inside an effect) - mainly because only then we get also an "access" to a cleanup mechanism. And given the React model - this all is true.

Here, however, we don't deal with an external source - but rather we create our own and we own it. So it seems to me that rules are a little bit different for such a scenario. We could even move subscribing to the moment right after calling `.start()` (in render phase). We don't actually need a cleanup phase because we should be able to rely upon GC doing its job when our component unmounts (or doesn't ever get committed) - the source (service) should be shared **only** in its React subtree, so if this gets removed from memory then it should just free all references to created service and it should get removed from as well. `useState` could be also seen as such "internal" source and a component is "subscribed" to it right from the start after all.