### PR TITLE
Typo: doesn't exist -> already exists (for clarity)

### DIFF
--- a/docs/tutorials/reddit.md
+++ b/docs/tutorials/reddit.md
@@ -468,7 +468,7 @@ const redditMachine = Machine({
     SELECT: {
       target: '.selected',
       actions: assign((context, event) => {
-        // Use the existing subreddit actor if one doesn't exist
+        // Use the existing subreddit actor if one already exists
         let subreddit = context.subreddits[event.name];
 
         if (subreddit) {


### PR DESCRIPTION
I found this line confusing
// Use the existing subreddit actor if one doesn't exist
so I propose changing it to:
// Use the existing subreddit actor if one already exists