### PR TITLE
Include `TTypestate` for methods

### DIFF
--- a/.changeset/ninety-toys-smile.md
+++ b/.changeset/ninety-toys-smile.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Added TTypestate to withConfig, state, and start methods

--- a/.changeset/ninety-toys-smile.md
+++ b/.changeset/ninety-toys-smile.md
@@ -2,4 +2,8 @@
 'xstate': patch
 ---
 
-Added TTypestate to withConfig, state, and start methods
+This change carries forward the typestate type information encoded in the arguments of the following functions and assures that the return type also has the same typestate type information:
+
+- Cloned state machine returned by `.withConfig`.
+- `.state` getter defined for services.
+- `start` method of services.

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -441,7 +441,7 @@ class StateNode<
   public withConfig(
     options: Partial<MachineOptions<TContext, TEvent>>,
     context: TContext | undefined = this.context
-  ): StateNode<TContext, TStateSchema, TEvent> {
+  ): StateNode<TContext, TStateSchema, TEvent, TTypestate> {
     const { actions, activities, guards, services, delays } = this.options;
 
     return new StateNode(

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -226,7 +226,7 @@ export class Interpreter<
       return this._initialState;
     });
   }
-  public get state(): State<TContext, TEvent> {
+  public get state(): State<TContext, TEvent, any, TTypestate> {
     if (!IS_PRODUCTION) {
       warn(
         this._status !== InterpreterStatus.NotStarted,
@@ -454,7 +454,7 @@ export class Interpreter<
    */
   public start(
     initialState?: State<TContext, TEvent> | StateValue
-  ): Interpreter<TContext, TStateSchema, TEvent> {
+  ): Interpreter<TContext, TStateSchema, TEvent, TTypestate> {
     if (this._status === InterpreterStatus.Running) {
       // Do not restart the service if it is already started
       return this;

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -1,4 +1,4 @@
-import { Machine, assign } from '../src/index';
+import { Machine, assign, createMachine, interpret } from '../src/index';
 import { raise } from '../src/actions';
 
 function noop(_x) {
@@ -270,5 +270,107 @@ describe('Raise events', () => {
 
     noop(raiseGreetingMachine);
     expect(true).toBeTruthy();
+  });
+});
+
+describe('Typestates', () => {
+  // Using "none" because undefined and null are unavailable when not in strict mode.
+  type None = { type: 'none' };
+  const none: None = { type: 'none' };
+
+  const taskMachineConfiguration = {
+    id: 'task',
+    initial: 'idle',
+    context: {
+      result: none as None | number,
+      error: none as None | string
+    },
+    states: {
+      idle: {
+        on: { RUN: 'running' }
+      },
+      running: {
+        invoke: {
+          id: 'task-1',
+          src: 'taskService',
+          onDone: { target: 'succeeded', actions: 'assignSuccess' },
+          onError: { target: 'failed', actions: 'assignFailure' }
+        }
+      },
+      succeeded: {},
+      failed: {}
+    }
+  };
+
+  type TaskContext = typeof taskMachineConfiguration.context;
+
+  type TaskTypestate =
+    | { value: 'idle'; context: { result: None; error: None } }
+    | { value: 'running'; context: { result: None; error: None } }
+    | { value: 'succeeded'; context: { result: number; error: None } }
+    | { value: 'failed'; context: { result: None; error: string } };
+
+  type ExtractTypeState<T extends TaskTypestate['value']> = Extract<
+    TaskTypestate,
+    { value: T }
+  >['context'];
+  type Idle = ExtractTypeState<'idle'>;
+  type Running = ExtractTypeState<'running'>;
+  type Succeeded = ExtractTypeState<'succeeded'>;
+  type Failed = ExtractTypeState<'failed'>;
+
+  const machine = createMachine<TaskContext, any, TaskTypestate>(
+    taskMachineConfiguration
+  );
+
+  it("should preserve typestate for the service returned by Interpreter.start() and a servcie's .state getter.", () => {
+    const service = interpret(machine);
+    const startedService = service.start();
+
+    const idle: Idle = startedService.state.matches('idle')
+      ? startedService.state.context
+      : { result: none, error: none };
+    expect(idle).toEqual({ result: none, error: none });
+
+    const running: Running = startedService.state.matches('running')
+      ? startedService.state.context
+      : { result: none, error: none };
+    expect(running).toEqual({ result: none, error: none });
+
+    const succeeded: Succeeded = startedService.state.matches('succeeded')
+      ? startedService.state.context
+      : { result: 12, error: none };
+    expect(succeeded).toEqual({ result: 12, error: none });
+
+    const failed: Failed = startedService.state.matches('failed')
+      ? startedService.state.context
+      : { result: none, error: 'oops' };
+    expect(failed).toEqual({ result: none, error: 'oops' });
+  });
+
+  it('should preserve typestate for state node returned by StateNode.withConfig.', () => {
+    const machine2 = machine.withConfig({});
+    const service = interpret(machine2);
+    service.start();
+
+    const idle: Idle = service.state.matches('idle')
+      ? service.state.context
+      : { result: none, error: none };
+    expect(idle).toEqual({ result: none, error: none });
+
+    const running: Running = service.state.matches('running')
+      ? service.state.context
+      : { result: none, error: none };
+    expect(running).toEqual({ result: none, error: none });
+
+    const succeeded: Succeeded = service.state.matches('succeeded')
+      ? service.state.context
+      : { result: 12, error: none };
+    expect(succeeded).toEqual({ result: 12, error: none });
+
+    const failed: Failed = service.state.matches('failed')
+      ? service.state.context
+      : { result: none, error: 'oops' };
+    expect(failed).toEqual({ result: none, error: 'oops' });
   });
 });

--- a/packages/xstate-react/test/types.test.tsx
+++ b/packages/xstate-react/test/types.test.tsx
@@ -7,7 +7,7 @@ import {
   Interpreter,
   spawn,
   createMachine
-} from '../../core/src';
+} from 'xstate';
 import { useService, useMachine } from '../src';
 
 describe('useService', () => {
@@ -102,12 +102,14 @@ describe('useMachine', () => {
       if (state.matches('no')) {
         const undefinedValue: undefined = state.context.value;
 
-        return null;
+        return <span>{undefinedValue ? 'Yes' : 'No'}</span>;
       } else if (state.matches('yes')) {
-        const numbericValue: number = state.context.value;
+        const numericValue: number = state.context.value;
 
-        return null;
+        return <span>{numericValue ? 'Yes' : 'No'}</span>;
       }
+
+      return <span>No</span>;
     };
 
     render(<YesNo />);


### PR DESCRIPTION
This fixes issues where the state returned by `useMachine` looses the `TTypestate` information