### PR TITLE
Update Multiple Guards example

### DIFF
--- a/docs/guides/guards.md
+++ b/docs/guides/guards.md
@@ -218,6 +218,9 @@ const doorMachine = Machine(
           SET_ADMIN: {
             actions: assign({ level: 'admin' })
           },
+          SET_ALARM: {
+            actions: assign({ alert: true })
+          },
           OPEN: [
             // Transitions are tested one at a time.
             // The first valid transition will be taken.
@@ -246,6 +249,13 @@ const doorService = interpret(doorMachine)
   .onTransition(state => console.log(state.value))
   .start();
 // => { closed: 'idle' }
+
+doorService.send('OPEN');
+// => { closed: 'idle' }
+
+doorService.send('SET_ALARM');
+// => { closed: 'idle' }
+// (state does not change, but context changes)
 
 doorService.send('OPEN');
 // => { closed: 'error' }


### PR DESCRIPTION
The multiple guards example sets the initial context of `alarm` to `false`. After calling `doorService.send('OPEN')` the example says that the state will update to `{ closed: 'error' }`, which is not true unless `alarm` is set to `true` in the original context definition.

This PR updates the documentation to include a `SET_ALARM` action. Alternatively we could just set the context to `true` 🤷‍♂ 