### PR TITLE
Fixed an issue with invoked service not being correctly started

### DIFF
--- a/.changeset/great-toes-vanish.md
+++ b/.changeset/great-toes-vanish.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Fixed an issue with invoked service not being correctly started if other service got stopped in a subsequent microstep (in response to raised or null event).

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -1127,12 +1127,11 @@ class StateNode<
     const activities = currentState ? { ...currentState.activities } : {};
     for (const action of actions) {
       if (action.type === actionTypes.start) {
-        activities[action.activity!.type] = action as ActivityDefinition<
-          TContext,
-          TEvent
-        >;
+        activities[
+          action.activity!.id || action.activity!.type
+        ] = action as ActivityDefinition<TContext, TEvent>;
       } else if (action.type === actionTypes.stop) {
-        activities[action.activity!.type] = false;
+        activities[action.activity!.id || action.activity!.type] = false;
       }
     }
 

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -830,7 +830,7 @@ export class Interpreter<
         // If the activity will be stopped right after it's started
         // (such as in transient states)
         // don't bother starting the activity.
-        if (!this.state.activities[activity.type]) {
+        if (!this.state.activities[activity.id || activity.type]) {
           break;
         }
 

--- a/packages/core/test/invoke.test.ts
+++ b/packages/core/test/invoke.test.ts
@@ -5,13 +5,15 @@ import {
   sendParent,
   send,
   EventObject,
-  StateValue
+  StateValue,
+  createMachine
 } from '../src';
 import {
   actionTypes,
   done as _done,
   doneInvoke,
-  escalate
+  escalate,
+  raise
 } from '../src/actions';
 import { interval } from 'rxjs';
 import { map, take } from 'rxjs/operators';
@@ -2177,7 +2179,7 @@ describe('invoke', () => {
       service.start();
     });
 
-    it('should not invoke a service if transient', (done) => {
+    it('should not invoke a service if it gets stopped immediately by transitioning away in microstep', (done) => {
       // Since an invocation will be canceled when the state machine leaves the
       // invoking state, it does not make sense to start an invocation in a state
       // that will be exited immediately
@@ -2214,6 +2216,65 @@ describe('invoke', () => {
           done();
         })
         .start();
+    });
+
+    it('should invoke a service if other service gets stopped in subsequent microstep (#1180)', (done) => {
+      const machine = createMachine({
+        initial: 'running',
+        states: {
+          running: {
+            type: 'parallel',
+            states: {
+              one: {
+                initial: 'active',
+                on: {
+                  STOP_ONE: '.idle'
+                },
+                states: {
+                  idle: {},
+                  active: {
+                    invoke: {
+                      id: 'active',
+                      src: () => () => {}
+                    },
+                    on: {
+                      NEXT: {
+                        actions: raise('STOP_ONE')
+                      }
+                    }
+                  }
+                }
+              },
+              two: {
+                initial: 'idle',
+                on: {
+                  NEXT: '.active'
+                },
+                states: {
+                  idle: {},
+                  active: {
+                    invoke: {
+                      id: 'post',
+                      src: () => Promise.resolve(42),
+                      onDone: '#done'
+                    }
+                  }
+                }
+              }
+            }
+          },
+          done: {
+            id: 'done',
+            type: 'final'
+          }
+        }
+      });
+
+      const service = interpret(machine)
+        .onDone(() => done())
+        .start();
+
+      service.send('NEXT');
     });
   });
 


### PR DESCRIPTION
fixes #1180

Problem was that for invoked services `action.activity.type` is always equal to `xstate.invoke` and thus all invoked services were registered/deregistered under the same key in `state.activities`, which led to a problem of an invoked service not being started when another invoked service has been stopped in following microstep because we only start services when machine settles macrostep to avoid starting services unnecessarily.

cc @jschppll