### PR TITLE
Fixed an issue with data expressions of root's final nodes being called twice

### DIFF
--- a/.changeset/modern-pumas-applaud.md
+++ b/.changeset/modern-pumas-applaud.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Fixed an issue with data expressions of root's final nodes being called twice.

--- a/packages/core/test/final.test.ts
+++ b/packages/core/test/final.test.ts
@@ -195,4 +195,26 @@ describe('final states', () => {
 
     service.send('REQUEST_SECRET');
   });
+
+  it("should only call data expression once when entering root's final state", () => {
+    const spy = jest.fn();
+    const machine = Machine({
+      initial: 'start',
+      states: {
+        start: {
+          on: {
+            FINISH: 'end'
+          }
+        },
+        end: {
+          type: 'final',
+          data: spy
+        }
+      }
+    });
+
+    const service = interpret(machine).start();
+    service.send({ type: 'FINISH', value: 1 });
+    expect(spy).toBeCalledTimes(1);
+  });
 });


### PR DESCRIPTION
fixes #1079 , cc @RafalFilipek

This shouldnt be a breking change as this incorrecty generated done event had no chance to be caught by the machine (as it has reached the final state it has stopped by then and ignores all events)