### PR TITLE
Work around erroneously inherited execute = false option

### DIFF
--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -146,7 +146,8 @@ export class Interpreter<
       }
     },
     logger: global.console.log.bind(console),
-    devTools: false
+    devTools: false,
+    childOptions: {}
   }))(typeof window === 'undefined' ? global : window);
   /**
    * The current state of the interpreted machine.
@@ -971,16 +972,17 @@ export class Interpreter<
     machine: StateMachine<TChildContext, TChildStateSchema, TChildEvent>,
     options: { id?: string; autoForward?: boolean; sync?: boolean } = {}
   ): Interpreter<TChildContext, TChildStateSchema, TChildEvent> {
-    const childService = new Interpreter(machine, {
-      ...this.options, // inherit options from this interpreter
-      parent: this,
-      id: options.id || machine.id
-    });
-
     const resolvedOptions = {
       ...DEFAULT_SPAWN_OPTIONS,
       ...options
     };
+
+    const childService = new Interpreter(machine, {
+      ...this.options, // inherit options from this interpreter
+      ...this.options.childOptions, // override parent options if specified
+      parent: this,
+      id: options.id || machine.id
+    });
 
     if (resolvedOptions.sync) {
       childService.onTransition((state) => {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1065,6 +1065,16 @@ export interface InterpreterOptions {
    * Whether state actions should be executed immediately upon transition. Defaults to `true`.
    */
   execute: boolean;
+  /**
+   * The default interpreter options for invoked machines.
+   * Overrides the defaults inherited from this parent.
+   */
+  childOptions: {
+    /**
+     * Whether state actions for invoked machines should be executed immediately upon transition.
+     */
+    execute?: boolean;
+  };
   clock: Clock;
   logger: (...args: any[]) => void;
   parent?: Interpreter<any, any, any>;

--- a/packages/core/test/interpreter.test.ts
+++ b/packages/core/test/interpreter.test.ts
@@ -1911,4 +1911,43 @@ Event: {\\"type\\":\\"SOME_EVENT\\"}"
       service.start();
     });
   });
+
+  it('execute = false should not be inherited by spawned machines', (done) => {
+    let called = false;
+
+    const childMachine = createMachine({
+      initial: 'active',
+      states: {
+        active: {
+          entry: () => {
+            done();
+          }
+        }
+      }
+    });
+
+    const parentMachine = createMachine({
+      initial: 'started',
+      states: {
+        started: {
+          entry: () => {
+            called = true;
+          },
+          invoke: childMachine
+        }
+      }
+    });
+
+    const service = interpret(parentMachine, {
+      execute: false,
+      childOptions: {
+        execute: true
+      }
+    }).start();
+
+    service.subscribe((state) => {
+      expect(called).toBeFalsy();
+      service.execute(state);
+    });
+  });
 });


### PR DESCRIPTION
Closes #1125, closes #1161 (issues observed with `@xstate/react@next` which has `execute: false`).

This is an alternative for #1162 that introduces no breaking changes.

The `childOptions` option will not be documented, as it is a temporary fix that will be deprecated in version 5.