### PR TITLE
@xstate/immer initial release

### DIFF
--- a/.changeset/twenty-weeks-share.md
+++ b/.changeset/twenty-weeks-share.md
@@ -1,0 +1,5 @@
+---
+'@xstate/immer': minor
+---
+
+Initial release for `@xstate/immer`.

--- a/.github/actions/change-release-intent/main.js
+++ b/.github/actions/change-release-intent/main.js
@@ -8,10 +8,10 @@ async function execWithOutput(command, args, options) {
   return {
     code: await exec(command, args, {
       listeners: {
-        stdout: data => {
+        stdout: (data) => {
           myOutput += data.toString();
         },
-        stderr: data => {
+        stderr: (data) => {
           myError += data.toString();
         }
       },
@@ -27,7 +27,8 @@ const publishablePackages = [
   'xstate',
   '@xstate/fsm',
   '@xstate/graph',
-  '@xstate/test'
+  '@xstate/test',
+  '@xstate/immer'
 ];
 
 (async () => {

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,7 +49,7 @@ const toggleMachine = createMachine({
 
 // Machine instance with internal state
 const toggleService = interpret(toggleMachine)
-  .onTransition(state => console.log(state.value))
+  .onTransition((state) => console.log(state.value))
   .start();
 // => 'inactive'
 
@@ -83,7 +83,7 @@ const fetchMachine = createMachine({
       invoke: {
         id: 'fetchLuke',
         src: (context, event) =>
-          fetch('https://swapi.co/api/people/1').then(data => data.json()),
+          fetch('https://swapi.co/api/people/1').then((data) => data.json()),
         onDone: {
           target: 'resolved',
           actions: assign({

--- a/docs/packages/xstate-react/index.md
+++ b/docs/packages/xstate-react/index.md
@@ -198,10 +198,11 @@ const fetchMachine = Machine({
 const Fetcher = ({ onResolve }) => {
   const [state, send] = useMachine(fetchMachine, {
     actions: {
-      notifySuccess: ctx => onResolve(ctx.data)
+      notifySuccess: (ctx) => onResolve(ctx.data)
     },
     services: {
-      fetchData: (_, e) => fetch(`some/api/${e.query}`).then(res => res.json())
+      fetchData: (_, e) =>
+        fetch(`some/api/${e.query}`).then((res) => res.json())
     }
   });
 
@@ -252,11 +253,11 @@ We can also continue to use `switch`, but we must make an adjustment to our appr
 
 ```js
 switch (true) {
-  case current.matches('idle'):
+  case state.matches('idle'):
     return /* ... */;
-  case current.matches({ loading: 'user' }):
+  case state.matches({ loading: 'user' }):
     return /* ... */;
-  case current.matches({ loading: 'friends' }):
+  case state.matches({ loading: 'friends' }):
     return /* ... */;
   default:
     return null;
@@ -319,7 +320,7 @@ You can subscribe to that service's state changes with the [`useEffect` hook](ht
 // ...
 
 useEffect(() => {
-  const subscription = service.subscribe(state => {
+  const subscription = service.subscribe((state) => {
     // simple state logging
     console.log(state);
   });

--- a/docs/packages/xstate-vue/index.md
+++ b/docs/packages/xstate-vue/index.md
@@ -8,6 +8,22 @@
 npm i xstate @xstate/vue
 ```
 
+**Via CDN**
+
+```html
+<script src="https://unpkg.com/@xstate/vue/dist/xstate-vue.min.js"></script>
+```
+
+By using the global variable `XStateVue`
+
+or
+
+```html
+<script src="https://unpkg.com/@xstate/vue/dist/xstate-vue.fsm.min.js"></script>
+```
+
+By using the global variable `XStateVueFSM`
+
 2. Import the `useMachine` composition function:
 
 ```vue

--- a/packages/xstate-immer/README.md
+++ b/packages/xstate-immer/README.md
@@ -1,3 +1,76 @@
 # @xstate/immer
 
-Coming soon!
+This package contains utilities for using [Immer](https://immerjs.github.io/immer/docs/introduction) with XState.
+
+Included in `@xstate/immer`:
+
+- `assign()` - an Immer action that allows you to immutably assign to machine `context` in a convenient way
+- `createUpdater()` - a useful function that allows you to cohesively specify a context update event, assign action, and validator, all together. (See example below)
+
+## Quick Start
+
+1. Install `xstate` and `@xstate/immer`:
+
+```bash
+npm install xstate @xstate/immer
+```
+
+2. Import the Immer utilities:
+
+```js
+import { createMachine, interpret } from 'xstate';
+import { assign, createUpdater } from '@xstate/immer';
+
+const updateLevel = createUpdater('UPDATE_LEVEL', (ctx, level) => {
+  ctx.level = level;
+});
+
+const toggleMachine = createMachine({
+  id: 'toggle',
+  context: {
+    count: 0,
+    level: 0
+  },
+  initial: 'inactive',
+  states: {
+    inactive: {
+      on: {
+        TOGGLE: {
+          target: 'active',
+          // Immutably update context the same "mutable"
+          // way as you would do with Immer!
+          actions: assign((ctx) => ctx.count++)
+        },
+        // Use the updater for more convenience:
+        [updateLevel.type]: {
+          actions: updateLevel.assign
+        }
+      }
+    },
+    active: {
+      on: {
+        TOGGLE: { target: 'inactive' }
+      }
+    }
+  }
+});
+
+const toggleService = interpret(toggleMachine)
+  .onTransition((state) => {
+    console.log(state.context);
+  })
+  .start();
+
+toggleService.send('TOGGLE');
+// { count: 1, level: 0 }
+
+toggleService.send(udpateLevel(9));
+// { count: 1, level: 9 }
+
+toggleService.send('TOGGLE');
+// { count: 2, level: 9 }
+
+toggleService.send(udpateLevel(-100));
+// Notice how the level is not updated in 'inactive' state:
+// { count: 2, level: 9 }
+```

--- a/packages/xstate-immer/README.md
+++ b/packages/xstate-immer/README.md
@@ -64,13 +64,13 @@ const toggleService = interpret(toggleMachine)
 toggleService.send('TOGGLE');
 // { count: 1, level: 0 }
 
-toggleService.send(udpateLevel(9));
+toggleService.send(updateLevel(9));
 // { count: 1, level: 9 }
 
 toggleService.send('TOGGLE');
 // { count: 2, level: 9 }
 
-toggleService.send(udpateLevel(-100));
+toggleService.send(updateLevel(-100));
 // Notice how the level is not updated in 'inactive' state:
 // { count: 2, level: 9 }
 ```

--- a/packages/xstate-immer/README.md
+++ b/packages/xstate-immer/README.md
@@ -21,7 +21,7 @@ npm install xstate @xstate/immer
 import { createMachine, interpret } from 'xstate';
 import { assign, createUpdater } from '@xstate/immer';
 
-const updateLevel = createUpdater('UPDATE_LEVEL', (ctx, level) => {
+const levelUpdater = createUpdater('UPDATE_LEVEL', (ctx, level) => {
   ctx.level = level;
 });
 
@@ -42,8 +42,8 @@ const toggleMachine = createMachine({
           actions: assign((ctx) => ctx.count++)
         },
         // Use the updater for more convenience:
-        [updateLevel.type]: {
-          actions: updateLevel.assign
+        [levelUpdater.type]: {
+          actions: levelUpdater.assign
         }
       }
     },
@@ -64,13 +64,13 @@ const toggleService = interpret(toggleMachine)
 toggleService.send('TOGGLE');
 // { count: 1, level: 0 }
 
-toggleService.send(updateLevel(9));
+toggleService.send(levelUpdater.update(9));
 // { count: 1, level: 9 }
 
 toggleService.send('TOGGLE');
 // { count: 2, level: 9 }
 
-toggleService.send(updateLevel(-100));
+toggleService.send(levelUpdater.update(-100));
 // Notice how the level is not updated in 'inactive' state:
 // { count: 2, level: 9 }
 ```

--- a/packages/xstate-immer/README.md
+++ b/packages/xstate-immer/README.md
@@ -7,7 +7,7 @@ This package contains utilities for using [Immer](https://immerjs.github.io/imme
 
 - [Quick Start](#quick-start)
 - [API](#api)
-  - [`assign(producer)`](#assignproducer)
+  - [`assign(recipe)`](#assignrecipe)
   - [`createUpdater(eventType, recipe)`](#createupdatereventtype-recipe)
 - [TypeScript](#typescript)
 
@@ -88,7 +88,7 @@ toggleService.send(levelUpdater.update(-100));
 
 ## API
 
-### `assign(producer)`
+### `assign(recipe)`
 
 Returns an XState event object that will update the machine's `context` to reflect the changes ("mutations") to `context` made in the `recipe` function.
 

--- a/packages/xstate-immer/package.json
+++ b/packages/xstate-immer/package.json
@@ -38,11 +38,11 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "immer": "^5.0.0",
+    "immer": "^6.0.3",
     "xstate": "^4.6.0"
   },
   "devDependencies": {
-    "immer": "^5.0.0",
+    "immer": "^6.0.3",
     "lerna-alias": "3.0.3-0",
     "typescript": "^3.8.3",
     "xstate": "*"

--- a/packages/xstate-immer/package.json
+++ b/packages/xstate-immer/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@xstate/immer",
-  "private": true,
   "version": "0.0.1",
   "description": "XState with Immer",
   "keywords": [

--- a/packages/xstate-immer/src/index.ts
+++ b/packages/xstate-immer/src/index.ts
@@ -44,7 +44,7 @@ export interface ImmerUpdater<TContext, TEvent extends ImmerUpdateEvent> {
 
 export function createUpdater<TContext, TEvent extends ImmerUpdateEvent>(
   type: TEvent['type'],
-  recipe: (ctx: Draft<TContext>, input: TEvent['input']) => void
+  recipe: ImmerAssigner<TContext, TEvent>
 ): ImmerUpdater<TContext, TEvent> {
   const update = (input: TEvent['input']): TEvent => {
     return {
@@ -55,8 +55,8 @@ export function createUpdater<TContext, TEvent extends ImmerUpdateEvent>(
 
   return {
     update,
-    action: immerAssign<TContext, TEvent>((ctx, event) => {
-      recipe(ctx, event.input);
+    action: immerAssign<TContext, TEvent>((ctx, event, meta) => {
+      recipe(ctx, event, meta);
     }),
     type
   };

--- a/packages/xstate-immer/src/index.ts
+++ b/packages/xstate-immer/src/index.ts
@@ -35,8 +35,8 @@ export interface ImmerUpdateEvent<
 }
 
 export interface ImmerUpdater<TContext, TEvent extends ImmerUpdateEvent> {
-  (input: TEvent['input']): TEvent;
-  assign: ImmerAssignAction<TContext, TEvent>;
+  update: (input: TEvent['input']) => TEvent;
+  assign: AssignAction<TContext, TEvent>;
   type: TEvent['type'];
   validate?: (context: TContext, input: TEvent['input']) => boolean;
 }
@@ -46,20 +46,19 @@ export function createUpdater<TContext, TEvent extends ImmerUpdateEvent>(
   producer: (ctx: Draft<TContext>, input: TEvent['input']) => void,
   validate?: (ctx: TContext, input: TEvent['input']) => boolean
 ): ImmerUpdater<TContext, TEvent> {
-  const updater = (input: TEvent['input']): TEvent => {
+  const update = (input: TEvent['input']): TEvent => {
     return {
       type,
       input
     } as TEvent;
   };
 
-  Object.assign(updater, {
+  return {
+    update,
     assign: immerAssign<TContext, TEvent>((ctx, event) => {
       producer(ctx, event.input);
     }),
     validate,
     type
-  });
-
-  return updater as ImmerUpdater<TContext, TEvent>;
+  };
 }

--- a/packages/xstate-immer/src/index.ts
+++ b/packages/xstate-immer/src/index.ts
@@ -44,7 +44,7 @@ export interface ImmerUpdater<TContext, TEvent extends ImmerUpdateEvent> {
 
 export function createUpdater<TContext, TEvent extends ImmerUpdateEvent>(
   type: TEvent['type'],
-  producer: (ctx: Draft<TContext>, input: TEvent['input']) => void
+  recipe: (ctx: Draft<TContext>, input: TEvent['input']) => void
 ): ImmerUpdater<TContext, TEvent> {
   const update = (input: TEvent['input']): TEvent => {
     return {
@@ -56,7 +56,7 @@ export function createUpdater<TContext, TEvent extends ImmerUpdateEvent>(
   return {
     update,
     action: immerAssign<TContext, TEvent>((ctx, event) => {
-      producer(ctx, event.input);
+      recipe(ctx, event.input);
     }),
     type
   };

--- a/packages/xstate-immer/src/index.ts
+++ b/packages/xstate-immer/src/index.ts
@@ -27,7 +27,6 @@ export interface ImmerAssignAction<TContext, TEvent extends EventObject>
 export function assign<TContext, TEvent extends EventObject = EventObject>(
   assignment: ImmerAssigner<TContext, TEvent>
 ): AssignAction<TContext, TEvent> {
-  // @ts-ignore (possibly infinite TS bug)
   return xstateAssign((context, event) => {
     return produce(context, (draft) => void assignment(draft, event));
   });
@@ -42,9 +41,11 @@ export function patchEvent<TContext>(
   context: TContext,
   recipe: (draftContext: TContext) => void
 ): PatchEventObject {
+  const patches = produceWithPatches(context, recipe);
+
   return {
     type,
-    patches: produceWithPatches(context, recipe)
+    patches
   };
 }
 

--- a/packages/xstate-immer/src/index.ts
+++ b/packages/xstate-immer/src/index.ts
@@ -4,7 +4,15 @@ import {
   AssignAction,
   assign as xstateAssign
 } from 'xstate';
-import { produce, Draft, produceWithPatches, applyPatches } from 'immer';
+import {
+  produce,
+  Draft,
+  produceWithPatches,
+  applyPatches,
+  enablePatches
+} from 'immer';
+
+enablePatches();
 
 export type ImmerAssigner<TContext, TEvent extends EventObject> = (
   context: Draft<TContext>,

--- a/packages/xstate-immer/test/immer.test.ts
+++ b/packages/xstate-immer/test/immer.test.ts
@@ -1,4 +1,3 @@
-// @ts-ignore
 import { createMachine, interpret } from 'xstate';
 import { assign, createUpdater, ImmerUpdateEvent } from '../src';
 

--- a/packages/xstate-immer/test/immer.test.ts
+++ b/packages/xstate-immer/test/immer.test.ts
@@ -134,7 +134,7 @@ describe('@xstate/immer', () => {
 
     const zeroState = countMachine.initialState;
 
-    const twoState = countMachine.transition(zeroState, bazUpdater(4));
+    const twoState = countMachine.transition(zeroState, bazUpdater.update(4));
 
     expect(zeroState.context.foo.bar.baz).toEqual([1, 2, 3]);
     expect(twoState.context.foo.bar.baz).toEqual([1, 2, 3, 4]);
@@ -161,8 +161,8 @@ describe('@xstate/immer', () => {
     });
 
     type FormEvent =
-      | ReturnType<typeof nameUpdater>
-      | ReturnType<typeof ageUpdater>
+      | ImmerUpdateEvent<'UPDATE_NAME', string>
+      | ImmerUpdateEvent<'UPDATE_AGE', number>
       | {
           type: 'SUBMIT';
         };
@@ -200,8 +200,8 @@ describe('@xstate/immer', () => {
       })
       .start();
 
-    service.send(nameUpdater('David'));
-    service.send(ageUpdater(0));
+    service.send(nameUpdater.update('David'));
+    service.send(ageUpdater.update(0));
 
     service.send('SUBMIT');
   });

--- a/packages/xstate-immer/test/immer.test.ts
+++ b/packages/xstate-immer/test/immer.test.ts
@@ -112,7 +112,7 @@ describe('@xstate/immer', () => {
     const bazUpdater = createUpdater<
       typeof context,
       ImmerUpdateEvent<'UPDATE_BAZ', number>
-    >('UPDATE_BAZ', (ctx, input) => {
+    >('UPDATE_BAZ', (ctx, { input }) => {
       ctx.foo.bar.baz.push(input);
     });
 
@@ -150,14 +150,14 @@ describe('@xstate/immer', () => {
 
     const nameUpdater = createUpdater<FormContext, NameUpdateEvent>(
       'UPDATE_NAME',
-      (ctx, input) => {
+      (ctx, { input }) => {
         ctx.name = input;
       }
     );
 
     const ageUpdater = createUpdater<FormContext, AgeUpdateEvent>(
       'UPDATE_AGE',
-      (ctx, input) => {
+      (ctx, { input }) => {
         ctx.age = input;
       }
     );

--- a/packages/xstate-immer/test/immer.test.ts
+++ b/packages/xstate-immer/test/immer.test.ts
@@ -125,7 +125,7 @@ describe('@xstate/immer', () => {
         active: {
           on: {
             [bazUpdater.type]: {
-              actions: bazUpdater.assign
+              actions: bazUpdater.action
             }
           }
         }
@@ -141,40 +141,46 @@ describe('@xstate/immer', () => {
   });
 
   it('should create updates (form example)', (done) => {
-    const context = {
-      name: '',
-      age: undefined as number | undefined
-    };
+    interface FormContext {
+      name: string;
+      age: number | undefined;
+    }
 
-    const nameUpdater = createUpdater<
-      typeof context,
-      ImmerUpdateEvent<'UPDATE_NAME', string>
-    >('UPDATE_NAME', (ctx, input) => {
-      ctx.name = input;
-    });
+    type NameUpdateEvent = ImmerUpdateEvent<'UPDATE_NAME', string>;
+    type AgeUpdateEvent = ImmerUpdateEvent<'UPDATE_AGE', number>;
 
-    const ageUpdater = createUpdater<
-      typeof context,
-      ImmerUpdateEvent<'UPDATE_AGE', number>
-    >('UPDATE_AGE', (ctx, input) => {
-      ctx.age = input;
-    });
+    const nameUpdater = createUpdater<FormContext, NameUpdateEvent>(
+      'UPDATE_NAME',
+      (ctx, input) => {
+        ctx.name = input;
+      }
+    );
+
+    const ageUpdater = createUpdater<FormContext, AgeUpdateEvent>(
+      'UPDATE_AGE',
+      (ctx, input) => {
+        ctx.age = input;
+      }
+    );
 
     type FormEvent =
-      | ImmerUpdateEvent<'UPDATE_NAME', string>
-      | ImmerUpdateEvent<'UPDATE_AGE', number>
+      | NameUpdateEvent
+      | AgeUpdateEvent
       | {
           type: 'SUBMIT';
         };
 
-    const formMachine = createMachine<typeof context, FormEvent>({
+    const formMachine = createMachine<FormContext, FormEvent>({
       initial: 'editing',
-      context,
+      context: {
+        name: '',
+        age: undefined
+      },
       states: {
         editing: {
           on: {
-            [nameUpdater.type]: { actions: nameUpdater.assign },
-            [ageUpdater.type]: { actions: ageUpdater.assign },
+            [nameUpdater.type]: { actions: nameUpdater.action },
+            [ageUpdater.type]: { actions: ageUpdater.action },
             SUBMIT: 'submitting'
           }
         },

--- a/packages/xstate-viz/package.json
+++ b/packages/xstate-viz/package.json
@@ -38,7 +38,7 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
-    "immer": "^5.0.0",
+    "immer": "^6.0.3",
     "styled-components": "^4.4.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7397,6 +7397,11 @@ immer@^5.0.0:
   resolved "https://registry.yarnpkg.com/immer/-/immer-5.3.6.tgz#51eab8cbbeb13075fe2244250f221598818cac04"
   integrity sha512-pqWQ6ozVfNOUDjrLfm4Pt7q4Q12cGw2HUZgry4Q5+Myxu9nmHRkWBpI0J4+MK0AxbdFtdMTwEGVl7Vd+vEiK+A==
 
+immer@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-6.0.3.tgz#94d5051cd724668160a900d66d85ec02816f29bd"
+  integrity sha512-12VvNrfSrXZdm/BJgi/KDW2soq5freVSf3I1+4CLunUM8mAGx2/0Njy0xBVzi5zewQZiwM7z1/1T+8VaI7NkmQ==
+
 import-cwd@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-cwd/-/import-cwd-2.1.0.tgz#aa6cf36e722761285cb371ec6519f53e2435b0a9"


### PR DESCRIPTION
This PR adds the initial implementation of `@xstate/immer`

```js
import { createMachine, interpret } from 'xstate';
import { assign, createUpdater } from '@xstate/immer';

const levelUpdater = createUpdater('UPDATE_LEVEL', (ctx, level) => {
  ctx.level = level;
});

const toggleMachine = createMachine({
  id: 'toggle',
  context: {
    count: 0,
    level: 0
  },
  initial: 'inactive',
  states: {
    inactive: {
      on: {
        TOGGLE: {
          target: 'active',
          // Immutably update context the same "mutable"
          // way as you would do with Immer!
          actions: assign((ctx) => ctx.count++)
        },
        // Use the updater for more convenience:
        [levelUpdater.type]: {
          actions: levelUpdater.action
        }
      }
    },
    active: {
      on: {
        TOGGLE: { target: 'inactive' }
      }
    }
  }
});

const toggleService = interpret(toggleMachine)
  .onTransition((state) => {
    console.log(state.context);
  })
  .start();

toggleService.send('TOGGLE');
// { count: 1, level: 0 }

toggleService.send(levelUpdater.update(9));
// { count: 1, level: 9 }

toggleService.send('TOGGLE');
// { count: 2, level: 9 }

toggleService.send(levelUpdater.update(-100));
// Notice how the level is not updated in 'inactive' state:
// { count: 2, level: 9 }
```