### PR TITLE
Merge pull request #967 from andrewgordstewart/andrewgordstewart/add-tcontext-type-to-invoke-config

### DIFF
--- a/.changeset/large-elephants-smoke.md
+++ b/.changeset/large-elephants-smoke.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Add context & event types to InvokeConfig

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -400,7 +400,7 @@ class StateNode<
       } else if (typeof invokeConfig.src !== 'string') {
         const invokeSrc = `${this.id}:invocation[${i}]`; // TODO: util function
         this.machine.options.services = {
-          [invokeSrc]: invokeConfig.src as InvokeCreator<TContext>,
+          [invokeSrc]: invokeConfig.src as InvokeCreator<TContext, TEvent>,
           ...this.machine.options.services
         };
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -353,7 +353,7 @@ export type InvokeConfig<TContext, TEvent extends EventObject> =
       /**
        * The source of the machine to be invoked, or the machine itself.
        */
-      src: string | StateMachine<any, any, any> | InvokeCreator<any, any>;
+      src: string | StateMachine<any, any, any> | InvokeCreator<TContext, any>;
       /**
        * If `true`, events sent to the parent service will be forwarded to the invoked service.
        *

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -210,9 +210,13 @@ export type InvokeCallback = (
  * @param context The current machine `context`
  * @param event The event that invoked the service
  */
-export type InvokeCreator<TContext, TFinalContext = any> = (
+export type InvokeCreator<
+  TContext,
+  TEvent = AnyEventObject,
+  TFinalContext = any
+> = (
   context: TContext,
-  event: AnyEventObject
+  event: TEvent
 ) =>
   | PromiseLike<TFinalContext>
   | StateMachine<TFinalContext, any, any>
@@ -353,7 +357,10 @@ export type InvokeConfig<TContext, TEvent extends EventObject> =
       /**
        * The source of the machine to be invoked, or the machine itself.
        */
-      src: string | StateMachine<any, any, any> | InvokeCreator<TContext, any>;
+      src:
+        | string
+        | StateMachine<any, any, any>
+        | InvokeCreator<TContext, TEvent, any>;
       /**
        * If `true`, events sent to the parent service will be forwarded to the invoked service.
        *


### PR DESCRIPTION
With this change, the `invoke.src` property of a `StateNodeConfig` can perform type inference:

```
type UserContext = { foo: 'bar' };
type UserEvent = { type: 'READY' | 'SET' | 'GO' };
export const stateNode: StateNodeConfig<UserContext, any, UserEvent> = {
  invoke: {
    src: (ctx, event) => {
      switch (event.type) {
        case 'READY':
          // Property 'Foo' does not exist on type 'UserContext'. Did you mean 'foo'?ts(2551)
          return Promise.resolve(ctx.Foo);
        case 'SET':
          return Promise.resolve('SET');
        /// Type '"Go"' is not comparable to type '"READY" | "SET" | "GO"'.ts(2678)
        case 'Go':
          return Promise.resolve();
      }
    }
  }
};
```

See discussion starting [here](https://gitter.im/statecharts/statecharts?at=5e319ef63aca1e4c5f4218b3)