### PR TITLE
doc(core): update changeset for decide -> choose renaming

### DIFF
--- a/.changeset/good-countries-cross.md
+++ b/.changeset/good-countries-cross.md
@@ -6,7 +6,7 @@ Added support for conditional actions. It's possible now to have actions execute
 
 ```js
 entry: [
-  decide([
+  choose([
     { cond: ctx => ctx > 100, actions: raise('TOGGLE') },
     {
       cond: 'hasMagicBottle',


### PR DESCRIPTION
`decide` has been renamed to `choose` in #1095.