### PR TITLE
Remove a reference to xstate type from @xstate/react/fsm

### DIFF
--- a/packages/xstate-react/src/fsm.ts
+++ b/packages/xstate-react/src/fsm.ts
@@ -1,9 +1,8 @@
 import { useState, useEffect } from 'react';
 import { StateMachine, EventObject, interpret } from '@xstate/fsm';
-import { AnyEventObject } from 'xstate';
 import useConstant from './useConstant';
 
-export function useMachine<TC, TE extends EventObject = AnyEventObject>(
+export function useMachine<TC, TE extends EventObject = EventObject>(
   stateMachine: StateMachine.Machine<TC, TE, any>
 ): [
   StateMachine.State<TC, TE, any>,


### PR DESCRIPTION
fsm-related code should not depend on `xstate` package. The default I have used here seems to follow what is used in most places in `@xstate/fsm` package.