### PR TITLE
Add `types` field to all package.json's

### DIFF
--- a/.changeset/young-badgers-yawn.md
+++ b/.changeset/young-badgers-yawn.md
@@ -1,0 +1,11 @@
+---
+'@xstate/analytics': patch
+'@xstate/graph': patch
+'@xstate/immer': patch
+'@xstate/react': patch
+'@xstate/scxml': patch
+'@xstate/test': patch
+'@xstate/vue': patch
+---
+
+Added "types" to package.json

--- a/.changeset/young-badgers-yawn.md
+++ b/.changeset/young-badgers-yawn.md
@@ -1,7 +1,4 @@
 ---
-'@xstate/analytics': patch
-'@xstate/graph': patch
-'@xstate/react': patch
 '@xstate/test': patch
 ---
 

--- a/.changeset/young-badgers-yawn.md
+++ b/.changeset/young-badgers-yawn.md
@@ -1,11 +1,8 @@
 ---
 '@xstate/analytics': patch
 '@xstate/graph': patch
-'@xstate/immer': patch
 '@xstate/react': patch
-'@xstate/scxml': patch
 '@xstate/test': patch
-'@xstate/vue': patch
 ---
 
 Added "types" to package.json

--- a/packages/xstate-analytics/package.json
+++ b/packages/xstate-analytics/package.json
@@ -15,6 +15,7 @@
   "homepage": "https://github.com/davidkpiano/xstate/tree/master/packages/xstate-analytics#readme",
   "license": "MIT",
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "sideEffects": false,
   "files": [
     "lib/**/*.js",

--- a/packages/xstate-graph/package.json
+++ b/packages/xstate-graph/package.json
@@ -14,6 +14,7 @@
   "homepage": "https://github.com/davidkpiano/xstate/tree/master/packages/xstate-test#readme",
   "license": "MIT",
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "sideEffects": false,
   "files": [
     "lib/**/*.js",

--- a/packages/xstate-immer/package.json
+++ b/packages/xstate-immer/package.json
@@ -14,6 +14,7 @@
   "homepage": "https://github.com/davidkpiano/xstate/tree/master/packages/xstate-immer#readme",
   "license": "MIT",
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "sideEffects": false,
   "directories": {
     "lib": "lib",

--- a/packages/xstate-react/package.json
+++ b/packages/xstate-react/package.json
@@ -16,6 +16,7 @@
   "homepage": "https://github.com/davidkpiano/xstate/tree/master/packages/xstate-react#readme",
   "license": "MIT",
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "sideEffects": false,
   "directories": {
     "lib": "lib",

--- a/packages/xstate-scxml/package.json
+++ b/packages/xstate-scxml/package.json
@@ -14,6 +14,7 @@
   "homepage": "https://github.com/davidkpiano/xstate/tree/master/packages/xstate-scxml#readme",
   "license": "MIT",
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "sideEffects": false,
   "files": [
     "lib/**/*.js",

--- a/packages/xstate-test/package.json
+++ b/packages/xstate-test/package.json
@@ -17,6 +17,7 @@
   "homepage": "https://github.com/davidkpiano/xstate/tree/master/packages/xstate-test#readme",
   "license": "MIT",
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "browser": {
     "./lib/slimChalk.js": "./lib/slimChalk.browser.js"
   },

--- a/packages/xstate-vue/package.json
+++ b/packages/xstate-vue/package.json
@@ -17,6 +17,7 @@
   "homepage": "https://github.com/davidkpiano/xstate/tree/master/packages/xstate-vue#readme",
   "license": "MIT",
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "sideEffects": false,
   "directories": {
     "lib": "lib",


### PR DESCRIPTION
IntelliJ based IDE's have difficulty trying to find the types unless you use the main path directly. I.E "@xstate/react/lib/index"

This is most likely down to the wording on the typescript publish page. (https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html)

It says "Also note that if your main declaration file is named index.d.ts and lives at the root of the package (next to index.js) you do not need to mark the "types" property, though it is advisable to do so.", so given that the types aren't at the root it isn't resolving it.

Adding this in fixes the issue.