### PR TITLE
Use isolatedModules TS mode

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,7 @@ import { mapState } from './mapState';
 import { StateNode } from './StateNode';
 import { State } from './State';
 import { Machine, createMachine } from './Machine';
-import { Actor } from './Actor';
+import { Actor as ActorType } from './Actor';
 import {
   raise,
   send,
@@ -43,7 +43,6 @@ const actions = {
 };
 
 export {
-  Actor,
   Machine,
   StateNode,
   State,
@@ -62,5 +61,7 @@ export {
   doneInvoke,
   createMachine
 };
+
+export type Actor = ActorType;
 
 export * from './types';

--- a/packages/xstate-analytics/src/types.ts
+++ b/packages/xstate-analytics/src/types.ts
@@ -1,1 +1,3 @@
 // TBD
+
+export {};

--- a/packages/xstate-fsm/src/index.ts
+++ b/packages/xstate-fsm/src/index.ts
@@ -6,7 +6,7 @@ import {
   InitEvent
 } from './types';
 
-export { StateMachine, EventObject, InterpreterStatus, Typestate };
+export * from './types';
 
 const INIT_EVENT: InitEvent = { type: 'xstate.init' };
 const ASSIGN_ACTION: StateMachine.AssignAction = 'xstate.assign';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -5,6 +5,7 @@
     "target": "es5",
     "declaration": true,
     "declarationMap": true,
+    "isolatedModules": true,
     "moduleResolution": "node",
     "noUnusedLocals": true,
     "noUnusedParameters": true,


### PR DESCRIPTION
This is in preparation for supporting extra entries like `xstate/invoke`. 

I'm not yet sure if I'm going to actually leverage this mode (but most likely I would like to) - it's not much harmful though so worth to keep anyway as it's going to make it easier to switch transpiling tools. Main downside of this is that it's not possible to just reexport type from a file because of a single-file transpilation not knowing if a particular thing is a type or a runtime value and has to emit it as runtime export (the default). TS 3.8 will improve this situation a little bit by introducing `import type` syntax.

When trying this out I have actually expected that I would have to change way more code to accommodate `isolatedModules` constraints, but it seems that only a single thing had to be changed (a single `Actor` type reexport) 🎉 

~~EDIT:// actually some more type reexports have to be fixed, not sure why I've successfully compiled this without other changes - probably some caching issues >.< gonna fix other problems tomorrow~~