### PR TITLE
Loosen types for SendAction. Fixes #570

### DIFF
--- a/.changeset/tame-turkeys-live.md
+++ b/.changeset/tame-turkeys-live.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Loosened event type for `SendAction<TContext, AnyEventObject>`

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -70,7 +70,7 @@ export type Action<TContext, TEvent extends EventObject> =
   | ActionObject<TContext, TEvent>
   | ActionFunction<TContext, TEvent>
   | AssignAction<Required<TContext>, TEvent>
-  | SendAction<TContext, TEvent>
+  | SendAction<TContext, AnyEventObject>
   | RaiseAction<AnyEventObject>;
 
 export type Actions<TContext, TEvent extends EventObject> = SingleOrArray<


### PR DESCRIPTION
This PR loosens the `SendAction` type in `Actions` to accept `AnyEventObject`, since the target of the send action might accept different types of events (and can't be easily determined compile-time)