### PR TITLE
Added mentioned ‘strict’ parameter to the code

### DIFF
--- a/docs/guides/machines.md
+++ b/docs/guides/machines.md
@@ -20,9 +20,6 @@ const lightMachine = Machine({
 
   // Initial state
   initial: 'green',
- 
-  // Ensures the machine only accepts allowed events, default: false
-  strict: true,
 
   // Local context for entire machine
   context: {
@@ -45,12 +42,9 @@ const lightMachine = Machine({
 });
 ```
 
-The machine config is the same as the [state node config](./statenodes.md), with the addition of the following properties:
+The machine config is the same as the [state node config](./statenodes.md), with the addition of the context property:
 
 - `context` - represents the local "extended state" for all of the machine's nested states. See [the docs for context](./context.md) for more details.
-- `strict` - if `true`, ensures the following constraints are met. Defaults to `false`.
-  - Any events that are sent to the machine but not accepted (i.e., there doesn't exist any transitions in any state for the given event) will throw an error.
-  - Any unhandled Promise rejections will stop the machine ([Promise Rejection](./communication.md#promise-rejection)/Async [Invoking Callbacks](./communication.md#invoking-callbacks)).
 
 ## Options
 

--- a/docs/guides/machines.md
+++ b/docs/guides/machines.md
@@ -20,6 +20,9 @@ const lightMachine = Machine({
 
   // Initial state
   initial: 'green',
+ 
+  // Ensures the machine only accepts allowed events, default: false
+  strict: true,
 
   // Local context for entire machine
   context: {


### PR DESCRIPTION
The text below the code referred to the `strict` parameter, which wasn’t present in the code. This small fix adds it to the example.