### PR TITLE
Update transitions.md

### DIFF
--- a/docs/guides/transitions.md
+++ b/docs/guides/transitions.md
@@ -74,7 +74,7 @@ console.log(yellowState.value);
 
 ## Selecting Enabled Transitions
 
-An **enabled transition** is a transition that will be taken, given the current state and event. It will be taken if and only if:
+An **enabled transition** is a transition that will be taken conditionally, based upon the current state and event. It will be taken if and only if:
 
 - it is defined on a [state node](./statenodes.md) that matches the current state value
 - the transition [guard](./guards.md) (`cond` property) is satisfied (evaluates to `true`)


### PR DESCRIPTION
Suggested wording improvement to improve the reader's experience. The improvement is to more expediently communicate what seems to be the behavioral nuances of **Enabled Transitions**

Before:

> "An enabled transition is a transition that will be taken, given the current state and event. It will be taken if and only if..."

- As a reader, I interpreted from this the idea that "an enabled transition will be taken given the current state and event." Standing by itself the first few times reading that, that felt poorly differentiated from regular transitions, which would, of course, be **given** a current state and event in order to, well, transition. I had to sort of double and triple take the meaning. It wasn't until I tried to move along to the next sentence that I could backflow the idea that the sentence in contention was alluding to some form of conditional execution.

After:

> "An enabled transition is a transition that will be taken conditionally, based upon the current state and event. It will be taken if and only if..."

- A transition can be taken. "Conditionality" is easily injected into that idea. Then further clarification as to where the dependencies for conditionality derive from: state/event.