### PR TITLE
Fix UPDATE_COUNTRY action type to match

### DIFF
--- a/docs/packages/xstate-immer/index.md
+++ b/docs/packages/xstate-immer/index.md
@@ -141,7 +141,7 @@ const userMachine = createMachine({
   states: {
     active: {
       on: {
-        CHANGE_COUNTRY: {
+        UPDATE_COUNTRY: {
           actions: assign((context, event) => {
             context.address.country = event.value;
           })
@@ -155,7 +155,7 @@ const { initialState } = userMachine;
 
 const nextState = userMachine.transition(initialState, {
   type: 'UPDATE_COUNTRY',
-  country: 'USA'
+  value: 'USA'
 });
 
 nextState.context.address.country;


### PR DESCRIPTION
It looks like the machine is looking for an event with a `type` of `CHANGE_COUNTRY` and value in `value`, but the transition is being called with `UPDATE_COUNTRY` and a value in `country`. I've updated them to match.

Writing code that never runs in docs is hard.