### PR TITLE
Passed state type generic to the Config interface

### DIFF
--- a/.changeset/wise-lemons-travel.md
+++ b/.changeset/wise-lemons-travel.md
@@ -2,4 +2,4 @@
 '@xstate/fsm': patch
 ---
 
-Passed state type generic to the Config interface
+`StateMachine.Config` type accepts now a third type parameter - `TState` - similarly to other existing types. When provided it provides helpful intellisense when defining the state chart transitions.

--- a/.changeset/wise-lemons-travel.md
+++ b/.changeset/wise-lemons-travel.md
@@ -1,0 +1,5 @@
+---
+'@xstate/fsm': patch
+---
+
+Passed state type generic to the Config interface

--- a/packages/xstate-fsm/src/index.ts
+++ b/packages/xstate-fsm/src/index.ts
@@ -81,7 +81,7 @@ export function createMachine<
   TEvent extends EventObject = EventObject,
   TState extends Typestate<TContext> = any
 >(
-  fsmConfig: StateMachine.Config<TContext, TEvent>,
+  fsmConfig: StateMachine.Config<TContext, TEvent, TState>,
   options: {
     actions?: StateMachine.ActionMap<TContext, TEvent>;
   } = {}

--- a/packages/xstate-fsm/src/types.ts
+++ b/packages/xstate-fsm/src/types.ts
@@ -68,12 +68,16 @@ export namespace StateMachine {
     ) => this is TState extends { value: TSV } ? TState : never;
   }
 
-  export interface Config<TContext extends object, TEvent extends EventObject> {
+  export interface Config<
+    TContext extends object,
+    TEvent extends EventObject,
+    TState extends Typestate<TContext> = any
+  > {
     id?: string;
     initial: string;
     context?: TContext;
     states: {
-      [key: string]: {
+      [key in TState['value']]: {
         on?: {
           [K in TEvent['type']]?: SingleOrArray<
             Transition<TContext, TEvent extends { type: K } ? TEvent : never>

--- a/packages/xstate-fsm/test/fsm.test.ts
+++ b/packages/xstate-fsm/test/fsm.test.ts
@@ -20,9 +20,17 @@ describe('@xstate/fsm', () => {
     | {
         value: 'yellow';
         context: LightContext & { go: false };
+      }
+    | {
+        value: 'red';
+        context: LightContext & { go: false };
       };
 
-  const lightConfig: StateMachine.Config<LightContext, LightEvent> = {
+  const lightConfig: StateMachine.Config<
+    LightContext,
+    LightEvent,
+    LightState
+  > = {
     id: 'light',
     initial: 'green',
     context: { count: 0, foo: 'bar', go: true },


### PR DESCRIPTION
The `StateMachine.Config` interface should accept a third generic for our state type, which should then be provided when used in the `createMachine` function. I think. I have declared my own module and haven't had any issues, but if there are any reasons this wasn't set up this way originally let me know.

Using the state type provides helpful intellisense when defining the state chart transitions! 

**NOTE:** I ran tests locally but a bunch of them failed because local modules weren't resolved. Not sure if there is a step missing in `CONTRIBUTING.md` to link these packages.
