### PR TITLE
Fix/next tests

### DIFF
--- a/.changeset/tall-beans-suffer.md
+++ b/.changeset/tall-beans-suffer.md
@@ -1,7 +1,0 @@
----
-'xstate': minor
----
-
-The machine can now be safely JSON-serialized, using `JSON.stringify(machine)`. The shape of this serialization is defined in `machine.schema.json` and reflected in `machine.definition`.
-
-Note that `onEntry` and `onExit` have been deprecated in the definition in favor of `entry` and `exit`.

--- a/.changeset/twelve-tables-tap.md
+++ b/.changeset/twelve-tables-tap.md
@@ -1,5 +1,0 @@
----
-'xstate': patch
----
-
-Fixed memory leak - `State` objects had been retained in closures.

--- a/docs/guides/interpretation.md
+++ b/docs/guides/interpretation.md
@@ -191,6 +191,7 @@ The following options can be passed into the interpreter as the 2nd argument (`i
   - If `false`, events sent to an uninitialized service will throw an error.
 - `devTools` (boolean) - Signifies whether events should be sent to the [Redux DevTools extension](https://github.com/zalmoxisus/redux-devtools-extension). Defaults to `false`.
 - `logger` - Specifies the logger to be used for `log(...)` actions. Defaults to the native `console.log` method.
+- `clock` - Specifies the [clock interface for delayed actions](./delays.md#interpretation). Defaults to the native `setTimeout` and `clearTimeout` functions.
 
 ## Custom Interpreters
 

--- a/docs/guides/statenodes.md
+++ b/docs/guides/statenodes.md
@@ -73,7 +73,9 @@ const fetchMachine = Machine({
       }
     },
     failure: {
-      RETRY: 'pending'
+      on: {
+        RETRY: 'pending'
+      }
     }
   }
 });

--- a/docs/recipes/react.md
+++ b/docs/recipes/react.md
@@ -3,7 +3,7 @@
 The most straightforward way of using XState with React is through local component state. The machine used should always be decoupled from implementation details; e.g., it should never know that it is in React (or Vue, or Angular, etc.):
 
 ```js
-import { Machine, interpret } from 'xstate';
+import { Machine } from 'xstate';
 
 // This machine is completely decoupled from React
 export const toggleMachine = Machine({

--- a/docs/tutorials/reddit.md
+++ b/docs/tutorials/reddit.md
@@ -20,7 +20,7 @@ The Reddit app we're creating can be modeled with two top-level states:
 - `'selected'` - a subreddit is selected
 
 ```js {6-9}
-import { Machine } from 'xstate';
+import { Machine, assign } from 'xstate';
 
 const redditMachine = Machine({
   id: 'reddit',

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,17 @@
 # xstate
 
+## 4.8.0
+
+### Minor Changes
+
+- [`55aa589`](https://github.com/davidkpiano/xstate/commit/55aa589648a9afbd153e8b8e74cbf2e0ebf573fb) [#960](https://github.com/davidkpiano/xstate/pull/960) Thanks [@davidkpiano](https://github.com/davidkpiano)! - The machine can now be safely JSON-serialized, using `JSON.stringify(machine)`. The shape of this serialization is defined in `machine.schema.json` and reflected in `machine.definition`.
+
+  Note that `onEntry` and `onExit` have been deprecated in the definition in favor of `entry` and `exit`.
+
+### Patch Changes
+
+- [`1ae31c1`](https://github.com/davidkpiano/xstate/commit/1ae31c17dc81fb63e699b4b9bf1cf4ead023001d) [#1023](https://github.com/davidkpiano/xstate/pull/1023) Thanks [@Andarist](https://github.com/Andarist)! - Fixed memory leak - `State` objects had been retained in closures.
+
 ## 4.7.8
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xstate",
-  "version": "4.7.8",
+  "version": "4.8.0",
   "description": "Finite State Machines and Statecharts for the Modern Web.",
   "main": "dist/xstate.cjs.js",
   "module": "dist/xstate.esm.js",

--- a/packages/core/src/json.ts
+++ b/packages/core/src/json.ts
@@ -46,8 +46,8 @@ export function machineToJSON(stateNode: StateNode): StateNodeConfig {
       stateNode.initial === undefined ? undefined : String(stateNode.initial),
     id: stateNode.id,
     key: stateNode.key,
-    entry: stateNode.onEntry,
-    exit: stateNode.onExit,
+    entry: stateNode.entry,
+    exit: stateNode.exit,
     on: mapValues(stateNode.on, transition => {
       return transition.map(t => {
         return {

--- a/packages/core/src/machine.schema.json
+++ b/packages/core/src/machine.schema.json
@@ -57,7 +57,7 @@
               }
             },
             "initial": {
-              "type": "string"
+              "$ref": "#/definitions/initialTransitionObject"
             },
             "invoke": {
               "$ref": "#/definitions/invokeArray"
@@ -192,6 +192,17 @@
         }
       }
     },
+    "initialTransitionObject": {
+      "type": "object",
+      "properties": {
+        "target": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "transitionsObject": {
       "type": "object",
       "patternProperties": {
@@ -271,7 +282,7 @@
       "type": "string"
     },
     "initial": {
-      "type": "string"
+      "$ref": "#/definitions/initialTransitionObject"
     },
     "key": {
       "type": "string"

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -358,7 +358,8 @@ function formatTransition<TContext, TEvent extends EventObject>(
       : true;
   const { guards } = stateNode.machine.options;
   const target = resolveTarget(stateNode, normalizedTarget);
-  return {
+
+  const transition = {
     ...transitionConfig,
     actions: toActionObjects(toArray(transitionConfig.actions)),
     cond: toGuard(transitionConfig.cond, guards),
@@ -367,6 +368,18 @@ function formatTransition<TContext, TEvent extends EventObject>(
     internal,
     eventType: transitionConfig.event
   };
+
+  Object.defineProperty(transition, 'toJSON', {
+    value: () => ({
+      ...transition,
+      target: transition.target
+        ? transition.target.map(t => `#${t.id}`)
+        : undefined,
+      source: `#${stateNode.id}`
+    })
+  });
+
+  return transition;
 }
 export function formatTransitions<TContext, TEvent extends EventObject>(
   stateNode: StateNode<TContext, any, TEvent>

--- a/packages/core/test/json.test.ts
+++ b/packages/core/test/json.test.ts
@@ -34,11 +34,12 @@ describe('json', () => {
             function actionFunction() {
               return true;
             },
+            // TODO: investigate why this had to be casted to any to satisfy TS
             assign({
               number: 10,
               string: 'test',
               evalNumber: () => 42
-            }),
+            }) as any,
             assign(ctx => ({
               ...ctx
             }))

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "downlevelIteration": true,
     "experimentalDecorators": true,
     "skipLibCheck": true,
+    "resolveJsonModule": true,
     "jsx": "react",
     "lib": ["es6", "dom"],
     "strictPropertyInitialization": true


### PR DESCRIPTION
`toJSON` was missing on the transition objects causing circular JSON error when serializing. The definition also couldn't schema-check because of my latest initial transitions changes, so I've added support for them here.