### PR TITLE
Fix toJSON for transitions

### DIFF
--- a/.changeset/grumpy-deers-applaud.md
+++ b/.changeset/grumpy-deers-applaud.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Delayed transitions defined using `after` were previously causing a circular dependency when the machine was converted `.toJSON()`. This has now been fixed.

--- a/.changeset/grumpy-deers-applaud.md
+++ b/.changeset/grumpy-deers-applaud.md
@@ -2,4 +2,4 @@
 'xstate': patch
 ---
 
-Delayed transitions defined using `after` were previously causing a circular dependency when the machine was converted `.toJSON()`. This has now been fixed.
+Delayed transitions defined using `after` were previously causing a circular dependency when the machine was converted using `.toJSON()`. This has now been fixed.

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -1800,18 +1800,15 @@ class StateNode<
       target,
       source: this,
       internal,
-      eventType: transitionConfig.event
-    };
-
-    Object.defineProperty(transition, 'toJSON', {
-      value: () => ({
+      eventType: transitionConfig.event,
+      toJSON: () => ({
         ...transition,
         target: transition.target
           ? transition.target.map((t) => `#${t.id}`)
           : undefined,
         source: `#{this.id}`
       })
-    });
+    };
 
     return transition;
   }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -923,6 +923,13 @@ export interface TransitionDefinition<TContext, TEvent extends EventObject>
   actions: Array<ActionObject<TContext, TEvent>>;
   cond?: Guard<TContext, TEvent>;
   eventType: TEvent['type'] | NullEvent['type'] | '*';
+  toJSON: () => {
+    target: string[] | undefined;
+    source: string;
+    actions: Array<ActionObject<TContext, TEvent>>;
+    cond?: Guard<TContext, TEvent>;
+    eventType: TEvent['type'] | NullEvent['type'] | '*';
+  };
 }
 
 export type TransitionDefinitionMap<TContext, TEvent extends EventObject> = {

--- a/packages/core/test/json.test.ts
+++ b/packages/core/test/json.test.ts
@@ -48,6 +48,9 @@ describe('json', () => {
               target: ['foo', 'bar'],
               cond: (ctx) => !!ctx.string
             }
+          },
+          after: {
+            1000: 'bar'
           }
         },
         foo: {},


### PR DESCRIPTION
This PR fixes `.toJSON()` for machines containing delayed transitions defined in `after` (and elsewhere).