### PR TITLE
Use Set#clear() when stopping an interpreter

### DIFF
--- a/packages/xstate-fsm/src/index.ts
+++ b/packages/xstate-fsm/src/index.ts
@@ -227,7 +227,7 @@ export function interpret<
     },
     stop: () => {
       status = InterpreterStatus.Stopped;
-      listeners.forEach(listener => listeners.delete(listener));
+      listeners.clear();
       return service;
     },
     get status() {


### PR DESCRIPTION
Previously the `stop()` method would loop through the transition listeners and delete each one from the Set.

This change simplifies that to using the [Set#clear()][1] method.

[1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/clear