### PR TITLE
Simplier code contributions.

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,7 @@
+tasks:
+  - before: yarn install 
+  - command: yarn run dev
+  - command: yarn run docs:dev
+ports: 
+  - port: 8080
+    onOpen: open-preview

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,12 @@
 
 Thank you for your interest in contributing to XState! This project is made possible by contributors like you, and we welcome any contributions to the code base and the documentation.
 
+## Contribute using one-click online setup.
+
+Contribute to XState using a free fully featured VS Code like online development environment; cloned repo, pre-installed dependencies and web server + test suite running.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/davidkpiano/xstate)
+
 ## Environment
 
 - Ensure you have the latest version of Node and Yarn.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [![npm version](https://badge.fury.io/js/xstate.svg)](https://badge.fury.io/js/xstate)
 [![Statecharts gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/statecharts/statecharts)
 <img src="https://opencollective.com/xstate/tiers/backer/badge.svg?label=sponsors&color=brightgreen" />
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/davidkpiano/xstate)
 
 JavaScript and TypeScript [finite state machines](https://en.wikipedia.org/wiki/Finite-state_machine) and [statecharts](http://www.inf.ed.ac.uk/teaching/courses/seoc/2005_2006/resources/statecharts.pdf) for the modern web.
 


### PR DESCRIPTION
Hi! :slightly_smiling_face: 

This Pr simplifies code contributions by fully automating the dev setup with gitpod a free online VS code like IDE with a single click it will launch a ready to code workspace where:

- xState repo is already cloned.
- dependencies pre-installed.
- webserver + test suite running via `npm run dev` and `npm run docs:dev`

So that anyone interested in contributing can start straight away without wasting any time on the setup.
 
You can give it a try on my fork of the repo via this link:

https://gitpod.io/#https://github.com/nisarhassan12/xstate

this is how it looks: 

![image](https://user-images.githubusercontent.com/46004116/75512294-b8873000-5a12-11ea-81b3-fbfbed30469c.png)

