### PR TITLE
[Docs] Correct variable name in xstate-react example

### DIFF
--- a/packages/xstate-react/README.md
+++ b/packages/xstate-react/README.md
@@ -252,11 +252,11 @@ We can also continue to use `switch`, but we must make an adjustment to our appr
 
 ```js
 switch (true) {
-  case current.matches('idle'):
+  case state.matches('idle'):
     return /* ... */;
-  case current.matches({ loading: 'user' }):
+  case state.matches({ loading: 'user' }):
     return /* ... */;
-  case current.matches({ loading: 'friends' }):
+  case state.matches({ loading: 'friends' }):
     return /* ... */;
   default:
     return null;


### PR DESCRIPTION
It seems to me that the `current` variable is a typo and should be `state`