### PR TITLE
Update rollup config for esm build

### DIFF
--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -18,7 +18,12 @@ const createNpmConfig = ({ input, output }) => ({
   input,
   output,
   preserveModules: true,
-  plugins: [createTsPlugin()]
+  plugins: [
+    rollupReplace({
+      'process.env.NODE_ENV': JSON.stringify('production')
+    }),
+    createTsPlugin()
+  ]
 });
 
 const createUmdConfig = ({ input, output, target = undefined }) => ({


### PR DESCRIPTION
I was trying to use the es module of xstate in my `index.mjs` file without any bundler:

```js
import {
  createMachine,
  interpret,
} from "https://unpkg.com/xstate@4.9.1/es/index.js";

```
And I got this error:

![image](https://user-images.githubusercontent.com/1091472/80790047-61433e80-8bc0-11ea-90a1-6143d3e236e8.png)

![image](https://user-images.githubusercontent.com/1091472/80790060-6acca680-8bc0-11ea-8af3-75219e3f13ed.png)

Because `process` does not exist in browser.

Enable `rollup-plugin-replace` for rollup would fix the `esm` build.