### PR TITLE
Add failing type test for raise events

### DIFF
--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -1,4 +1,5 @@
 import { Machine, assign } from '../src/index';
+import { raise } from '../src/actions';
 
 function noop(_x) {
   return;
@@ -196,6 +197,108 @@ describe('Nested parallel stateSchema', () => {
   noop(nestedParallelMachine);
 
   it('should work with a parallel StateSchema defined', () => {
+    expect(true).toBeTruthy();
+  });
+});
+
+describe('Raise events', () => {
+  interface GreetingStateSchema {
+    states: {
+      pending: {};
+      morning: {};
+      lunchTime: {};
+      afternoon: {};
+      evening: {};
+      night: {};
+    };
+  }
+
+  type GreetingEvent =
+    | { type: 'DECIDE' }
+    | { type: 'MORNING' }
+    | { type: 'LUNCH_TIME' }
+    | { type: 'AFTERNOON' }
+    | { type: 'EVENING' }
+    | { type: 'NIGHT' };
+
+  interface GreetingContext {
+    hour: number;
+  }
+
+  const greetingContext: GreetingContext = { hour: 10 };
+
+  const raiseGreetingMachine = Machine<
+    GreetingContext,
+    GreetingStateSchema,
+    GreetingEvent
+  >({
+    key: 'greeting',
+    context: greetingContext,
+    initial: 'pending',
+    states: {
+      pending: {
+        on: {
+          DECIDE: [
+            {
+              // This one does not work
+              actions: raise<GreetingContext, { type: 'MORNING' }>({
+                type: 'MORNING'
+              }),
+              cond: ctx => ctx.hour < 12
+            },
+            {
+              // This one does work which makes me wonder what the second type
+              // argument of type should be. I thought the event type that is
+              // raised should be passed ('LUNCH_TIME') or is it like the
+              // assign() API where we want the event that caused the action to
+              // be executed?
+              actions: raise<
+                GreetingContext,
+                { type: 'DECIDE' } | { type: 'LUNCH_TIME' }
+              >({
+                type: 'LUNCH_TIME'
+              }),
+              cond: ctx => ctx.hour === 12
+            },
+            {
+              // Does not work
+              actions: raise<GreetingContext, { type: 'AFTERNOON' }>(
+                'AFTERNOON'
+              ),
+              cond: ctx => ctx.hour < 18
+            },
+            {
+              // Does not work
+              actions: raise({ type: 'EVENING' }),
+              cond: ctx => ctx.hour < 22
+            },
+            {
+              // Works and fixes the type errors for the others too.
+              // Uncomment next line to see them pass :o
+              // actions: raise('NIGHT'),
+              cond: ctx => ctx.hour < 24
+            }
+          ]
+        }
+      },
+      morning: {},
+      lunchTime: {},
+      afternoon: {},
+      evening: {},
+      night: {}
+    },
+    on: {
+      MORNING: '.morning',
+      LUNCH_TIME: '.lunchTime',
+      AFTERNOON: '.afternoon',
+      EVENING: '.evening',
+      NIGHT: '.night'
+    }
+  });
+
+  noop(raiseGreetingMachine);
+
+  it('should work with all the ways to raise events', () => {
     expect(true).toBeTruthy();
   });
 });


### PR DESCRIPTION
As discussed in https://github.com/davidkpiano/xstate/issues/949, I added a machine with some raise events that throws type errors.
I added comments explaining which ways to type the `raise` event work, and which ones do not.
Pay special attention to the last `raise` event that I had to comment for the test to fail as it removed the type errors from the other raise events. (`actions: raise('NIGHT')`).

Unfortunately, my TypeScript knowledge of generics is too limited to fix the issue or investigate further.