### PR TITLE
Fix types for send() and sendParent()

### DIFF
--- a/.changeset/blue-needles-accept.md
+++ b/.changeset/blue-needles-accept.md
@@ -2,4 +2,4 @@
 'xstate': minor
 ---
 
-The types for the `send()` and `sendParent()` action creators have been changed to fix the issue of only being able to send events that the machine can receive. In reality, a machine can and should send events to other actors that it might not be able to receive itself. See #711 for more information.
+The types for the `send()` and `sendParent()` action creators have been changed to fix the issue of only being able to send events that the machine can receive. In reality, a machine can and should send events to other actors that it might not be able to receive itself. See [#711](https://github.com/davidkpiano/xstate/issues/711) for more information.

--- a/.changeset/blue-needles-accept.md
+++ b/.changeset/blue-needles-accept.md
@@ -1,0 +1,5 @@
+---
+'xstate': minor
+---
+
+The types for the `send()` and `sendParent()` action creators have been changed to fix the issue of only being able to send events that the machine can receive. In reality, a machine can and should send events to other actors that it might not be able to receive itself. See #711 for more information.

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -1150,7 +1150,7 @@ class StateNode<
         action
       ): action is
         | RaiseActionObject<TEvent>
-        | SendActionObject<TContext, TEvent> =>
+        | SendActionObject<TContext, TEvent, TEvent> =>
         action.type === actionTypes.raise ||
         (action.type === actionTypes.send &&
           (action as SendActionObject<TContext, TEvent>).to ===

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -32,7 +32,8 @@ import {
   SCXML,
   ExprWithMeta,
   ChooseConditon,
-  ChooseAction
+  ChooseAction,
+  AnyEventObject
 } from './types';
 import * as actionTypes from './actionTypes';
 import {
@@ -158,7 +159,7 @@ export function toActivityDefinition<TContext, TEvent extends EventObject>(
  */
 export function raise<TContext, TEvent extends EventObject>(
   event: Event<TEvent>
-): RaiseAction<TEvent> | SendAction<TContext, TEvent> {
+): RaiseAction<TEvent> | SendAction<TContext, TEvent, TEvent> {
   if (!isString(event)) {
     return send(event, { to: SpecialTargets.Internal });
   }
@@ -187,30 +188,38 @@ export function resolveRaise<TEvent extends EventObject>(
  *  - `delay` - The number of milliseconds to delay the sending of the event.
  *  - `to` - The target of this event (by default, the machine the event was sent from).
  */
-export function send<TContext, TEvent extends EventObject>(
-  event: Event<TEvent> | SendExpr<TContext, TEvent>,
+export function send<
+  TContext,
+  TEvent extends EventObject,
+  TSentEvent extends EventObject = AnyEventObject
+>(
+  event: Event<TSentEvent> | SendExpr<TContext, TEvent, TSentEvent>,
   options?: SendActionOptions<TContext, TEvent>
-): SendAction<TContext, TEvent> {
+): SendAction<TContext, TEvent, TSentEvent> {
   return {
     to: options ? options.to : undefined,
     type: actionTypes.send,
-    event: isFunction(event) ? event : toEventObject<TEvent>(event),
+    event: isFunction(event) ? event : toEventObject<TSentEvent>(event),
     delay: options ? options.delay : undefined,
     id:
       options && options.id !== undefined
         ? options.id
         : isFunction(event)
         ? event.name
-        : (getEventType<TEvent>(event) as string)
+        : (getEventType<TSentEvent>(event) as string)
   };
 }
 
-export function resolveSend<TContext, TEvent extends EventObject>(
-  action: SendAction<TContext, TEvent>,
+export function resolveSend<
+  TContext,
+  TEvent extends EventObject,
+  TSentEvent extends EventObject
+>(
+  action: SendAction<TContext, TEvent, TSentEvent>,
   ctx: TContext,
   _event: SCXML.Event<TEvent>,
   delaysMap?: DelayFunctionMap<TContext, TEvent>
-): SendActionObject<TContext, TEvent> {
+): SendActionObject<TContext, TEvent, TSentEvent> {
   const meta = {
     _event
   };
@@ -253,11 +262,15 @@ export function resolveSend<TContext, TEvent extends EventObject>(
  * @param event The event to send to the parent machine.
  * @param options Options to pass into the send event.
  */
-export function sendParent<TContext, TEvent extends EventObject>(
-  event: Event<any> | SendExpr<TContext, TEvent>,
+export function sendParent<
+  TContext,
+  TEvent extends EventObject,
+  TSentEvent extends EventObject = AnyEventObject
+>(
+  event: Event<TSentEvent> | SendExpr<TContext, TEvent, TSentEvent>,
   options?: SendActionOptions<TContext, TEvent>
-): SendAction<TContext, TEvent> {
-  return send<TContext, TEvent>(event, {
+): SendAction<TContext, TEvent, TSentEvent> {
+  return send<TContext, TEvent, TSentEvent>(event, {
     ...options,
     to: SpecialTargets.Parent
   });
@@ -268,9 +281,12 @@ export function sendParent<TContext, TEvent extends EventObject>(
  */
 export function sendUpdate<TContext, TEvent extends EventObject>(): SendAction<
   TContext,
-  TEvent
+  TEvent,
+  { type: ActionTypes.Update }
 > {
-  return sendParent<TContext, TEvent>(actionTypes.update);
+  return sendParent<TContext, TEvent, { type: ActionTypes.Update }>(
+    actionTypes.update
+  );
 }
 
 /**
@@ -279,8 +295,12 @@ export function sendUpdate<TContext, TEvent extends EventObject>(): SendAction<
  * @param event The event to send back to the sender
  * @param options Options to pass into the send event
  */
-export function respond<TContext, TEvent extends EventObject>(
-  event: Event<TEvent> | SendExpr<TContext, TEvent>,
+export function respond<
+  TContext,
+  TEvent extends EventObject,
+  TSentEvent extends EventObject = AnyEventObject
+>(
+  event: Event<TEvent> | SendExpr<TContext, TEvent, TSentEvent>,
   options?: SendActionOptions<TContext, TEvent>
 ) {
   return send<TContext, TEvent>(event, {
@@ -482,7 +502,7 @@ export function pure<TContext, TEvent extends EventObject>(
 export function forwardTo<TContext, TEvent extends EventObject>(
   target: Required<SendActionOptions<TContext, TEvent>>['to'],
   options?: SendActionOptions<TContext, TEvent>
-): SendAction<TContext, TEvent> {
+): SendAction<TContext, TEvent, AnyEventObject> {
   return send<TContext, TEvent>((_, event) => event, {
     ...options,
     to: target
@@ -503,7 +523,7 @@ export function escalate<
 >(
   errorData: TErrorData | ExprWithMeta<TContext, TEvent, TErrorData>,
   options?: SendActionOptions<TContext, TEvent>
-): SendAction<TContext, TEvent> {
+): SendAction<TContext, TEvent, AnyEventObject> {
   return sendParent<TContext, TEvent>(
     (context, event, meta) => {
       return {
@@ -553,7 +573,7 @@ export function resolveActions<TContext, TEvent extends EventObject>(
           return resolveRaise(actionObject as RaiseAction<TEvent>);
         case actionTypes.send:
           const sendAction = resolveSend(
-            actionObject as SendAction<TContext, TEvent>,
+            actionObject as SendAction<TContext, TEvent, AnyEventObject>,
             updatedContext,
             _event,
             machine.options.delays

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -27,7 +27,8 @@ import {
   EventData,
   Observer,
   Spawnable,
-  Typestate
+  Typestate,
+  AnyEventObject
 } from './types';
 import { State, bindActionToState, isState } from './State';
 import * as actionTypes from './actionTypes';
@@ -670,7 +671,7 @@ export class Interpreter<
   }
 
   private sendTo = (
-    event: SCXML.Event<TEvent>,
+    event: SCXML.Event<AnyEventObject>,
     to: string | number | Actor
   ) => {
     const isParent =
@@ -700,7 +701,7 @@ export class Interpreter<
 
     if ('machine' in target) {
       // Send SCXML events to machines
-      (target as Interpreter<TContext, TStateSchema, TEvent>).send({
+      (target as Interpreter<any, any, any>).send({
         ...event,
         name:
           event.name === actionTypes.error ? `${error(this.id)}` : event.name,
@@ -756,7 +757,9 @@ export class Interpreter<
       if (sendAction.to) {
         this.sendTo(sendAction._event, sendAction.to);
       } else {
-        this.send(sendAction._event);
+        this.send(
+          (sendAction as SendActionObject<TContext, TEvent, TEvent>)._event
+        );
       }
     }, sendAction.delay as number);
   }
@@ -808,7 +811,9 @@ export class Interpreter<
           if (sendAction.to) {
             this.sendTo(sendAction._event, sendAction.to);
           } else {
-            this.send(sendAction._event);
+            this.send(
+              (sendAction as SendActionObject<TContext, TEvent, TEvent>)._event
+            );
           }
         }
         break;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -75,7 +75,7 @@ type Action<TContext, TEvent extends EventObject> =
   | ActionObject<TContext, TEvent>
   | ActionFunction<TContext, TEvent>
   | AssignAction<Required<TContext>, TEvent>
-  | SendAction<TContext, AnyEventObject>
+  | SendAction<TContext, TEvent, AnyEventObject>
   | RaiseAction<AnyEventObject>
   | ChooseAction<TContext, TEvent>;
 
@@ -810,24 +810,30 @@ export interface LogActionObject<TContext, TEvent extends EventObject>
   value: any;
 }
 
-export interface SendAction<TContext, TEvent extends EventObject>
-  extends ActionObject<TContext, TEvent> {
+export interface SendAction<
+  TContext,
+  TEvent extends EventObject,
+  TSentEvent extends EventObject
+> extends ActionObject<TContext, TEvent> {
   to:
     | string
     | number
     | Actor
     | ExprWithMeta<TContext, TEvent, string | number | Actor>
     | undefined;
-  event: TEvent | SendExpr<TContext, TEvent>;
+  event: TSentEvent | SendExpr<TContext, TEvent, TSentEvent>;
   delay?: number | string | DelayExpr<TContext, TEvent>;
   id: string | number;
 }
 
-export interface SendActionObject<TContext, TEvent extends EventObject>
-  extends SendAction<TContext, TEvent> {
+export interface SendActionObject<
+  TContext,
+  TEvent extends EventObject,
+  TSentEvent extends EventObject = AnyEventObject
+> extends SendAction<TContext, TEvent, TSentEvent> {
   to: string | number | Actor | undefined;
-  _event: SCXML.Event<TEvent>;
-  event: TEvent;
+  _event: SCXML.Event<TSentEvent>;
+  event: TSentEvent;
   delay?: number;
   id: string | number;
 }
@@ -843,11 +849,11 @@ export type ExprWithMeta<TContext, TEvent extends EventObject, T> = (
   meta: SCXMLEventMeta<TEvent>
 ) => T;
 
-export type SendExpr<TContext, TEvent extends EventObject> = ExprWithMeta<
+export type SendExpr<
   TContext,
-  TEvent,
-  TEvent
->;
+  TEvent extends EventObject,
+  TSentEvent extends EventObject = AnyEventObject
+> = ExprWithMeta<TContext, TEvent, TSentEvent>;
 
 export enum SpecialTargets {
   Parent = '#_parent',

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -8,7 +8,7 @@ import {
 } from '../src/index';
 import { pure, sendParent, log, choose } from '../src/actions';
 
-describe('onEntry/onExit actions', () => {
+describe('entry/exit actions', () => {
   const pedestrianStates = {
     initial: 'walk',
     states: {
@@ -1318,5 +1318,28 @@ describe('choose', () => {
     const service = interpret(machine).start();
 
     expect(service.state.context).toEqual({ answer: 42 });
+  });
+});
+
+describe('sendParent', () => {
+  // https://github.com/davidkpiano/xstate/issues/711
+  it('TS: should compile for any event', () => {
+    interface ChildContext {}
+    interface ChildEvent {
+      type: 'CHILD';
+    }
+
+    const child = Machine<ChildContext, any, ChildEvent>({
+      id: 'child',
+      initial: 'start',
+      states: {
+        start: {
+          // This should not be a TypeScript error
+          entry: [sendParent({ type: 'PARENT' })]
+        }
+      }
+    });
+
+    expect(child).toBeTruthy();
   });
 });


### PR DESCRIPTION
This PR fixes the generic types for `send()` and `sendParent()` action creators to accept a third generic type: `TSentEvent`, which represents the event to be sent, which can be (and usually is) different than what the sending machine accepts.

Fixes #711