### PR TITLE
Fixed memory leak - `State` objects had been retained in closures

### DIFF
--- a/.changeset/twelve-tables-tap.md
+++ b/.changeset/twelve-tables-tap.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Fixed memory leak - `State` objects had been retained in closures.

--- a/packages/core/src/State.ts
+++ b/packages/core/src/State.ts
@@ -245,7 +245,7 @@ export class State<
 
     Object.defineProperty(this, 'nextEvents', {
       get: () => {
-        return nextEvents(config.configuration);
+        return nextEvents(this.configuration);
       }
     });
   }


### PR DESCRIPTION
`config` had a reference to `.history` and it had managed to "recursively" retain all of the past histories through closures, as we copy the `configuration` onto the `this` anyway the fix was simple - just use a different object to access it.