### PR TITLE
Change changeset-generated release to prevent some packages from publishing

### DIFF
--- a/.github/actions/change-release-intent/action.yml
+++ b/.github/actions/change-release-intent/action.yml
@@ -1,0 +1,5 @@
+name: Change changeset release intent
+description: Change changeset release intent
+runs:
+  using: 'node12'
+  main: './main.js'

--- a/.github/actions/change-release-intent/main.js
+++ b/.github/actions/change-release-intent/main.js
@@ -1,0 +1,59 @@
+const { exec } = require('@actions/exec');
+const getWorkspaces = require('get-workspaces').default;
+
+async function execWithOutput(command, args, options) {
+  let myOutput = '';
+  let myError = '';
+
+  return {
+    code: await exec(command, args, {
+      listeners: {
+        stdout: data => {
+          myOutput += data.toString();
+        },
+        stderr: data => {
+          myError += data.toString();
+        }
+      },
+
+      ...options
+    }),
+    stdout: myOutput,
+    stderr: myError
+  };
+}
+
+const publishablePackages = ['xstate', '@xstate/fsm', '@xstate/test'];
+
+(async () => {
+  const currentBranchName = (await execWithOutput('git', [
+    'rev-parse',
+    '--abbrev-ref',
+    'HEAD'
+  ])).stdout.trim();
+
+  if (!/^changeset-release\//.test(currentBranchName)) {
+    return;
+  }
+
+  const latestCommitMessage = (await execWithOutput('git', [
+    'log',
+    '-1',
+    '--pretty=%B'
+  ])).stdout.trim();
+
+  await exec('git', ['reset', '--mixed', 'HEAD~1']);
+
+  const workspaces = await getWorkspaces();
+
+  for (let workspace of workspaces) {
+    if (publishablePackages.includes(workspace.name)) {
+      continue;
+    }
+    await exec('git', ['checkout', '--', workspace.dir]);
+  }
+
+  await exec('git', ['add', '.']);
+  await exec('git', ['commit', '-m', `'${latestCommitMessage}'`]);
+  await exec('git', ['push', 'origin', currentBranchName, '--force']);
+})();

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,3 +32,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Change generated release intent
+        uses: ./.github/actions/change-release-intent

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "homepage": "https://github.com/davidkpiano/xstate#readme",
   "dependencies": {
+    "@actions/exec": "^1.0.2",
     "@changesets/cli": "^2.4.0",
     "@manypkg/cli": "^0.9.0",
     "@types/jest": "^24.0.23",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,18 @@
 # yarn lockfile v1
 
 
+"@actions/exec@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@actions/exec/-/exec-1.0.2.tgz#80ae9c2ea0bf5d0046a9f73d2a1b15bddfff0311"
+  integrity sha512-Yo/wfcFuxbVjAaAfvx3aGLhMEuonOahas2jf8BwyA52IkXTAmLi7YVZTpGAQG/lTxuGoNLg9slTWQD4rr7rMDQ==
+  dependencies:
+    "@actions/io" "^1.0.1"
+
+"@actions/io@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@actions/io/-/io-1.0.1.tgz#81a9418fe2bbdef2d2717a8e9f85188b9c565aca"
+  integrity sha512-rhq+tfZukbtaus7xyUtwKfuiCRXd1hWSfmJNEpFgBQJ4woqPEpsBw04awicjwz9tyG2/MVhAEMfVn664Cri5zA==
+
 "@babel/cli@^7.6.0":
   version "7.6.4"
   resolved "https://registry.npmjs.org/@babel/cli/-/cli-7.6.4.tgz#9b35a4e15fa7d8f487418aaa8229c8b0bc815f20"


### PR DESCRIPTION
This fixes generating versioning PRs, quite brute-forcefully. I remove some updated files from the commit - keeping only those files which are in releasable packages. 

This is a temporary solution, Im collaborating with Changesets team on a proper one, but in the meantime we should merge this in.