### PR TITLE
Add a custom timeout for GitHub actions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -4,6 +4,8 @@ on: [push]
 
 jobs:
   build:
+    timeout-minutes: 20
+
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   release:
+    timeout-minutes: 20
+
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Our build+test action takes 2min~ so we definitely don't need 6h of a timeout (GitHub's default)