### PR TITLE
Fixed issue with `useMachine` crashing without providing optional `options` parameter

### DIFF
--- a/.changeset/beige-plants-share.md
+++ b/.changeset/beige-plants-share.md
@@ -1,0 +1,5 @@
+---
+'@xstate/vue': patch
+---
+
+Fixed issue with `useMachine` crashing without providing optional `options` parameter.

--- a/packages/xstate-vue/src/index.ts
+++ b/packages/xstate-vue/src/index.ts
@@ -33,7 +33,7 @@ export function useMachine<TContext, TEvent extends EventObject>(
   machine: StateMachine<TContext, any, TEvent>,
   options: Partial<InterpreterOptions> &
     Partial<UseMachineOptions<TContext, TEvent>> &
-    Partial<MachineOptions<TContext, TEvent>>
+    Partial<MachineOptions<TContext, TEvent>> = {}
 ): {
   state: Ref<State<TContext, TEvent>>;
   send: Interpreter<TContext, any, TEvent>['send'];

--- a/packages/xstate-vue/test/UseMachine-no-extra-options.vue
+++ b/packages/xstate-vue/test/UseMachine-no-extra-options.vue
@@ -1,0 +1,30 @@
+<template>
+  <button @click="send('TOGGLE')">
+    {{ state.value === 'inactive' ? 'Turn on' : 'Turn off' }}
+  </button>
+</template>
+
+<script lang="ts">
+import { useMachine } from '../src';
+import { Machine } from 'xstate';
+
+const toggleMachine = Machine({
+  id: 'toggle',
+  initial: 'inactive',
+  states: {
+    inactive: {
+      on: { TOGGLE: 'active' }
+    },
+    active: {
+      on: { TOGGLE: 'inactive' }
+    }
+  }
+});
+
+export default {
+  setup() {
+    const { state, send } = useMachine(toggleMachine);
+    return { state, send };
+  }
+};
+</script>

--- a/packages/xstate-vue/test/useMachine.test.ts
+++ b/packages/xstate-vue/test/useMachine.test.ts
@@ -6,6 +6,7 @@ import {
 } from '@testing-library/vue';
 import VueCompositionApi from '@vue/composition-api';
 import UseMachine from './UseMachine.vue';
+import UseMachineNoExtraOptions from './UseMachine-no-extra-options.vue';
 import { Machine, assign, doneInvoke } from 'xstate';
 import { createLocalVue, mount } from '@vue/test-utils';
 
@@ -88,5 +89,11 @@ describe('useMachine composition function', () => {
     const { service, send } = wrapper.vm.$data;
     expect(service).toBeDefined();
     expect(typeof send).toBe('function');
+  });
+
+  it('should not crash without optional `options` parameter being provided', async () => {
+    expect(() => {
+      renderWithCompositionApi(UseMachineNoExtraOptions);
+    }).not.toThrow();
   });
 });


### PR DESCRIPTION
fixes #975