### PR TITLE
@xstate/test: Introduce coverage options

### DIFF
--- a/.changeset/fifty-pears-hammer.md
+++ b/.changeset/fifty-pears-hammer.md
@@ -1,0 +1,5 @@
+---
+'@xstate/test': minor
+---
+
+Options for `testModel.getCoverage()` and `testModel.testCoverage()` can now be provided to filter which state nodes should be covered by the tests.

--- a/packages/xstate-test/README.md
+++ b/packages/xstate-test/README.md
@@ -177,7 +177,27 @@ Returns an array of testing plans based on the simple paths from the test model'
 
 **Options**
 
-- `filter` (function): A function that takes in the `state` and returns `true` if the state should be traversed, or `false` if traversal should stop.
+| Argument | Type     | Description                                                                                                    |
+| -------- | -------- | -------------------------------------------------------------------------------------------------------------- |
+| `filter` | function | Takes in the `state` and returns `true` if the state should be traversed, or `false` if traversal should stop. |
+
+### `testModel.testCoverage(options?)`
+
+Tests that all state nodes were covered (traversed) in the exected tests.
+
+**_Options_**
+
+| Argument | Type     | Description                                                                               |
+| -------- | -------- | ----------------------------------------------------------------------------------------- |
+| `filter` | function | Takes in each `stateNode` and returns `true` if that state node should have been covered. |
+
+```js
+// Only test coverage for state nodes with a `.meta` property defined:
+
+testModel.testCoverage({
+  filter: stateNode => !!stateNode.meta
+});
+```
 
 ### `testPlan.description`
 

--- a/packages/xstate-test/src/index.ts
+++ b/packages/xstate-test/src/index.ts
@@ -311,11 +311,10 @@ export class TestModel<TTestContext, TContext> {
     options?: CoverageOptions<TContext>
   ): { stateNodes: Record<string, number> } {
     const filter = options ? options.filter : undefined;
-    const stateNodes = getStateNodes(this.machine).filter(
-      filter || (() => true)
-    );
+    const stateNodes = getStateNodes(this.machine);
+    const filteredStateNodes = filter ? stateNodes.filter(filter) : stateNodes;
     const coverage = {
-      stateNodes: stateNodes.reduce((acc, stateNode) => {
+      stateNodes: filteredStateNodes.reduce((acc, stateNode) => {
         acc[stateNode.id] = 0;
         return acc;
       }, {})

--- a/packages/xstate-test/src/index.ts
+++ b/packages/xstate-test/src/index.ts
@@ -15,7 +15,8 @@ import {
   TestPathResult,
   TestSegmentResult,
   TestMeta,
-  EventExecutor
+  EventExecutor,
+  CoverageOptions
 } from './types';
 
 /**
@@ -306,8 +307,13 @@ export class TestModel<TTestContext, TContext> {
     }
   }
 
-  public getCoverage(): { stateNodes: Record<string, number> } {
-    const stateNodes = getStateNodes(this.machine);
+  public getCoverage(
+    options?: CoverageOptions<TContext>
+  ): { stateNodes: Record<string, number> } {
+    const filter = options ? options.filter : undefined;
+    const stateNodes = getStateNodes(this.machine).filter(
+      filter || (() => true)
+    );
     const coverage = {
       stateNodes: stateNodes.reduce((acc, stateNode) => {
         acc[stateNode.id] = 0;
@@ -322,8 +328,8 @@ export class TestModel<TTestContext, TContext> {
     return coverage;
   }
 
-  public testCoverage(): void {
-    const coverage = this.getCoverage();
+  public testCoverage(options?: CoverageOptions<TContext>): void {
+    const coverage = this.getCoverage(options);
     const missingStateNodes = Object.keys(coverage.stateNodes).filter(id => {
       return !coverage.stateNodes[id];
     });

--- a/packages/xstate-test/src/types.ts
+++ b/packages/xstate-test/src/types.ts
@@ -1,4 +1,4 @@
-import { EventObject, State } from 'xstate';
+import { EventObject, State, StateNode } from 'xstate';
 export interface TestMeta<T, TContext> {
   test?: (testContext: T, state: State<TContext, any>) => Promise<void> | void;
   description?: string | ((state: State<TContext, any>) => string);
@@ -137,4 +137,8 @@ export interface TestModelOptions<T> {
 export interface TestModelCoverage {
   stateNodes: Map<string, number>;
   transitions: Map<string, Map<EventObject, number>>;
+}
+
+export interface CoverageOptions<TContext> {
+  filter?: (stateNode: StateNode<TContext, any, any>) => boolean;
 }

--- a/packages/xstate-test/test/index.test.ts
+++ b/packages/xstate-test/test/index.test.ts
@@ -325,6 +325,66 @@ describe('coverage', () => {
       );
     }
   });
+
+  it('skips filtered states (filter option)', async () => {
+    const TestBug = Machine({
+      id: 'testbug',
+      initial: 'idle',
+      context: {
+        retries: 0
+      },
+      states: {
+        idle: {
+          on: {
+            START: 'passthrough'
+          },
+          meta: {
+            test: () => {
+              /* ... */
+            }
+          }
+        },
+        passthrough: {
+          on: {
+            '': 'end'
+          }
+        },
+        end: {
+          type: 'final',
+          meta: {
+            test: () => {
+              /* ... */
+            }
+          }
+        }
+      }
+    });
+
+    const testModel = createModel(TestBug).withEvents({
+      START: () => {
+        /* ... */
+      }
+    });
+
+    const testPlans = testModel.getShortestPathPlans();
+
+    const promises: any[] = [];
+    testPlans.forEach(plan => {
+      plan.paths.forEach(() => {
+        promises.push(plan.test(undefined));
+      });
+    });
+
+    await Promise.all(promises);
+
+    expect(() => {
+      testModel.testCoverage({
+        filter: stateNode => {
+          return !!stateNode.meta;
+        }
+      });
+    }).not.toThrow();
+  });
 });
 
 describe('events', () => {


### PR DESCRIPTION
This PR introduces options for `testModel.getCoverage(options)` and `testModel.testCoverage(options)`:

```js
// Only test coverage for state nodes with a `.meta` property defined:
 testModel.testCoverage({
  filter: stateNode => !!stateNode.meta
});
```

Related issue: #718