### PR TITLE
Target multiple actors by providing a list of refs in the send action's .to property

### DIFF
--- a/.changeset/odd-waves-laugh.md
+++ b/.changeset/odd-waves-laugh.md
@@ -1,0 +1,11 @@
+---
+'xstate': minor
+---
+
+Send an event to multiple targets by providing a list of references for a _send_ action creator's `.to` property: E.g.:
+
+```js
+send('SOME_EVENT', to: ['actor1', 'invokedMachineId2'])
+...
+send('SOME_EVENT', to: (ctx, evt) => [ctx.actor1, ctx.actor2, ...evt.addtionalTargets])
+```

--- a/docs/guides/actions.md
+++ b/docs/guides/actions.md
@@ -295,6 +295,29 @@ entry: assign({
 }
 ```
 
+The target may also be an array of targets or a **target expression** returning an array of targets:
+
+```js
+entry: assign({
+  actorRef1: spawn(someMachine, 'ref1'),
+  actorRef2: spawn(someMachine, 'ref2')
+}),
+  // Send { type: 'SOME_EVENT' } to the spawned actors.
+  {
+    actions: send('SOME_EVENT', {
+      to: ['ref1', 'ref2']
+    })
+  };
+// ...
+
+// Send { type: 'SOME_EVENT' } to the spawned actors using a target expression
+{
+  actions: send('SOME_EVENT', {
+    to: context => [context.actoreRef1.ref, context.actorRef2.ref]
+  });
+}
+```
+
 ::: warning
 Again, the `send(...)` function is an action creator and **will not imperatively send an event.** Instead, it returns an action object that describes where the event will be sent to:
 

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -659,7 +659,7 @@ export class Interpreter<
 
   private sendTo = (
     event: SCXML.Event<TEvent>,
-    to: string | number | Actor | Array<string | number | Actor>
+    to: SingleOrArray<string | number | Actor>
   ) => {
     // Recursively call this.sendTo for each target if the event's .to target is a list
     if (Array.isArray(to)) {

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -661,8 +661,8 @@ export class Interpreter<
     event: SCXML.Event<TEvent>,
     to: string | number | Actor | Array<string | number | Actor>
   ) => {
+    // Recursively call this.sendTo for each target if the event's .to target is a list
     if (Array.isArray(to)) {
-      console.log(to);
       to.forEach(target => this.sendTo(event, target));
       return;
     }

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -129,14 +129,14 @@ export class Interpreter<
    * - `clock` uses the global `setTimeout` and `clearTimeout` functions
    * - `logger` uses the global `console.log()` method
    */
-  public static defaultOptions: InterpreterOptions = (global => ({
+  public static defaultOptions: InterpreterOptions = ((global) => ({
     execute: true,
     deferEvents: true,
     clock: {
       setTimeout: (fn, ms) => {
         return global.setTimeout.call(null, fn, ms);
       },
-      clearTimeout: id => {
+      clearTimeout: (id) => {
         return global.clearTimeout.call(null, id);
       }
     },
@@ -294,7 +294,7 @@ export class Interpreter<
     if (this.state.configuration && isDone) {
       // get final child state node
       const finalChildStateNode = state.configuration.find(
-        sn => sn.type === 'final' && sn.parent === this.machine
+        (sn) => sn.type === 'final' && sn.parent === this.machine
       );
 
       const doneData =
@@ -505,7 +505,7 @@ export class Interpreter<
     }
 
     // Stop all children
-    this.children.forEach(child => {
+    this.children.forEach((child) => {
       if (isFunction(child.stop)) {
         child.stop();
       }
@@ -634,7 +634,7 @@ export class Interpreter<
         });
 
         batchedActions.push(
-          ...(nextState.actions.map(a =>
+          ...(nextState.actions.map((a) =>
             bindActionToState(a, nextState)
           ) as Array<ActionObject<TContext, TEvent>>)
         );
@@ -663,7 +663,7 @@ export class Interpreter<
   ) => {
     // Recursively call this.sendTo for each target if the event's .to target is a list
     if (Array.isArray(to)) {
-      to.forEach(target => this.sendTo(event, target));
+      to.forEach((target) => this.sendTo(event, target));
       return;
     }
 
@@ -720,7 +720,7 @@ export class Interpreter<
     if (
       _event.name.indexOf(actionTypes.errorPlatform) === 0 &&
       !this.state.nextEvents.some(
-        nextEvent => nextEvent.indexOf(actionTypes.errorPlatform) === 0
+        (nextEvent) => nextEvent.indexOf(actionTypes.errorPlatform) === 0
       )
     ) {
       throw (_event.data as any).data;
@@ -746,16 +746,13 @@ export class Interpreter<
     }
   }
   private defer(sendAction: SendActionObject<TContext, TEvent>): void {
-    this.delayedEventsMap[sendAction.id] = this.clock.setTimeout(
-      () => {
-        if (sendAction.to) {
-          this.sendTo(sendAction._event, sendAction.to);
-        } else {
-          this.send(sendAction._event);
-        }
-      },
-      sendAction.delay as number
-    );
+    this.delayedEventsMap[sendAction.id] = this.clock.setTimeout(() => {
+      if (sendAction.to) {
+        this.sendTo(sendAction._event, sendAction.to);
+      } else {
+        this.send(sendAction._event);
+      }
+    }, sendAction.delay as number);
   }
   private cancel(sendId: string | number): void {
     this.clock.clearTimeout(this.delayedEventsMap[sendId]);
@@ -974,7 +971,7 @@ export class Interpreter<
     };
 
     if (resolvedOptions.sync) {
-      childService.onTransition(state => {
+      childService.onTransition((state) => {
         this.send(actionTypes.update as any, {
           state,
           id: childService.id
@@ -984,17 +981,17 @@ export class Interpreter<
 
     const actor = childService;
 
-    this.children.set(childService.id, actor as Actor<
-      State<TChildContext, TChildEvent>,
-      TChildEvent
-    >);
+    this.children.set(
+      childService.id,
+      actor as Actor<State<TChildContext, TChildEvent>, TChildEvent>
+    );
 
     if (resolvedOptions.autoForward) {
       this.forwardTo.add(childService.id);
     }
 
     childService
-      .onDone(doneEvent => {
+      .onDone((doneEvent) => {
         this.removeChild(childService.id);
         this.send(toSCXMLEvent(doneEvent as any, { origin: childService.id }));
       })
@@ -1006,7 +1003,7 @@ export class Interpreter<
     let canceled = false;
 
     promise.then(
-      response => {
+      (response) => {
         if (!canceled) {
           this.removeChild(id);
           this.send(
@@ -1014,7 +1011,7 @@ export class Interpreter<
           );
         }
       },
-      errorData => {
+      (errorData) => {
         if (!canceled) {
           this.removeChild(id);
           const errorEvent = error(id, errorData);
@@ -1044,7 +1041,7 @@ export class Interpreter<
       subscribe: (next, handleError, complete) => {
         let unsubscribed = false;
         promise.then(
-          response => {
+          (response) => {
             if (unsubscribed) {
               return;
             }
@@ -1054,7 +1051,7 @@ export class Interpreter<
             }
             complete && complete();
           },
-          err => {
+          (err) => {
             if (unsubscribed) {
               return;
             }
@@ -1084,7 +1081,7 @@ export class Interpreter<
     const listeners = new Set<(e: EventObject) => void>();
 
     const receive = (e: TEvent) => {
-      listeners.forEach(listener => listener(e));
+      listeners.forEach((listener) => listener(e));
       if (canceled) {
         return;
       }
@@ -1094,7 +1091,7 @@ export class Interpreter<
     let callbackStop;
 
     try {
-      callbackStop = callback(receive, newListener => {
+      callbackStop = callback(receive, (newListener) => {
         receivers.add(newListener);
       });
     } catch (err) {
@@ -1109,8 +1106,8 @@ export class Interpreter<
 
     const actor = {
       id,
-      send: event => receivers.forEach(receiver => receiver(event)),
-      subscribe: next => {
+      send: (event) => receivers.forEach((receiver) => receiver(event)),
+      subscribe: (next) => {
         listeners.add(next);
 
         return {
@@ -1139,10 +1136,10 @@ export class Interpreter<
     id: string
   ): Actor {
     const subscription = source.subscribe(
-      value => {
+      (value) => {
         this.send(toSCXMLEvent(value, { origin: id }));
       },
-      err => {
+      (err) => {
         this.removeChild(id);
         this.send(toSCXMLEvent(error(id, err) as any, { origin: id }));
       },
@@ -1291,7 +1288,7 @@ export function spawn(
 ): Actor {
   const resolvedOptions = resolveSpawnOptions(nameOrOptions);
 
-  return withServiceScope(undefined, service => {
+  return withServiceScope(undefined, (service) => {
     if (!IS_PRODUCTION) {
       warn(
         !!service,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -808,7 +808,12 @@ export interface SendAction<TContext, TEvent extends EventObject>
     | string
     | number
     | Actor
-    | ExprWithMeta<TContext, TEvent, string | number | Actor>
+    | Array<string | number | Actor>
+    | ExprWithMeta<
+        TContext,
+        TEvent,
+        string | number | Actor | Array<string | number | Actor>
+      >
     | undefined;
   event: TEvent | SendExpr<TContext, TEvent>;
   delay?: number | string | DelayExpr<TContext, TEvent>;
@@ -817,7 +822,7 @@ export interface SendAction<TContext, TEvent extends EventObject>
 
 export interface SendActionObject<TContext, TEvent extends EventObject>
   extends SendAction<TContext, TEvent> {
-  to: string | number | Actor | undefined;
+  to: string | number | Actor | Array<string | number | Actor> | undefined;
   _event: SCXML.Event<TEvent>;
   event: TEvent;
   delay?: number;
@@ -849,7 +854,14 @@ export enum SpecialTargets {
 export interface SendActionOptions<TContext, TEvent extends EventObject> {
   id?: string | number;
   delay?: number | string | DelayExpr<TContext, TEvent>;
-  to?: string | ExprWithMeta<TContext, TEvent, string | number | Actor>;
+  to?:
+    | string
+    | string[]
+    | ExprWithMeta<
+        TContext,
+        TEvent,
+        string | number | Actor | Array<string | number | Actor>
+      >;
 }
 
 export interface CancelAction extends ActionObject<any, any> {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -805,15 +805,8 @@ export interface LogActionObject<TContext, TEvent extends EventObject>
 export interface SendAction<TContext, TEvent extends EventObject>
   extends ActionObject<TContext, TEvent> {
   to:
-    | string
-    | number
-    | Actor
-    | Array<string | number | Actor>
-    | ExprWithMeta<
-        TContext,
-        TEvent,
-        string | number | Actor | Array<string | number | Actor>
-      >
+    | SingleOrArray<string | number | Actor>
+    | ExprWithMeta<TContext, TEvent, SingleOrArray<string | number | Actor>>
     | undefined;
   event: TEvent | SendExpr<TContext, TEvent>;
   delay?: number | string | DelayExpr<TContext, TEvent>;
@@ -822,7 +815,7 @@ export interface SendAction<TContext, TEvent extends EventObject>
 
 export interface SendActionObject<TContext, TEvent extends EventObject>
   extends SendAction<TContext, TEvent> {
-  to: string | number | Actor | Array<string | number | Actor> | undefined;
+  to: SingleOrArray<string | number | Actor> | undefined;
   _event: SCXML.Event<TEvent>;
   event: TEvent;
   delay?: number;
@@ -857,11 +850,7 @@ export interface SendActionOptions<TContext, TEvent extends EventObject> {
   to?:
     | string
     | string[]
-    | ExprWithMeta<
-        TContext,
-        TEvent,
-        string | number | Actor | Array<string | number | Actor>
-      >;
+    | ExprWithMeta<TContext, TEvent, SingleOrArray<string | number | Actor>>;
 }
 
 export interface CancelAction extends ActionObject<any, any> {

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -257,20 +257,20 @@ describe('onEntry/onExit actions', () => {
 
   describe('State.actions', () => {
     it('should return the entry actions of an initial state', () => {
-      expect(lightMachine.initialState.actions.map(a => a.type)).toEqual([
+      expect(lightMachine.initialState.actions.map((a) => a.type)).toEqual([
         'enter_green'
       ]);
     });
 
     it('should return the entry actions of an initial state (deep)', () => {
-      expect(deepMachine.initialState.actions.map(a => a.type)).toEqual([
+      expect(deepMachine.initialState.actions.map((a) => a.type)).toEqual([
         'enter_a',
         'enter_a1'
       ]);
     });
 
     it('should return the entry actions of an initial state (parallel)', () => {
-      expect(parallelMachine.initialState.actions.map(a => a.type)).toEqual([
+      expect(parallelMachine.initialState.actions.map((a) => a.type)).toEqual([
         'enter_a',
         'enter_a1',
         'enter_b',
@@ -280,13 +280,13 @@ describe('onEntry/onExit actions', () => {
 
     it('should return the entry and exit actions of a transition', () => {
       expect(
-        lightMachine.transition('green', 'TIMER').actions.map(a => a.type)
+        lightMachine.transition('green', 'TIMER').actions.map((a) => a.type)
       ).toEqual(['exit_green', 'enter_yellow']);
     });
 
     it('should return the entry and exit actions of a deep transition', () => {
       expect(
-        lightMachine.transition('yellow', 'TIMER').actions.map(a => a.type)
+        lightMachine.transition('yellow', 'TIMER').actions.map((a) => a.type)
       ).toEqual(['exit_yellow', 'enter_red', 'enter_walk']);
     });
 
@@ -294,32 +294,32 @@ describe('onEntry/onExit actions', () => {
       expect(
         lightMachine
           .transition('red.walk', 'PED_COUNTDOWN')
-          .actions.map(a => a.type)
+          .actions.map((a) => a.type)
       ).toEqual(['exit_walk', 'enter_wait']);
     });
 
     it('should not have actions for unhandled events (shallow)', () => {
       expect(
-        lightMachine.transition('green', 'FAKE').actions.map(a => a.type)
+        lightMachine.transition('green', 'FAKE').actions.map((a) => a.type)
       ).toEqual([]);
     });
 
     it('should not have actions for unhandled events (deep)', () => {
       expect(
-        lightMachine.transition('red', 'FAKE').actions.map(a => a.type)
+        lightMachine.transition('red', 'FAKE').actions.map((a) => a.type)
       ).toEqual([]);
     });
 
     it('should exit and enter the state for self-transitions (shallow)', () => {
       expect(
-        lightMachine.transition('green', 'NOTHING').actions.map(a => a.type)
+        lightMachine.transition('green', 'NOTHING').actions.map((a) => a.type)
       ).toEqual(['exit_green', 'enter_green']);
     });
 
     it('should exit and enter the state for self-transitions (deep)', () => {
       // 'red' state resolves to 'red.walk'
       expect(
-        lightMachine.transition('red', 'NOTHING').actions.map(a => a.type)
+        lightMachine.transition('red', 'NOTHING').actions.map((a) => a.type)
       ).toEqual(['exit_walk', 'exit_red', 'enter_red', 'enter_walk']);
     });
 
@@ -327,7 +327,7 @@ describe('onEntry/onExit actions', () => {
       expect(
         parallelMachine
           .transition(parallelMachine.initialState, 'CHANGE')
-          .actions.map(a => a.type)
+          .actions.map((a) => a.type)
       ).toEqual([
         'exit_b1', // reverse document order
         'exit_a1',
@@ -341,7 +341,7 @@ describe('onEntry/onExit actions', () => {
 
     it('should return nested actions in the correct (child to parent) order', () => {
       expect(
-        deepMachine.transition('a.a1', 'CHANGE').actions.map(a => a.type)
+        deepMachine.transition('a.a1', 'CHANGE').actions.map((a) => a.type)
       ).toEqual([
         'exit_a1',
         'exit_a',
@@ -354,7 +354,7 @@ describe('onEntry/onExit actions', () => {
 
     it('should ignore parent state actions for same-parent substates', () => {
       expect(
-        deepMachine.transition('a.a1', 'NEXT').actions.map(a => a.type)
+        deepMachine.transition('a.a1', 'NEXT').actions.map((a) => a.type)
       ).toEqual(['exit_a1', 'enter_a2']);
     });
 
@@ -362,13 +362,13 @@ describe('onEntry/onExit actions', () => {
       expect(
         deepMachine
           .transition(deepMachine.initialState, 'NEXT_FN')
-          .actions.map(action => action.type)
+          .actions.map((action) => action.type)
       ).toEqual(['exit_a1', 'enter_a3_fn']);
 
       expect(
         deepMachine
           .transition('a.a3', 'NEXT')
-          .actions.map(action => action.type)
+          .actions.map((action) => action.type)
       ).toEqual(['exit_a3_fn', 'do_a3_to_a2', 'enter_a2']);
     });
 
@@ -380,7 +380,7 @@ describe('onEntry/onExit actions', () => {
       const stateD2 = parallelMachine2.transition(stateB, 'to-D2');
       const stateA = parallelMachine2.transition(stateD2, 'to-A');
 
-      expect(stateA.actions.map(action => action.type)).toEqual(['D2 Exit']);
+      expect(stateA.actions.map((action) => action.type)).toEqual(['D2 Exit']);
     });
 
     describe('should ignore same-parent state actions (sparse)', () => {
@@ -434,20 +434,20 @@ describe('onEntry/onExit actions', () => {
 
   describe('State.actions (with entry/exit instead of onEntry/onExit)', () => {
     it('should return the entry actions of an initial state', () => {
-      expect(newLightMachine.initialState.actions.map(a => a.type)).toEqual([
+      expect(newLightMachine.initialState.actions.map((a) => a.type)).toEqual([
         'enter_green'
       ]);
     });
 
     it('should return the entry and exit actions of a transition', () => {
       expect(
-        newLightMachine.transition('green', 'TIMER').actions.map(a => a.type)
+        newLightMachine.transition('green', 'TIMER').actions.map((a) => a.type)
       ).toEqual(['exit_green', 'enter_yellow']);
     });
 
     it('should return the entry and exit actions of a deep transition', () => {
       expect(
-        newLightMachine.transition('yellow', 'TIMER').actions.map(a => a.type)
+        newLightMachine.transition('yellow', 'TIMER').actions.map((a) => a.type)
       ).toEqual(['exit_yellow', 'enter_red', 'enter_walk']);
     });
 
@@ -455,32 +455,34 @@ describe('onEntry/onExit actions', () => {
       expect(
         newLightMachine
           .transition('red.walk', 'PED_COUNTDOWN')
-          .actions.map(a => a.type)
+          .actions.map((a) => a.type)
       ).toEqual(['exit_walk', 'enter_wait']);
     });
 
     it('should not have actions for unhandled events (shallow)', () => {
       expect(
-        newLightMachine.transition('green', 'FAKE').actions.map(a => a.type)
+        newLightMachine.transition('green', 'FAKE').actions.map((a) => a.type)
       ).toEqual([]);
     });
 
     it('should not have actions for unhandled events (deep)', () => {
       expect(
-        newLightMachine.transition('red', 'FAKE').actions.map(a => a.type)
+        newLightMachine.transition('red', 'FAKE').actions.map((a) => a.type)
       ).toEqual([]);
     });
 
     it('should exit and enter the state for self-transitions (shallow)', () => {
       expect(
-        newLightMachine.transition('green', 'NOTHING').actions.map(a => a.type)
+        newLightMachine
+          .transition('green', 'NOTHING')
+          .actions.map((a) => a.type)
       ).toEqual(['exit_green', 'enter_green']);
     });
 
     it('should exit and enter the state for self-transitions (deep)', () => {
       // 'red' state resolves to 'red.walk'
       expect(
-        newLightMachine.transition('red', 'NOTHING').actions.map(a => a.type)
+        newLightMachine.transition('red', 'NOTHING').actions.map((a) => a.type)
       ).toEqual(['exit_walk', 'exit_red', 'enter_red', 'enter_walk']);
     });
   });
@@ -515,13 +517,13 @@ describe('onEntry/onExit actions', () => {
       expect(
         parallelMachineWithOnEntry
           .transition('start', 'ENTER_PARALLEL')
-          .actions.map(a => a.type)
+          .actions.map((a) => a.type)
       ).toEqual(['enter_p1', 'enter_inner']);
     });
   });
 
   describe('targetless transitions', () => {
-    it("shouldn't exit a state on a parent's targetless transition", done => {
+    it("shouldn't exit a state on a parent's targetless transition", (done) => {
       const actual: string[] = [];
 
       const parent = Machine({
@@ -563,7 +565,7 @@ describe('onEntry/onExit actions', () => {
         .catch(done);
     });
 
-    it("shouldn't exit (and reenter) state on targetless delayed transition", done => {
+    it("shouldn't exit (and reenter) state on targetless delayed transition", (done) => {
       const actual: string[] = [];
 
       const machine = Machine({
@@ -676,7 +678,7 @@ describe('actions config', () => {
     const { initialState } = simpleMachine;
     const nextState = simpleMachine.transition(initialState, 'E');
 
-    expect(nextState.actions.map(a => a.type)).toEqual(
+    expect(nextState.actions.map((a) => a.type)).toEqual(
       expect.arrayContaining(['definedAction', 'undefinedAction'])
     );
 
@@ -690,7 +692,7 @@ describe('actions config', () => {
   it('should reference actions defined in actions parameter of machine options (initial state)', () => {
     const { initialState } = simpleMachine;
 
-    expect(initialState.actions.map(a => a.type)).toEqual(
+    expect(initialState.actions.map((a) => a.type)).toEqual(
       expect.arrayContaining(['definedAction', 'undefinedAction'])
     );
   });
@@ -730,7 +732,7 @@ describe('actions config', () => {
 
     const { initialState } = anonMachine;
 
-    initialState.actions.forEach(action => {
+    initialState.actions.forEach((action) => {
       if (action.exec) {
         action.exec(
           initialState.context,
@@ -750,7 +752,7 @@ describe('actions config', () => {
 
     expect(inactiveState.actions.length).toBe(2);
 
-    inactiveState.actions.forEach(action => {
+    inactiveState.actions.forEach((action) => {
       if (action.exec) {
         action.exec(
           inactiveState.context,
@@ -770,7 +772,7 @@ describe('actions config', () => {
 });
 
 describe('action meta', () => {
-  it('should provide the original action and state to the exec function', done => {
+  it('should provide the original action and state to the exec function', (done) => {
     const testMachine = Machine(
       {
         id: 'test',
@@ -841,7 +843,7 @@ describe('purely defined actions', () => {
             })
           },
           EACH: {
-            actions: pure<any, any>(ctx =>
+            actions: pure<any, any>((ctx) =>
               ctx.items.map((item, index) => ({
                 type: 'EVENT',
                 item,
@@ -905,7 +907,7 @@ describe('purely defined actions', () => {
 });
 
 describe('forwardTo()', () => {
-  it('should forward an event to a service', done => {
+  it('should forward an event to a service', (done) => {
     const child = Machine<void, { type: 'EVENT'; value: number }>({
       id: 'child',
       initial: 'active',
@@ -947,7 +949,7 @@ describe('forwardTo()', () => {
     service.send('EVENT', { value: 42 });
   });
 
-  it('should forward an event to a service (dynamic)', done => {
+  it('should forward an event to a service (dynamic)', (done) => {
     const child = Machine<void, { type: 'EVENT'; value: number }>({
       id: 'child',
       initial: 'active',
@@ -976,7 +978,7 @@ describe('forwardTo()', () => {
           }),
           on: {
             EVENT: {
-              actions: forwardTo(ctx => ctx.child)
+              actions: forwardTo((ctx) => ctx.child)
             },
             SUCCESS: 'last'
           }
@@ -1007,7 +1009,7 @@ describe('log()', () => {
         entry: log('some string', 'string label'),
         on: {
           EXPR: {
-            actions: log(ctx => `expr ${ctx.count}`, 'expr label')
+            actions: log((ctx) => `expr ${ctx.count}`, 'expr label')
           }
         }
       }
@@ -1194,7 +1196,7 @@ describe('choose', () => {
         foo: {
           entry: choose([
             {
-              cond: ctx => ctx.counter > 100,
+              cond: (ctx) => ctx.counter > 100,
               actions: assign<Ctx>({ answer: 42 })
             }
           ])
@@ -1275,7 +1277,7 @@ describe('send()', () => {
         actions: send<any, any>('TOGGLE', { to: (_ctx, evt) => evt.target })
       },
       BY_TARGET_EXPR_REF: {
-        actions: send<any, any>('TOGGLE', { to: ctx => [ctx.ref1, ctx.ref2] })
+        actions: send<any, any>('TOGGLE', { to: (ctx) => [ctx.ref1, ctx.ref2] })
       }
     },
     states: {
@@ -1298,7 +1300,7 @@ describe('send()', () => {
   });
 
   const makeTest = (description: string, evt: string | AnyEventObject) =>
-    it(description, done => {
+    it(description, (done) => {
       const parentService = interpret(parentMachine).onDone(() => {
         done();
       });
@@ -1320,7 +1322,7 @@ describe('send()', () => {
     'BY_TARGET_EXPR_REF'
   );
 
-  it('should support targetting multiple invoked machines by providing an list of ids for the .to property', done => {
+  it('should support targetting multiple invoked machines by providing an list of ids for the .to property', (done) => {
     const childMachine = createMachine({
       initial: 'FALSE',
       states: {

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -6,7 +6,7 @@ import {
   interpret,
   spawn
 } from '../src/index';
-import { pure, sendParent, log, choose } from '../src/actions';
+import { pure, sendParent, log, choose, send } from '../src/actions';
 
 describe('onEntry/onExit actions', () => {
   const pedestrianStates = {
@@ -256,20 +256,20 @@ describe('onEntry/onExit actions', () => {
 
   describe('State.actions', () => {
     it('should return the entry actions of an initial state', () => {
-      expect(lightMachine.initialState.actions.map((a) => a.type)).toEqual([
+      expect(lightMachine.initialState.actions.map(a => a.type)).toEqual([
         'enter_green'
       ]);
     });
 
     it('should return the entry actions of an initial state (deep)', () => {
-      expect(deepMachine.initialState.actions.map((a) => a.type)).toEqual([
+      expect(deepMachine.initialState.actions.map(a => a.type)).toEqual([
         'enter_a',
         'enter_a1'
       ]);
     });
 
     it('should return the entry actions of an initial state (parallel)', () => {
-      expect(parallelMachine.initialState.actions.map((a) => a.type)).toEqual([
+      expect(parallelMachine.initialState.actions.map(a => a.type)).toEqual([
         'enter_a',
         'enter_a1',
         'enter_b',
@@ -279,13 +279,13 @@ describe('onEntry/onExit actions', () => {
 
     it('should return the entry and exit actions of a transition', () => {
       expect(
-        lightMachine.transition('green', 'TIMER').actions.map((a) => a.type)
+        lightMachine.transition('green', 'TIMER').actions.map(a => a.type)
       ).toEqual(['exit_green', 'enter_yellow']);
     });
 
     it('should return the entry and exit actions of a deep transition', () => {
       expect(
-        lightMachine.transition('yellow', 'TIMER').actions.map((a) => a.type)
+        lightMachine.transition('yellow', 'TIMER').actions.map(a => a.type)
       ).toEqual(['exit_yellow', 'enter_red', 'enter_walk']);
     });
 
@@ -293,32 +293,32 @@ describe('onEntry/onExit actions', () => {
       expect(
         lightMachine
           .transition('red.walk', 'PED_COUNTDOWN')
-          .actions.map((a) => a.type)
+          .actions.map(a => a.type)
       ).toEqual(['exit_walk', 'enter_wait']);
     });
 
     it('should not have actions for unhandled events (shallow)', () => {
       expect(
-        lightMachine.transition('green', 'FAKE').actions.map((a) => a.type)
+        lightMachine.transition('green', 'FAKE').actions.map(a => a.type)
       ).toEqual([]);
     });
 
     it('should not have actions for unhandled events (deep)', () => {
       expect(
-        lightMachine.transition('red', 'FAKE').actions.map((a) => a.type)
+        lightMachine.transition('red', 'FAKE').actions.map(a => a.type)
       ).toEqual([]);
     });
 
     it('should exit and enter the state for self-transitions (shallow)', () => {
       expect(
-        lightMachine.transition('green', 'NOTHING').actions.map((a) => a.type)
+        lightMachine.transition('green', 'NOTHING').actions.map(a => a.type)
       ).toEqual(['exit_green', 'enter_green']);
     });
 
     it('should exit and enter the state for self-transitions (deep)', () => {
       // 'red' state resolves to 'red.walk'
       expect(
-        lightMachine.transition('red', 'NOTHING').actions.map((a) => a.type)
+        lightMachine.transition('red', 'NOTHING').actions.map(a => a.type)
       ).toEqual(['exit_walk', 'exit_red', 'enter_red', 'enter_walk']);
     });
 
@@ -326,7 +326,7 @@ describe('onEntry/onExit actions', () => {
       expect(
         parallelMachine
           .transition(parallelMachine.initialState, 'CHANGE')
-          .actions.map((a) => a.type)
+          .actions.map(a => a.type)
       ).toEqual([
         'exit_b1', // reverse document order
         'exit_a1',
@@ -340,7 +340,7 @@ describe('onEntry/onExit actions', () => {
 
     it('should return nested actions in the correct (child to parent) order', () => {
       expect(
-        deepMachine.transition('a.a1', 'CHANGE').actions.map((a) => a.type)
+        deepMachine.transition('a.a1', 'CHANGE').actions.map(a => a.type)
       ).toEqual([
         'exit_a1',
         'exit_a',
@@ -353,7 +353,7 @@ describe('onEntry/onExit actions', () => {
 
     it('should ignore parent state actions for same-parent substates', () => {
       expect(
-        deepMachine.transition('a.a1', 'NEXT').actions.map((a) => a.type)
+        deepMachine.transition('a.a1', 'NEXT').actions.map(a => a.type)
       ).toEqual(['exit_a1', 'enter_a2']);
     });
 
@@ -361,13 +361,13 @@ describe('onEntry/onExit actions', () => {
       expect(
         deepMachine
           .transition(deepMachine.initialState, 'NEXT_FN')
-          .actions.map((action) => action.type)
+          .actions.map(action => action.type)
       ).toEqual(['exit_a1', 'enter_a3_fn']);
 
       expect(
         deepMachine
           .transition('a.a3', 'NEXT')
-          .actions.map((action) => action.type)
+          .actions.map(action => action.type)
       ).toEqual(['exit_a3_fn', 'do_a3_to_a2', 'enter_a2']);
     });
 
@@ -379,7 +379,7 @@ describe('onEntry/onExit actions', () => {
       const stateD2 = parallelMachine2.transition(stateB, 'to-D2');
       const stateA = parallelMachine2.transition(stateD2, 'to-A');
 
-      expect(stateA.actions.map((action) => action.type)).toEqual(['D2 Exit']);
+      expect(stateA.actions.map(action => action.type)).toEqual(['D2 Exit']);
     });
 
     describe('should ignore same-parent state actions (sparse)', () => {
@@ -433,20 +433,20 @@ describe('onEntry/onExit actions', () => {
 
   describe('State.actions (with entry/exit instead of onEntry/onExit)', () => {
     it('should return the entry actions of an initial state', () => {
-      expect(newLightMachine.initialState.actions.map((a) => a.type)).toEqual([
+      expect(newLightMachine.initialState.actions.map(a => a.type)).toEqual([
         'enter_green'
       ]);
     });
 
     it('should return the entry and exit actions of a transition', () => {
       expect(
-        newLightMachine.transition('green', 'TIMER').actions.map((a) => a.type)
+        newLightMachine.transition('green', 'TIMER').actions.map(a => a.type)
       ).toEqual(['exit_green', 'enter_yellow']);
     });
 
     it('should return the entry and exit actions of a deep transition', () => {
       expect(
-        newLightMachine.transition('yellow', 'TIMER').actions.map((a) => a.type)
+        newLightMachine.transition('yellow', 'TIMER').actions.map(a => a.type)
       ).toEqual(['exit_yellow', 'enter_red', 'enter_walk']);
     });
 
@@ -454,34 +454,32 @@ describe('onEntry/onExit actions', () => {
       expect(
         newLightMachine
           .transition('red.walk', 'PED_COUNTDOWN')
-          .actions.map((a) => a.type)
+          .actions.map(a => a.type)
       ).toEqual(['exit_walk', 'enter_wait']);
     });
 
     it('should not have actions for unhandled events (shallow)', () => {
       expect(
-        newLightMachine.transition('green', 'FAKE').actions.map((a) => a.type)
+        newLightMachine.transition('green', 'FAKE').actions.map(a => a.type)
       ).toEqual([]);
     });
 
     it('should not have actions for unhandled events (deep)', () => {
       expect(
-        newLightMachine.transition('red', 'FAKE').actions.map((a) => a.type)
+        newLightMachine.transition('red', 'FAKE').actions.map(a => a.type)
       ).toEqual([]);
     });
 
     it('should exit and enter the state for self-transitions (shallow)', () => {
       expect(
-        newLightMachine
-          .transition('green', 'NOTHING')
-          .actions.map((a) => a.type)
+        newLightMachine.transition('green', 'NOTHING').actions.map(a => a.type)
       ).toEqual(['exit_green', 'enter_green']);
     });
 
     it('should exit and enter the state for self-transitions (deep)', () => {
       // 'red' state resolves to 'red.walk'
       expect(
-        newLightMachine.transition('red', 'NOTHING').actions.map((a) => a.type)
+        newLightMachine.transition('red', 'NOTHING').actions.map(a => a.type)
       ).toEqual(['exit_walk', 'exit_red', 'enter_red', 'enter_walk']);
     });
   });
@@ -516,13 +514,13 @@ describe('onEntry/onExit actions', () => {
       expect(
         parallelMachineWithOnEntry
           .transition('start', 'ENTER_PARALLEL')
-          .actions.map((a) => a.type)
+          .actions.map(a => a.type)
       ).toEqual(['enter_p1', 'enter_inner']);
     });
   });
 
   describe('targetless transitions', () => {
-    it("shouldn't exit a state on a parent's targetless transition", (done) => {
+    it("shouldn't exit a state on a parent's targetless transition", done => {
       const actual: string[] = [];
 
       const parent = Machine({
@@ -564,7 +562,7 @@ describe('onEntry/onExit actions', () => {
         .catch(done);
     });
 
-    it("shouldn't exit (and reenter) state on targetless delayed transition", (done) => {
+    it("shouldn't exit (and reenter) state on targetless delayed transition", done => {
       const actual: string[] = [];
 
       const machine = Machine({
@@ -677,7 +675,7 @@ describe('actions config', () => {
     const { initialState } = simpleMachine;
     const nextState = simpleMachine.transition(initialState, 'E');
 
-    expect(nextState.actions.map((a) => a.type)).toEqual(
+    expect(nextState.actions.map(a => a.type)).toEqual(
       expect.arrayContaining(['definedAction', 'undefinedAction'])
     );
 
@@ -691,7 +689,7 @@ describe('actions config', () => {
   it('should reference actions defined in actions parameter of machine options (initial state)', () => {
     const { initialState } = simpleMachine;
 
-    expect(initialState.actions.map((a) => a.type)).toEqual(
+    expect(initialState.actions.map(a => a.type)).toEqual(
       expect.arrayContaining(['definedAction', 'undefinedAction'])
     );
   });
@@ -731,7 +729,7 @@ describe('actions config', () => {
 
     const { initialState } = anonMachine;
 
-    initialState.actions.forEach((action) => {
+    initialState.actions.forEach(action => {
       if (action.exec) {
         action.exec(
           initialState.context,
@@ -751,7 +749,7 @@ describe('actions config', () => {
 
     expect(inactiveState.actions.length).toBe(2);
 
-    inactiveState.actions.forEach((action) => {
+    inactiveState.actions.forEach(action => {
       if (action.exec) {
         action.exec(
           inactiveState.context,
@@ -771,7 +769,7 @@ describe('actions config', () => {
 });
 
 describe('action meta', () => {
-  it('should provide the original action and state to the exec function', (done) => {
+  it('should provide the original action and state to the exec function', done => {
     const testMachine = Machine(
       {
         id: 'test',
@@ -842,7 +840,7 @@ describe('purely defined actions', () => {
             })
           },
           EACH: {
-            actions: pure<any, any>((ctx) =>
+            actions: pure<any, any>(ctx =>
               ctx.items.map((item, index) => ({
                 type: 'EVENT',
                 item,
@@ -906,7 +904,7 @@ describe('purely defined actions', () => {
 });
 
 describe('forwardTo()', () => {
-  it('should forward an event to a service', (done) => {
+  it('should forward an event to a service', done => {
     const child = Machine<void, { type: 'EVENT'; value: number }>({
       id: 'child',
       initial: 'active',
@@ -948,7 +946,7 @@ describe('forwardTo()', () => {
     service.send('EVENT', { value: 42 });
   });
 
-  it('should forward an event to a service (dynamic)', (done) => {
+  it('should forward an event to a service (dynamic)', done => {
     const child = Machine<void, { type: 'EVENT'; value: number }>({
       id: 'child',
       initial: 'active',
@@ -977,7 +975,7 @@ describe('forwardTo()', () => {
           }),
           on: {
             EVENT: {
-              actions: forwardTo((ctx) => ctx.child)
+              actions: forwardTo(ctx => ctx.child)
             },
             SUCCESS: 'last'
           }
@@ -1008,7 +1006,7 @@ describe('log()', () => {
         entry: log('some string', 'string label'),
         on: {
           EXPR: {
-            actions: log((ctx) => `expr ${ctx.count}`, 'expr label')
+            actions: log(ctx => `expr ${ctx.count}`, 'expr label')
           }
         }
       }
@@ -1195,7 +1193,7 @@ describe('choose', () => {
         foo: {
           entry: choose([
             {
-              cond: (ctx) => ctx.counter > 100,
+              cond: ctx => ctx.counter > 100,
               actions: assign<Ctx>({ answer: 42 })
             }
           ])
@@ -1236,5 +1234,75 @@ describe('choose', () => {
     const service = interpret(machine).start();
     service.send({ type: 'NEXT', counter: 101 });
     expect(service.state.context).toEqual({ answer: 42 });
+  });
+});
+
+describe.only('send()', () => {
+  it('should allow multiple targets', done => {
+    const childMachine = createMachine({
+      initial: 'FALSE',
+      states: {
+        FALSE: {
+          entry: log((_, evt) => `Spawning a machine ${evt.type}`),
+          on: {
+            TOGGLE: {
+              target: 'TRUE',
+              actions: [log((_, _evt) => `Toggle`), sendParent('INCREMENT')]
+            }
+          }
+        },
+        TRUE: {
+          type: 'final'
+        }
+      }
+    });
+
+    const parentMachine = createMachine({
+      context: {
+        ref1: undefined,
+        ref2: undefined
+      },
+      initial: 'zero',
+      on: {
+        INCREMENT: {
+          actions: [
+            log(() => 'INCREMENT'),
+            log((_, evt) => JSON.stringify(evt, null, 2))
+          ] as any
+        },
+        RUN: {
+          actions: send<any, any>('TOGGLE', { to: ['ref1', 'ref2'] })
+        }
+      },
+      states: {
+        zero: {
+          entry: assign<any, any>({
+            ref1: () => spawn(childMachine, 'ref1'),
+            ref2: () => spawn(childMachine, 'ref2')
+          }),
+          on: {
+            INCREMENT: 'one'
+          }
+        },
+        one: {
+          on: { INCREMENT: 'two' }
+        },
+        two: {
+          type: 'final'
+        }
+      }
+    });
+
+    const parentService = interpret(parentMachine)
+      .onDone(() => {
+        done();
+      })
+      .onTransition(state => {
+        console.log('Next:', state.value, JSON.stringify(state.event, null, 2));
+      });
+
+    parentService.start();
+
+    parentService.send('RUN');
   });
 });


### PR DESCRIPTION
This PR implements support for targeting multiple actors by allowing you to provide a list of references in a _send_ action's `.to` property. E.g.:

```ts
on : {
  TOGGLE_ALL: {
    actions: send('TOGGLE', { to: ['ref1', 'ref2'] })
  }
}
```
I'm not sure if this is SCXML compliant.

Tasks:
- [x] Update documentation
- [x] Finalize test
- [x] Add changeset
- [x] Remove logs