### PR TITLE
Removed `TContext` generic type parameter from `raise` action creator

### DIFF
--- a/.changeset/stupid-wasps-destroy.md
+++ b/.changeset/stupid-wasps-destroy.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Removed `TContext` generic type parameter from `raise` action creator. It was never actually utilized internally and caused it being inferred to `unknown` which in turn could cause problems with type compatibility when type checking..

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -142,9 +142,9 @@ export function toActivityDefinition<TContext, TEvent extends EventObject>(
  *
  * @param eventType The event to raise.
  */
-export function raise<TContext, TEvent extends EventObject>(
+export function raise<TEvent extends EventObject>(
   event: Event<TEvent>
-): RaiseAction<TEvent> | SendAction<TContext, TEvent> {
+): RaiseAction<TEvent> | SendAction<any, TEvent> {
   if (!isString(event)) {
     return send(event, { to: SpecialTargets.Internal });
   }

--- a/packages/core/src/scxml.ts
+++ b/packages/core/src/scxml.ts
@@ -128,8 +128,7 @@ function mapActions<
   return elements.map(element => {
     switch (element.name) {
       case 'raise':
-        return actions.raise<TContext, TEvent>(element.attributes!
-          .event! as string);
+        return actions.raise<TEvent>(element.attributes!.event! as string);
       case 'assign':
         return actions.assign<TContext, TEvent>((context, e, meta) => {
           const fnBody = `

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -241,7 +241,7 @@ describe('Raise events', () => {
           DECIDE: [
             {
               // This one does not work
-              actions: raise<GreetingContext, { type: 'MORNING' }>({
+              actions: raise<{ type: 'MORNING' }>({
                 type: 'MORNING'
               }),
               cond: ctx => ctx.hour < 12
@@ -252,19 +252,14 @@ describe('Raise events', () => {
               // raised should be passed ('LUNCH_TIME') or is it like the
               // assign() API where we want the event that caused the action to
               // be executed?
-              actions: raise<
-                GreetingContext,
-                { type: 'DECIDE' } | { type: 'LUNCH_TIME' }
-              >({
+              actions: raise<{ type: 'DECIDE' } | { type: 'LUNCH_TIME' }>({
                 type: 'LUNCH_TIME'
               }),
               cond: ctx => ctx.hour === 12
             },
             {
               // Does not work
-              actions: raise<GreetingContext, { type: 'AFTERNOON' }>(
-                'AFTERNOON'
-              ),
+              actions: raise<{ type: 'AFTERNOON' }>('AFTERNOON'),
               cond: ctx => ctx.hour < 18
             },
             {


### PR DESCRIPTION
relates to #949 

this doesn't fix the issue completely yet, but i believe the change is sound and makes things a little bit easier, TS shouldnt be able to assign inferred `unknown` to parametrized `TContext` after all