### PR TITLE
Annotate failing SCXML tests

### DIFF
--- a/packages/core/src/invoke.ts
+++ b/packages/core/src/invoke.ts
@@ -38,9 +38,10 @@ export function spawnMachine<
       ) as TMachine;
     }
     const childService = interpret(resolvedMachine, {
-      ...options, // inherit options from this interpreter
+      ...options,
       parent,
-      id: id || resolvedMachine.id
+      id: id || resolvedMachine.id,
+      clock: (parent as any).clock
     });
 
     const resolvedOptions = {

--- a/packages/core/src/scxml.ts
+++ b/packages/core/src/scxml.ts
@@ -7,7 +7,7 @@ import {
   DelayExpr
 } from './types';
 import { Machine } from './index';
-import { mapValues, keys, isString } from './utils';
+import { mapValues, keys, isString, flatten } from './utils';
 import * as actions from './actions';
 import { spawnMachine } from './invoke';
 import { MachineNode } from './MachineNode';
@@ -153,7 +153,7 @@ function mapActions<
 
           return evaluateExecutableContent(context, e, meta, fnBody);
         });
-      case 'send':
+      case 'send': {
         const { event, eventexpr, target, id } = element.attributes!;
 
         let convertedEvent: TEvent['type'] | SendExpr<TContext, TEvent>;
@@ -203,6 +203,7 @@ function mapActions<
           to: target as string | undefined,
           id: id as string | undefined
         });
+      }
       case 'log':
         const label = element.attributes!.label;
 
@@ -280,11 +281,11 @@ function toConfig(
       element => element.name === 'invoke'
     );
 
