### PR TITLE
Fixed an issue with `choose` and `pure` not being able to use actions defined in options

### DIFF
--- a/.changeset/tall-cars-provide.md
+++ b/.changeset/tall-cars-provide.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Fixed an issue with `choose` and `pure` not being able to use actions defined in options.

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -601,7 +601,7 @@ export function resolveActions<TContext, TEvent extends EventObject>(
             currentState,
             updatedContext,
             _event,
-            toActionObjects(toArray(matchedActions))
+            toActionObjects(toArray(matchedActions), machine.options.actions)
           );
           updatedContext = resolved[1];
           return resolved[0];
@@ -619,7 +619,7 @@ export function resolveActions<TContext, TEvent extends EventObject>(
             currentState,
             updatedContext,
             _event,
-            toActionObjects(toArray(matchedActions))
+            toActionObjects(toArray(matchedActions), machine.options.actions)
           );
           updatedContext = resolved[1];
           return resolved[0];

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -1292,4 +1292,31 @@ describe('choose', () => {
 
     expect(service.state.context).toEqual({ counter: 101, answer: 42 });
   });
+
+  it('should be able to use actions defined in options', () => {
+    interface Ctx {
+      answer?: number;
+    }
+
+    const machine = createMachine<Ctx>(
+      {
+        context: {},
+        initial: 'foo',
+        states: {
+          foo: {
+            entry: choose([{ cond: () => true, actions: 'revealAnswer' }])
+          }
+        }
+      },
+      {
+        actions: {
+          revealAnswer: assign<Ctx>({ answer: 42 })
+        }
+      }
+    );
+
+    const service = interpret(machine).start();
+
+    expect(service.state.context).toEqual({ answer: 42 });
+  });
 });


### PR DESCRIPTION
fixes #1152