### PR TITLE
Added missing import to typescript.md

### DIFF
--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -131,7 +131,7 @@ The typestates of a machine are specified as the 3rd generic type in `createMach
 **Example:**
 
 ```ts
-import { createMachine } from 'xstate';
+import { createMachine, interpret } from 'xstate';
 
 interface User {
   name: string;


### PR DESCRIPTION
Added missing import for interpret from 'xstate' for the example.

This will enable readers to copy and paste the code and execute without errors.