### PR TITLE
Make withContext argument Partial

### DIFF
--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -463,7 +463,7 @@ class StateNode<
    * @param context Custom context (will override predefined context, not recursive)
    */
   public withContext(
-    context: TContext
+    context: Partial<TContext>
   ): StateNode<TContext, TStateSchema, TEvent> {
     return new StateNode(this.config, this.options, context);
   }

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -290,7 +290,7 @@ class StateNode<
     /**
      * The initial extended state
      */
-    public context?: Readonly<TContext>
+    public context?: Readonly<Partial<TContext>>
   ) {
     this.options = Object.assign(createDefaultOptions<TContext>(), options);
     this.parent = this.options._parent;


### PR DESCRIPTION
I am not sure if I am overlooking something obvious, but it feels odd I would need to specify full context shape whenever I need a machine with one value changed.