### PR TITLE
Updated the promise example

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ const fetchMachine = createMachine({
       invoke: {
         id: 'fetchLuke',
         src: (context, event) =>
-          fetch('https://swapi.co/api/people/1').then((data) => data.json()),
+          fetch('https://swapi.dev/api/people/1').then((res) => res.data),
         onDone: {
           target: 'resolved',
           actions: assign({
@@ -106,6 +106,12 @@ const fetchMachine = createMachine({
     }
   }
 });
+
+const swService = interpret(fetchMachine)
+  .onTransition((state) => console.log(state.value))
+  .start();
+
+swService.send('FETCH');
 ```
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->


### PR DESCRIPTION
- Using the new official swapi URL (`https://swapi.dev`)
- Returning data based on received data structure (`res.data` instead of `data.json()`)
- Added an example `.send('FETCH')` call to service

Note: since this is just a readme update, I didn't include a changeset, since I wasn't sure which module to select in the interactive CLI. Happy to go back and do that if you want a changeset included for readme updates. In that case, please let me know which modules I should select in the CLI.