### PR TITLE
Removed support for `service.send(type, payload)`

### DIFF
--- a/.changeset/witty-hounds-invent.md
+++ b/.changeset/witty-hounds-invent.md
@@ -1,0 +1,5 @@
+---
+'xstate': major
+---
+
+Removed support for `service.send(type, payload)`. We are using `send` API at multiple places and this was the only one supporting this shape of parameters. Additionally, it had not strict TS types and using it was unsafe (type-wise).

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -23,7 +23,6 @@ import {
   MachineOptions,
   ActionFunctionMap,
   SCXML,
-  EventData,
   Observer,
   Spawnable,
   Typestate
@@ -43,7 +42,6 @@ import {
   isObservable,
   uniqueId,
   isMachineNode,
-  toEventObject,
   toSCXMLEvent,
   reportUnhandledExceptionOnInvocation,
   symbolObservable
@@ -532,15 +530,14 @@ export class Interpreter<
    * @param event The event(s) to send
    */
   public send = (
-    event: SingleOrArray<Event<TEvent>> | SCXML.Event<TEvent>,
-    payload?: EventData
+    event: SingleOrArray<Event<TEvent>> | SCXML.Event<TEvent>
   ): State<TContext, TEvent> => {
     if (isArray(event)) {
       this.batch(event);
       return this.state;
     }
 
-    const _event = toSCXMLEvent(toEventObject(event as Event<TEvent>, payload));
+    const _event = toSCXMLEvent(event);
 
     if (this._status === InterpreterStatus.Stopped) {
       // do nothing
@@ -956,10 +953,11 @@ export class Interpreter<
 
     if (resolvedOptions.sync) {
       childService.onTransition(state => {
-        this.send(actionTypes.update as any, {
+        this.send({
+          type: actionTypes.update,
           state,
           id: childService.id
-        });
+        } as any);
       });
     }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -40,8 +40,6 @@ export interface ActionObject<TContext, TEvent extends EventObject> {
 
 export type DefaultContext = Record<string, any> | undefined;
 
-export type EventData = Record<string, any> & { type?: never };
-
 /**
  * The specified string event types or the specified event objects.
  */

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -15,7 +15,6 @@ import {
   ConditionPredicate,
   SCXML,
   StateLike,
-  EventData,
   TransitionConfig,
   TransitionConfigTargetShortcut,
   NullEvent,
@@ -548,12 +547,10 @@ export const uniqueId = (() => {
 })();
 
 export function toEventObject<TEvent extends EventObject>(
-  event: Event<TEvent>,
-  payload?: EventData
-  // id?: TEvent['type']
+  event: Event<TEvent>
 ): TEvent {
-  if (isString(event) || typeof event === 'number') {
-    return { type: event, ...payload } as TEvent;
+  if (isString(event)) {
+    return { type: event } as TEvent;
   }
 
   return event;

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -939,7 +939,7 @@ describe('forwardTo()', () => {
       .onDone(() => done())
       .start();
 
-    service.send('EVENT', { value: 42 });
+    service.send({ type: 'EVENT', value: 42 });
   });
 
   it('should forward an event to a service (dynamic)', done => {
@@ -986,7 +986,7 @@ describe('forwardTo()', () => {
       .onDone(() => done())
       .start();
 
-    service.send('EVENT', { value: 42 });
+    service.send({ type: 'EVENT', value: 42 });
   });
 });
 

--- a/packages/core/test/actor.test.ts
+++ b/packages/core/test/actor.test.ts
@@ -146,8 +146,8 @@ describe('spawning machines', () => {
       })
       .start();
 
-    service.send('ADD', { id: 42 });
-    service.send('SET_COMPLETE', { id: 42 });
+    service.send({ type: 'ADD', id: 42 });
+    service.send({ type: 'SET_COMPLETE', id: 42 });
   });
 
   it('should invoke actors (when sending batch)', done => {
@@ -158,7 +158,7 @@ describe('spawning machines', () => {
       .start();
 
     service.send([{ type: 'ADD', id: 42 }]);
-    service.send('SET_COMPLETE', { id: 42 });
+    service.send({ type: 'SET_COMPLETE', id: 42 });
   });
 
   it('should invoke a null actor if spawned outside of a service', () => {

--- a/packages/core/test/interpreter.test.ts
+++ b/packages/core/test/interpreter.test.ts
@@ -1170,21 +1170,6 @@ Event: {\\"type\\":\\"SOME_EVENT\\"}"
       service.send({ type: 'EVENT', id: 42 });
     });
 
-    it('can send events with a string and object payload', done => {
-      let state: any;
-      const service = interpret(sendMachine)
-        .onTransition(s => {
-          state = s;
-        })
-        .onDone(() => {
-          expect(state.event).toEqual({ type: 'EVENT', id: 42 });
-          done();
-        })
-        .start();
-
-      service.send('EVENT', { id: 42 });
-    });
-
     it('should receive and process all events sent simultaneously', done => {
       const toggleMachine = Machine({
         id: 'toggle',


### PR DESCRIPTION
As discussed in https://github.com/davidkpiano/xstate/issues/998 and on Slack