### PR TITLE
shallow merges the existing machine context and the passed in context…

### DIFF
--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -460,12 +460,15 @@ class StateNode<
   /**
    * Clones this state machine with custom context.
    *
-   * @param context Custom context (will override predefined context, not recursive)
+   * @param context Custom context (will shallow merge predefined context with new context)
    */
   public withContext(
     context: TContext
   ): StateNode<TContext, TStateSchema, TEvent> {
-    return new StateNode(this.config, this.options, context);
+    return new StateNode(this.config, this.options, {
+      ...this.context,
+      ...context
+    });
   }
 
   /**


### PR DESCRIPTION
… from the parent.

not sure what sort of effect this change will have, since it appears that when it was created it was intentionally not merging the contexts. But all the tests pass. :D 

Fixes #993 