### PR TITLE
Fix erroneously inherited execute = false option

### DIFF
--- a/.changeset/early-elephants-whisper.md
+++ b/.changeset/early-elephants-whisper.md
@@ -3,3 +3,14 @@
 ---
 
 By default, spawned machines will now have `execute: true` to prevent edge-cases where the parent service is configured with `execute: false` and this is (erroneously) set for invoked child services.
+
+If you were relying on this unintentional behavior to prevent invoked machines from executing their actions, the `execute: false` option can be set in the `invoke` config:
+
+```js
+// ...
+invoke: {
+  src: someMachine,
+  execute: false
+}
+// ...
+```

--- a/.changeset/early-elephants-whisper.md
+++ b/.changeset/early-elephants-whisper.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+By default, spawned machines will now have `execute: true` to prevent edge-cases where the parent service is configured with `execute: false` and this is (erroneously) set for invoked child services.

--- a/docs/guides/interpretation.md
+++ b/docs/guides/interpretation.md
@@ -27,7 +27,7 @@ import { Machine, interpret } from 'xstate';
 const machine = Machine(/* machine config */);
 
 // Interpret the machine, and add a listener for whenever a transition occurs.
-const service = interpret(machine).onTransition(state => {
+const service = interpret(machine).onTransition((state) => {
   console.log(state.value);
 });
 
@@ -115,7 +115,7 @@ Listeners for state transitions are registered via the `.onTransition(...)` meth
 const service = interpret(machine);
 
 // Add a state listener, which is called whenever a state transition occurs.
-service.onTransition(state => {
+service.onTransition((state) => {
   console.log(state.value);
 });
 
@@ -127,7 +127,7 @@ service.start();
 If you only want the `.onTransition(...)` handler(s) to be called when the state changes (that is, when the `state.value` changes, the `state.context` changes, or there are new `state.actions`), use [`state.changed`](https://xstate.js.org/docs/guides/states.html#state-changed):
 
 ```js {2}
-service.onTransition(state => {
+service.onTransition((state) => {
   if (state.changed) {
     console.log(state.value);
   }
@@ -172,7 +172,7 @@ const service = interpret(machine, {
   execute: false // do not execute actions on state transitions
 });
 
-service.onTransition(state => {
+service.onTransition((state) => {
   // execute actions on next animation frame
   // instead of immediately
   requestAnimationFrame(() => service.execute(state));
@@ -180,6 +180,21 @@ service.onTransition(state => {
 
 service.start();
 ```
+
+::: warning
+
+If you want to prevent [invoked machines](./communication.md#invoking-machines) from executing, you must explicitly set `execute: false` in the `invoke` config:
+
+```js {4}
+// ...
+invoke: {
+  src: someMachine,
+  execute: false
+}
+// ...
+```
+
+:::
 
 ## Options
 
@@ -215,13 +230,13 @@ function send(event) {
   // Get the side-effect actions to execute
   const { actions } = currentState;
 
-  actions.forEach(action => {
+  actions.forEach((action) => {
     // If the action is executable, execute it
     action.exec && action.exec();
   });
 
   // Notify the listeners
-  listeners.forEach(listener => listener(currentState));
+  listeners.forEach((listener) => listener(currentState));
 }
 
 function listen(listener) {
@@ -233,7 +248,7 @@ function unlisten(listener) {
 }
 
 // Now you can listen and send events to update state
-listen(state => {
+listen((state) => {
   console.log(state.value);
 });
 
@@ -247,7 +262,7 @@ send('SOME_EVENT');
 
 ```js
 const service = interpret(machine)
-  .onTransition(state => console.log(state))
+  .onTransition((state) => console.log(state))
   .onDone(() => console.log('done'))
   .start(); // returns started service
 ```

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -827,7 +827,7 @@ export class Interpreter<
             ? this.machine.options.services[activity.src]
             : undefined;
 
-          const { id, data } = activity;
+          const { id, data, execute = true } = activity;
 
           if (!IS_PRODUCTION) {
             warn(
@@ -875,7 +875,8 @@ export class Interpreter<
                 : source,
               {
                 id,
-                autoForward
+                autoForward,
+                execute
               }
             );
           } else {

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -83,7 +83,11 @@ interface SpawnOptions {
   sync?: boolean;
 }
 
-const DEFAULT_SPAWN_OPTIONS = { sync: false, autoForward: false };
+const DEFAULT_SPAWN_OPTIONS = {
+  sync: false,
+  autoForward: false,
+  execute: true
+};
 
 /**
  * Maintains a stack of the current service in scope.
@@ -951,18 +955,24 @@ export class Interpreter<
     TChildEvent extends EventObject
   >(
     machine: StateMachine<TChildContext, TChildStateSchema, TChildEvent>,
-    options: { id?: string; autoForward?: boolean; sync?: boolean } = {}
+    options: {
+      id?: string;
+      autoForward?: boolean;
+      sync?: boolean;
+      execute?: boolean;
+    } = {}
   ): Interpreter<TChildContext, TChildStateSchema, TChildEvent> {
-    const childService = new Interpreter(machine, {
-      ...this.options, // inherit options from this interpreter
-      parent: this,
-      id: options.id || machine.id
-    });
-
     const resolvedOptions = {
+      ...this.options, // inherit options from this interpreter
       ...DEFAULT_SPAWN_OPTIONS,
       ...options
     };
+
+    const childService = new Interpreter(machine, {
+      ...resolvedOptions,
+      parent: this,
+      id: options.id || machine.id
+    });
 
     if (resolvedOptions.sync) {
       childService.onTransition((state) => {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -254,6 +254,10 @@ export interface InvokeDefinition<TContext, TEvent extends EventObject>
    * Data should be mapped to match the child machine's context shape.
    */
   data?: Mapper<TContext, TEvent> | PropertyMapper<TContext, TEvent>;
+  /**
+   * Whether state actions should be executed immediately upon transition. Defaults to `true`.
+   */
+  execute?: boolean;
 }
 
 export interface Delay {
@@ -387,6 +391,12 @@ export type InvokeConfig<TContext, TEvent extends EventObject> =
        *  Use `autoForward` property instead of `forward`. Support for `forward` will get removed in the future.
        */
       forward?: boolean;
+      /**
+       * If `false`, actions on the invoked machine will not be executed.
+       *
+       * Default: `true`
+       */
+      execute?: boolean;
       /**
        * Data from the parent machine's context to set as the (partial or full) context
        * for the invoked child machine.

--- a/packages/core/test/interpreter.test.ts
+++ b/packages/core/test/interpreter.test.ts
@@ -1525,6 +1525,45 @@ Event: {\\"type\\":\\"SOME_EVENT\\"}"
           service.execute(state);
         });
       });
+
+      it('execute option should be configurable for invoked machines', (done) => {
+        const childMachine = createMachine({
+          initial: 'active',
+          states: {
+            active: {
+              entry: () => {
+                throw new Error('action executed on childMachine');
+              }
+            }
+          }
+        });
+
+        const parentMachine = createMachine({
+          initial: 'started',
+          states: {
+            started: {
+              invoke: {
+                src: childMachine,
+                execute: false
+              },
+              on: {
+                EVENT: 'success'
+              }
+            },
+            success: { type: 'final' }
+          }
+        });
+
+        const service = interpret(parentMachine)
+          .onDone(() => {
+            done();
+          })
+          .start();
+
+        setTimeout(() => {
+          service.send('EVENT');
+        }, 20);
+      });
     });
 
     describe('id', () => {

--- a/packages/core/test/interpreter.test.ts
+++ b/packages/core/test/interpreter.test.ts
@@ -1497,6 +1497,34 @@ Event: {\\"type\\":\\"SOME_EVENT\\"}"
           })
           .start();
       });
+
+      it('execute = false should not be inherited by spawned machines', (done) => {
+        const childMachine = createMachine({
+          initial: 'active',
+          states: {
+            active: {
+              entry: () => {
+                done();
+              }
+            }
+          }
+        });
+
+        const parentMachine = createMachine({
+          initial: 'started',
+          states: {
+            started: {
+              invoke: childMachine
+            }
+          }
+        });
+
+        const service = interpret(parentMachine, { execute: false }).start();
+
+        service.subscribe((state) => {
+          service.execute(state);
+        });
+      });
     });
 
     describe('id', () => {


### PR DESCRIPTION
Closes #1125, closes #1161 (issues observed with `@xstate/react@next` which has `execute: false`)