-    const onEntryElement = nodeJson.elements.find(
+    const onEntryElements = nodeJson.elements.filter(
       element => element.name === 'onentry'
     );
 
-    const onExitElement = nodeJson.elements.find(
+    const onExitElements = nodeJson.elements.filter(
       element => element.name === 'onexit'
     );
 
@@ -307,6 +308,14 @@ function toConfig(
 
     const on = transitionElements.map(value => {
       const event = getAttribute(value, 'event') || '';
+
+      if (event === 'done.invoke') {
+        throw new Error(
+          'done.invoke gets often used in SCXML tests as inexact event descriptor.' +
+            " As long as this stay unimplemented or done.invoke doesn't get a specialcased while converting throw when seeing it to avoid tests using this to pass by accident."
+        );
+      }
+
       const targets = getAttribute(value, 'target');
       const internal = getAttribute(value, 'type') === 'internal';
 
@@ -329,12 +338,16 @@ function toConfig(
       };
     });
 
-    const onEntry = onEntryElement
-      ? mapActions(onEntryElement.elements!)
+    const onEntry = onEntryElements
+      ? flatten(
+          onEntryElements.map(onEntryElement =>
+            mapActions(onEntryElement.elements!)
+          )
+        )
       : undefined;
 
-    const onExit = onExitElement
-      ? mapActions(onExitElement.elements!)
+    const onExit = onExitElements
+      ? onExitElements.map(onExitElement => mapActions(onExitElement.elements!))
       : undefined;
 
     const invoke = invokeElements.map(element => {
@@ -350,7 +363,11 @@ function toConfig(
         el => el.name === 'content'
       ) as XMLElement;
 
-      return spawnMachine(scxmlToMachine(content, options));
+      return {
+        ...(element.attributes!.id && { id: element.attributes!.id as string }),
+        src: spawnMachine(scxmlToMachine(content, options)),
+        autoForward: element.attributes!.autoforward === 'true'
+      };
     });
 
     return {

--- a/packages/core/test/scxml.test.ts
+++ b/packages/core/test/scxml.test.ts
@@ -63,7 +63,7 @@ const testGroups = {
     // 'test0', // not implemented
   ],
   in: [
-    // 'TestInPredicate', // In() conversion not implemented yet
+    // 'TestInPredicate', // conversion of In() predicate not implemented yet
   ],
   'internal-transitions': ['test0', 'test1'],
   misc: ['deep-initial'],
@@ -96,8 +96,8 @@ const testGroups = {
     'test4',
     'test5',
     'test6',
-    // 'test7',
-    // 'test7b',
+    'test7',
+    'test7b',
     'test8',
     'test9',
     'test10',
@@ -111,8 +111,9 @@ const testGroups = {
     'test18',
     'test19',
     'test20',
-    // 'test21',
-    // 'test21b',
+    'test21',
+    'test21b',
+    'test21c',
     'test22',
     'test23',
     'test24',
@@ -137,194 +138,205 @@ const testGroups = {
   'targetless-transition': ['test0', 'test1', 'test2', 'test3'],
   'w3c-ecma': [
     'test144.txml',
-    // 'test147.txml',
-    // 'test148.txml',
+    // 'test147.txml', // <if> not implemented yet
+    // 'test148.txml', // <if> not implemented yet
     'test149.txml',
-    // 'test150.txml',
-    // 'test151.txml',
-    // 'test152.txml',
+    // 'test150.txml', // <foreach> not implemented yet
+    // 'test151.txml', // <foreach> not implemented yet
+    // 'test152.txml', // <foreach> not implemented yet
     'test153.txml',
-    // 'test155.txml',
-    // 'test156.txml',
+    // 'test155.txml', // <foreach> not implemented yet
+    // 'test156.txml', // <foreach> not implemented yet
     'test158.txml',
-    // 'test159.txml',
+    // 'test159.txml', // different error handling
     'test172.txml',
     'test173.txml',
     'test174.txml',
     'test175.txml',
     'test176.txml',
-    // 'test179.txml',
-    // 'test183.txml',
+    // 'test179.txml', // conversion of <content> in <sens> not implemented yet
+    // 'test183.txml', idlocation not implemented yet
     'test185.txml',
-    // 'test186.txml',
+    // 'test186.txml', // not sure yet why
     'test187.txml',
     'test189.txml',
-    // 'test190.txml',
+    // 'test190.txml', // _sessionid not yet available for expressions
     'test191.txml',
-    // 'test192.txml',
+    // 'test192.txml', // conversion of #_invokeid not implemented yet
     'test193.txml',
-    // 'test194.txml',
-    // 'test198.txml',
-    // 'test199.txml',
+    // 'test194.txml', // illegal target for <send> causes the event error.execution to be raised
+    // 'test198.txml', // origintype not implemented yet
+    // 'test199.txml', // invalid send type results in error.execution
     'test200.txml',
     'test201.txml',
-    // 'test205.txml',
-    // 'test207.txml',
+    'test205.txml',
+    'test207.txml',
     'test208.txml',
     'test210.txml',
-    // 'test215.txml',
-    // 'test216.txml',
-    // 'test220.txml',
-    // 'test223.txml',
-    // 'test224.txml',
-    // 'test225.txml',
-    // 'test226.txml',
-    // 'test228.txml',
-    // 'test229.txml',
-    // 'test230.txml',
-    // 'test232.txml',
-    // 'test233.txml',
-    // 'test234.txml',
-    // 'test235.txml',
-    // 'test236.txml',
-    // 'test237.txml',
-    // 'test239.txml',
-    // 'test240.txml',
-    // 'test241.txml',
-    // 'test242.txml',
-    // 'test243.txml',
-    // 'test244.txml',
-    // 'test245.txml',
-    // 'test247.txml',
-    // 'test250.txml',
-    // 'test252.txml',
-    // 'test253.txml',
-    // 'test276.txml',
-    // 'test277.txml',
-    // 'test278.txml',
-    // 'test279.txml',
-    // 'test280.txml',
-    // 'test286.txml',
+    // 'test215.txml', // <invoke typeexpr="...">
+    // 'test216.txml', // <invoke srcexpr="...">
+    // 'test220.txml', // done.invoke used as inexact event descriptor
+    // 'test223.txml', // idlocation not implemented yet
+    // 'test224.txml', // done.invoke used as inexact event descriptor
+    // 'test225.txml', // unique invokeids generated at invoke time
+    // 'test226.txml', // <invoke src="...">
+    // 'test228.txml', // done.invoke used as inexact event descriptor + _event.invokeid not implemented yet
+    'test229.txml',
+    // 'test230.txml', // done.invoke used as inexact event descriptor + SCXML _event properties not implemented yet
+    // 'test232.txml', // done.invoke used as inexact event descriptor
+    // 'test233.txml', // <finalize> not implemented yet
+    // 'test234.txml', // <finalize> not implemented yet
+    'test235.txml',
+    // 'test236.txml', // done.invoke used as inexact event descriptor
+    // 'test237.txml', // done.invoke used as inexact event descriptor
+    // 'test239.txml', // done.invoke used as inexact event descriptor
+    // 'test240.txml', // conversion of namelist not implemented yet
+    // 'test241.txml', // conversion of namelist not implemented yet
+    // 'test242.txml', // <invoke src="...">
+    // 'test243.txml', // conversion of <param> in <scxml> not implemented yet
+    // 'test244.txml', // conversion of namelist not implemented yet
+    // 'test245.txml', // conversion of namelist not implemented yet
+    // 'test247.txml', // done.invoke used as inexact event descriptor
+    // 'test250.txml', // this is a manual test - we could test it by snapshoting logged valued
+    // 'test252.txml', // done.invoke used as inexact event descriptor
+    // 'test253.txml', // _event.origintype not implemented yet
+    // 'test276.txml', // <invoke src="...">
+    // 'test277.txml', // illegal expression in datamodel creates unbound variable
+    // 'test278.txml', // non-root datamodel with early binding not implemented yet
+    // 'test279.txml', // non-root datamodel with early binding not implemented yet
+    // 'test280.txml', // non-root datamodel with late binding not implemented yet
+    // 'test286.txml', // error.execution when evaluating assign
     'test287.txml',
-    // 'test294.txml',
-    // 'test298.txml',
-    // 'test302.txml',
-    // 'test303-1.txml',
-    // 'test303-2.txml',
-    // 'test303.txml',
-    // 'test304.txml',
-    // 'test307.txml',
-    // 'test309.txml',
-    // 'test310.txml',
-    // 'test311.txml',
-    // 'test312.txml',
-    // 'test313.txml',
-    // 'test314.txml',
+    // 'test294.txml', // conversion of <donedata> not implemented yet
+    // 'test298.txml', // error.execution when evaluating donedata
+    // 'test302.txml', // conversion of <script> not implemented yet
+    // 'test303-1.txml', // conversion of <script> not implemented yet
+    // 'test303-2.txml', // conversion of <script> not implemented yet
+    // 'test303.txml', // conversion of <script> not implemented yet
+    // 'test304.txml', // conversion of <script> not implemented yet
+    // 'test307.txml', // non-root datamodel with late binding not implemented yet
+    // 'test309.txml', // error in cond expression being treated as false
+    // 'test310.txml', // conversion of In() predicate not implemented yet
+    // 'test311.txml', // error.execution when evaluating assign
+    // 'test312.txml', // error.execution when evaluating assign
+    // 'test313.txml', // error.execution when evaluating assign
+    // 'test314.txml', // error.execution when evaluating assign
     'test318.txml',
-    // 'test319.txml',
-    // 'test321.txml',
-    // 'test322.txml',
-    // 'test323.txml',
-    // 'test324.txml',
-    // 'test325.txml',
-    // 'test326.txml',
-    // 'test329.txml',
-    // 'test330.txml',
-    'test331.txml',
-    // 'test332.txml',
+    // 'test319.txml', // SCXML has no init event, so _event stays unbound in onentry of initial state
+    // 'test321.txml', // _sessionid not yet available for expressions
+    // 'test322.txml', // _sessionid not yet available for expressions
+    // 'test323.txml', // _name not yet available for expressions
+    // 'test324.txml', // _name not yet available for expressions
+    // 'test325.txml', // _ioprocessors not yet available for expressions
+    // 'test326.txml', // _ioprocessors not yet available for expressions
+    // 'test329.txml', // system variables can't be modified, we don't keep them in datamodel, so it might be hard to run this test
+    // 'test330.txml', // SCXML _event properties not implemented yet
+    // 'test331.txml', // _event.type not implemented yet correctly
+    // 'test332.txml', // idlocation not implemented yet
     'test333.txml',
     'test335.txml',
     'test336.txml',
     'test337.txml',
-    // 'test338.txml',
+    // 'test338.txml', // _event.invokeid not implemented yet
     'test339.txml',
     'test342.txml',
-    // 'test343.txml',
-    // 'test344.txml',
-    // 'test346.txml',
-    // 'test347.txml',
+    // 'test343.txml', // error.execution when evaluating donedata
+    // 'test344.txml', // error in cond expression being treated as false and raises error.execution
+    // 'test346.txml', // system variables can't be modified, we don't keep them in datamodel, so it might be hard to run this test
+    // 'test347.txml', // done.invoke used as inexact event descriptor
     'test348.txml',
     'test349.txml',
-    // 'test350.txml',
-    // 'test351.txml',
-    // 'test352.txml',
-    // 'test354.txml',
+    // 'test350.txml', // _sessionid not yet available for expressions
+    // 'test351.txml', // _event.sendid not implemented yet
+    // 'test352.txml', // _event.origintype not implemented yet
+    // 'test354.txml', // conversion of namelist not implemented yet
     'test355.txml',
-    // 'test364.txml',
-    // 'test372.txml',
-    // 'test375.txml',
-    // 'test376.txml',
-    // 'test377.txml',
-    // 'test378.txml',
-    // 'test387.txml',
-    // 'test388.txml',
+    // 'test364.txml', // deep initial states not implemented yet
+    // 'test372.txml', // microstep not implemented correctly
+    'test375.txml',
+    // 'test376.txml', // executable blocks not implemented
+    'test377.txml',
+    // 'test378.txml', // executable blocks not implemented
+    'test387.txml',
+    // 'test388.txml', // deep initial states not implemented yet
     'test396.txml',
-    // 'test399.txml',
-    // 'test401.txml',
-    // 'test402.txml',
+    // 'test399.txml', // inexact prefix event matching not implemented
+    // 'test401.txml', // error.execution when evaluating assign
+    // 'test402.txml', // error.execution when evaluating assign + inexact prefix event matching not implemented
     'test403a.txml',
-    // 'test403b.txml',
-    // 'test403c.txml',
+    'test403b.txml',
+    'test403c.txml',
     'test404.txml',
     'test405.txml',
     'test406.txml',
     'test407.txml',
     'test409.txml',
-    // 'test411.txml',
-    // 'test412.txml',
-    // 'test413.txml',
+    // 'test411.txml', // conversion of In() predicate not implemented yet + <if> not implemented yet + microstep not implemented correctly
+    // 'test412.txml', // initial transitions with executable content not implemented yet
+    // 'test413.txml', // deep initial states not implemented yet
     'test416.txml',
     'test417.txml',
     'test419.txml',
     'test421.txml',
-    // 'test422.txml',
-    // 'test423.txml',
-    // 'test436.txml',
-    // 'test444.txml',
+    // 'test422.txml', conversion of type-less <invoke> not implemented yet
+    'test423.txml',
+    // 'test436.txml', // conversion of In() predicate not implemented yet + null datamodel not implemented yet
+    // 'test444.txml', // datamodel being mutated in cond's expression 😱
     'test445.txml',
-    // 'test446.txml',
-    // 'test448.txml',
+    // 'test446.txml', // conversion of <data src="..."> not implemented yet
+    // 'test448.txml', // nested datamodels not implemented yet
     'test449.txml',
-    // 'test451.txml',
-    // 'test452.txml',
+    // 'test451.txml', // conversion of In() predicate not implemented yet
+    // 'test452.txml', // conversion of <script> not implemented yet
     'test453.txml',
-    // 'test456.txml',
-    // 'test457.txml',
-    // 'test459.txml',
-    // 'test460.txml',
-    // 'test487.txml',
-    // 'test488.txml',
-    // 'test495.txml',
-    // 'test496.txml',
-    // 'test500.txml',
-    // 'test501.txml',
+    // 'test456.txml', // conversion of <script> not implemented yet
+    // 'test457.txml', // <foreach> not implemented yet
+    // 'test459.txml', // <foreach> not implemented yet + <if> not implemented yet
+    // 'test460.txml', // <foreach> not implemented yet
+    // 'test487.txml', // error.execution when evaluating assign
+    // 'test488.txml', // error.execution when evaluating param
+    'test495.txml',
+    // 'test496.txml', // error.communication not implemented yet
+    // 'test500.txml', // _ioprocessors not yet available for expressions
+    // 'test501.txml', // _ioprocessors not yet available for expressions
     'test503.txml',
-    // 'test504.txml',
-    // 'test505.txml',
-    // 'test506.txml',
-    // 'test521.txml',
-    // 'test525.txml',
-    // 'test527.txml',
-    // 'test528.txml',
-    // 'test529.txml',
-    // 'test530.txml',
+    'test504.txml',
+    'test505.txml',
+    'test506.txml',
+    // 'test509.txml', // Basic HTTP Event I/O processor not implemented
+    // 'test510.txml', // Basic HTTP Event I/O processor not implemented
+    // 'test518.txml', // Basic HTTP Event I/O processor not implemented
+    // 'test519.txml', // Basic HTTP Event I/O processor not implemented
+    // 'test520.txml', // Basic HTTP Event I/O processor not implemented
+    // 'test521.txml', // error.communication not implemented yet
+    // 'test522.txml', // Basic HTTP Event I/O processor not implemented
+    // 'test525.txml', // <foreach> not implemented yet
+    // 'test527.txml', // conversion of <donedata> not implemented yet
+    // 'test528.txml', // conversion of <donedata> not implemented yet + error.execution when evaluating donedata
+    // 'test529.txml', // conversion of <donedata> not implemented yet
+    // 'test530.txml', // done.invoke used as inexact event descriptor
+    // 'test531.txml', // Basic HTTP Event I/O processor not implemented
+    // 'test532.txml', // Basic HTTP Event I/O processor not implemented
     'test533.txml',
-    // 'test550.txml',
-    // 'test551.txml',
-    // 'test552.txml',
-    'test553.txml',
-    'test554.txml',
-    // 'test557.txml',
-    // 'test558.txml',
+    // 'test534.txml', // Basic HTTP Event I/O processor not implemented
+    // 'test550.txml', // non-root datamodel with early binding not implemented yet
+    // 'test551.txml', // non-root datamodel with early binding not implemented yet
+    // 'test552.txml', // conversion of <data src="..."> not implemented yet
+    // 'test553.txml', // namelist not implemented yet + errored send not dispatching an event
+    // 'test554.txml', // namelist not implemented yet + errored invoke cancelled
+    // 'test557.txml', // conversion of <data src="..."> not implemented yet
+    // 'test558.txml', // conversion of <data src="..."> not implemented yet
     'test560.txml',
-    // 'test561.txml',
-    // 'test562.txml',
-    // 'test569.txml',
+    // 'test561.txml', // processor creates an ECMAScript DOM object _event.data when receiving XML in an event
+    // 'test562.txml', // test that processor creates space normalized string in _event.data when receiving anything other than KVPs or XML in an event
+    // 'test567.txml', // Basic HTTP Event I/O processor not implemented
+    // 'test569.txml', // _ioprocessors not yet available for expressions
     'test570.txml'
-    // 'test576.txml',
-    // 'test578.txml',
-    // 'test579.txml',
-    // 'test580.txml'
+    // 'test576.txml', // deep initial states not implemented yet
+    // 'test577.txml', // Basic HTTP Event I/O processor not implemented
+    // 'test578.txml', // conversion of <content> in <send> not implemented yet
+    // 'test579.txml' // executable content in history states not implemented yet
+    // 'test580.txml' // conversion of In() predicate not implemented yet
   ]
 };
 
@@ -382,6 +394,9 @@ async function runTestToCompletion(
       nextState = state;
     })
     .onDone(() => {
+      if (nextState.value === 'fail') {
+        throw new Error('Reached "fail" state.');
+      }
       done = true;
     })
     .start(nextState);


### PR DESCRIPTION
Those comments **are not** exhaustive. If we resolve a particular mentioned issue a test in question might still be failing for some other reason - so the comment would have to be adjusted then.