### PR TITLE
Ensure actions are executed from a restored initial state.

### DIFF
--- a/.changeset/wet-swans-deny.md
+++ b/.changeset/wet-swans-deny.md
@@ -1,0 +1,5 @@
+---
+'xstate': minor
+---
+
+Actions from a restored state provided as a custom initial state to `interpret(machine).start(initialState)` are now executed properly. See #1174 for more information.

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -770,11 +770,12 @@ export class Interpreter<
   private exec(
     action: ActionObject<TContext, TEvent>,
     state: State<TContext, TEvent, TStateSchema, TTypestate>,
-    actionFunctionMap?: ActionFunctionMap<TContext, TEvent>
+    actionFunctionMap: ActionFunctionMap<TContext, TEvent> = this.machine
+      .options.actions
   ): void {
     const { context, _event } = state;
     const actionOrExec =
-      getActionFunction(action.type, actionFunctionMap) || action.exec;
+      action.exec || getActionFunction(action.type, actionFunctionMap);
     const exec = isFunction(actionOrExec)
       ? actionOrExec
       : actionOrExec

--- a/packages/core/test/interpreter.test.ts
+++ b/packages/core/test/interpreter.test.ts
@@ -120,7 +120,7 @@ describe('interpreter', () => {
     });
 
     // https://github.com/davidkpiano/xstate/issues/1174
-    it('executes actions from a restored initial state', (done) => {
+    it('executes actions from a restored state', (done) => {
       const lightMachine = Machine(
         {
           id: 'light',


### PR DESCRIPTION
The issue was that when restoring from an initial state, `state.actions` weren't being resolved against the specified `machine.options.actions` action mapping, so actions weren't being executed.

Fixes #1174