### PR TITLE
Escalate action with expression

### DIFF
--- a/.changeset/lazy-windows-tan.md
+++ b/.changeset/lazy-windows-tan.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+The `escalate()` action can now take in an expression, which will be evaluated against the `context`, `event`, and `meta` to return the error data.

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -478,7 +478,8 @@ export function forwardTo<TContext, TEvent extends EventObject>(
 /**
  * Escalates an error by sending it as an event to this machine's parent.
  *
- * @param errorData The error data to send.
+ * @param errorData The error data to send, or the expression function that
+ * takes in the `context`, `event`, and `meta`, and returns the error data to send.
  * @param options Options to pass into the send action creator.
  */
 export function escalate<

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -29,7 +29,8 @@ import {
   LogAction,
   LogActionObject,
   DelayFunctionMap,
-  SCXML
+  SCXML,
+  ExprWithMeta
 } from './types';
 import * as actionTypes from './actionTypes';
 import {
@@ -480,14 +481,22 @@ export function forwardTo<TContext, TEvent extends EventObject>(
  * @param errorData The error data to send.
  * @param options Options to pass into the send action creator.
  */
-export function escalate<TContext, TEvent extends EventObject>(
-  errorData: any,
+export function escalate<
+  TContext,
+  TEvent extends EventObject,
+  TErrorData = any
+>(
+  errorData: TErrorData | ExprWithMeta<TContext, TEvent, TErrorData>,
   options?: SendActionOptions<TContext, TEvent>
 ): SendAction<TContext, TEvent> {
   return sendParent<TContext, TEvent>(
-    {
-      type: actionTypes.error,
-      data: errorData
+    (context, event, meta) => {
+      return {
+        type: actionTypes.error,
+        data: isFunction(errorData)
+          ? errorData(context, event, meta)
+          : errorData
+      };
     },
     {
       ...options,

--- a/packages/core/test/invoke.test.ts
+++ b/packages/core/test/invoke.test.ts
@@ -2261,5 +2261,50 @@ describe('invoke', () => {
         })
         .start();
     });
+
+    it('handles escalated errors as an expression', done => {
+      interface ChildContext {
+        id: number;
+      }
+
+      const child = Machine<ChildContext>({
+        initial: 'die',
+        context: { id: 42 },
+        states: {
+          die: {
+            entry: escalate(ctx => ctx.id)
+          }
+        }
+      });
+
+      const parent = Machine({
+        initial: 'one',
+
+        states: {
+          one: {
+            invoke: {
+              id: 'child',
+              src: child,
+              onError: {
+                target: 'two',
+                cond: (_, event) => {
+                  expect(event.data).toEqual(42);
+                  return true;
+                }
+              }
+            }
+          },
+          two: {
+            type: 'final'
+          }
+        }
+      });
+
+      interpret(parent)
+        .onDone(() => {
+          done();
+        })
+        .start();
+    });
   });
 });


### PR DESCRIPTION
This PR adds the ability for `escalate()` to take in an expression, just like `send` or `sendParent`.