### PR TITLE
Pass invoke.data as meta argument to service creators. Closes #529

### DIFF
--- a/.changeset/thirty-tomatoes-jump.md
+++ b/.changeset/thirty-tomatoes-jump.md
@@ -1,0 +1,36 @@
+---
+'xstate': minor
+---
+
+The resolved value of the `invoke.data` property is now available in the "invoke meta" object, which is passed as the 3rd argument to the service creator in `options.services`. This will work for all types of invoked services now, including promises, observables, and callbacks. The behavior of `invoke.data` with invoked machines is unchanged.
+
+```js
+const machine = createMachine({
+  initial: 'pending',
+  context: {
+    id: 42
+  },
+  states: {
+    pending: {
+      invoke: {
+        src: 'fetchUser',
+        data: {
+          userId: (context) => context.id
+        },
+        onDone: 'success'
+      }
+    },
+    success: {
+      type: 'final'
+    }
+  }
+},
+{
+  services: {
+    fetchUser: (ctx, _, { data }) => {
+      return fetch(`some/api/user/${data.userId}`)
+        .then(response => response.json());
+    }
+  }
+}
+```

--- a/.changeset/thirty-tomatoes-jump.md
+++ b/.changeset/thirty-tomatoes-jump.md
@@ -2,7 +2,7 @@
 'xstate': minor
 ---
 
-The resolved value of the `invoke.data` property is now available in the "invoke meta" object, which is passed as the 3rd argument to the service creator in `options.services`. This will work for all types of invoked services now, including promises, observables, and callbacks. The behavior of `invoke.data` with invoked machines is unchanged.
+The resolved value of the `invoke.data` property is now available in the "invoke meta" object, which is passed as the 3rd argument to the service creator in `options.services`. This will work for all types of invoked services now, including promises, observables, and callbacks.
 
 ```js
 const machine = createMachine({

--- a/docs/guides/communication.md
+++ b/docs/guides/communication.md
@@ -72,8 +72,8 @@ If the state where the invoked promise is active is exited before the promise se
 // Function that returns a promise
 // This promise might resolve with, e.g.,
 // { name: 'David', location: 'Florida' }
-const fetchUser = userId =>
-  fetch(`url/to/user/${userId}`).then(response => response.json());
+const fetchUser = (userId) =>
+  fetch(`url/to/user/${userId}`).then((response) => response.json());
 
 const userMachine = Machine({
   id: 'user',
@@ -230,7 +230,7 @@ const pingPongMachine = Machine({
         src: (context, event) => (callback, onReceive) => {
           // Whenever parent sends 'PING',
           // send parent 'PONG' event
-          onReceive(e => {
+          onReceive((e) => {
             if (e.type === 'PING') {
               callback('PONG');
             }
@@ -273,7 +273,7 @@ const intervalMachine = Machine({
       invoke: {
         src: (context, event) =>
           interval(context.myInterval).pipe(
-            map(value => ({ type: 'COUNT', value })),
+            map((value) => ({ type: 'COUNT', value })),
             take(5)
           ),
         onDone: 'finished'
@@ -361,7 +361,7 @@ const parentMachine = Machine({
 });
 
 const service = interpret(parentMachine)
-  .onTransition(state => console.log(state.value))
+  .onTransition((state) => console.log(state.value))
   .start();
 // => 'pending'
 // ... after 1 minute
@@ -476,7 +476,7 @@ const parentMachine = Machine({
 });
 
 const service = interpret(parentMachine)
-  .onTransition(state => console.log(state.context))
+  .onTransition((state) => console.log(state.context))
   .start();
 // => { revealedSecret: undefined }
 // ...
@@ -659,7 +659,7 @@ import { interpret } from 'xstate';
 import { assert } from 'chai';
 import { userMachine } from '../path/to/userMachine';
 
-const mockFetchUser = async userId => {
+const mockFetchUser = async (userId) => {
   // Mock however you want, but ensure that the same
   // behavior and response format is used
   return { name: 'Test', location: 'Anywhere' };
@@ -672,9 +672,9 @@ const testUserMachine = userMachine.withConfig({
 });
 
 describe('userMachine', () => {
-  it('should go to the "success" state when a user is found', done => {
+  it('should go to the "success" state when a user is found', (done) => {
     interpret(testUserMachine)
-      .onTransition(state => {
+      .onTransition((state) => {
         if (state.matches('success')) {
           assert.deepEqual(state.context.user, {
             name: 'Test',
@@ -704,7 +704,7 @@ const machine = Machine({
 });
 
 const service = invoke(machine)
-  .onTransition(state => {
+  .onTransition((state) => {
     state.children.notifier; // service from createNotifier()
     state.children.logger; // service from createLogger()
   })

--- a/docs/guides/communication.md
+++ b/docs/guides/communication.md
@@ -30,6 +30,7 @@ An invocation is defined in a state node's configuration with the `invoke` prope
   - the invoked observable completes
 - `onError` - (optional) the transition to be taken when the invoked service encounters an execution error.
 - `autoForward` - (optional) `true` if all events sent to this machine should also be sent (or _forwarded_) to the invoked child (`false` by default)
+  - ⚠️ Avoid setting `autoForward` to `true`, as blindly forwarding all events may lead to unexpected behavior and/or infinite loops. Always prefer to explicitly send events, and/or use the `forward(...)` action creator to directly forward an event to an invoked child.
 - `data` - (optional, used only when invoking machines) an object that maps properties of the child machine's [context](./context.md) to a function that returns the corresponding value from the parent machine's `context`.
 
 ::: warning

--- a/docs/guides/communication.md
+++ b/docs/guides/communication.md
@@ -72,8 +72,8 @@ If the state where the invoked promise is active is exited before the promise se
 // Function that returns a promise
 // This promise might resolve with, e.g.,
 // { name: 'David', location: 'Florida' }
-const fetchUser = (userId) =>
-  fetch(`url/to/user/${userId}`).then((response) => response.json());
+const fetchUser = userId =>
+  fetch(`url/to/user/${userId}`).then(response => response.json());
 
 const userMachine = Machine({
   id: 'user',
@@ -230,7 +230,7 @@ const pingPongMachine = Machine({
         src: (context, event) => (callback, onReceive) => {
           // Whenever parent sends 'PING',
           // send parent 'PONG' event
-          onReceive((e) => {
+          onReceive(e => {
             if (e.type === 'PING') {
               callback('PONG');
             }
@@ -273,7 +273,7 @@ const intervalMachine = Machine({
       invoke: {
         src: (context, event) =>
           interval(context.myInterval).pipe(
-            map((value) => ({ type: 'COUNT', value })),
+            map(value => ({ type: 'COUNT', value })),
             take(5)
           ),
         onDone: 'finished'
@@ -361,7 +361,7 @@ const parentMachine = Machine({
 });
 
 const service = interpret(parentMachine)
-  .onTransition((state) => console.log(state.value))
+  .onTransition(state => console.log(state.value))
   .start();
 // => 'pending'
 // ... after 1 minute
@@ -476,7 +476,7 @@ const parentMachine = Machine({
 });
 
 const service = interpret(parentMachine)
-  .onTransition((state) => console.log(state.context))
+  .onTransition(state => console.log(state.context))
   .start();
 // => { revealedSecret: undefined }
 // ...
@@ -556,7 +556,7 @@ const service = interpret(pingMachine).start();
 // ...
 ```
 
-## Sending Responses
+## Sending Responses <Badge text="4.7+" />
 
 An invoked service (or [spawned actor](./actors.md)) can _respond_ to another service/actor; i.e., it can send an event _in response to_ an event sent by another service/actor. This is done with the `respond(...)` action creator.
 
@@ -650,41 +650,6 @@ const userMachine = Machine({
 });
 ```
 
-## Passing Data to Services <Badge text="4.11+" />
-
-Configured services can be further customized by specifying data in the `invoke.data` property, which will be passed to the service creator in the 3rd "invoke meta" argument. This will be resolved with the current `context` so that the resolved data can be used to create any type of invoked service (promises, observables, callbacks, etc.).
-
-```js {10-12, 23}
-const machine = createMachine({
-  initial: 'pending',
-  context: {
-    id: 42
-  },
-  states: {
-    pending: {
-      invoke: {
-        src: 'fetchUser',
-        data: {
-          userId: (context) => context.id
-        },
-        onDone: 'success'
-      }
-    },
-    success: {
-      type: 'final'
-    }
-  }
-},
-{
-  services: {
-    fetchUser: (ctx, _, { data }) => {
-      return fetch(`some/api/user/${data.userId}`)
-        .then(response => response.json());
-    }
-  }
-}
-```
-
 ## Testing
 
 By specifying services as strings above, "mocking" services can be done by specifying an alternative implementation with `.withConfig()`:
@@ -694,7 +659,7 @@ import { interpret } from 'xstate';
 import { assert } from 'chai';
 import { userMachine } from '../path/to/userMachine';
 
-const mockFetchUser = async (userId) => {
+const mockFetchUser = async userId => {
   // Mock however you want, but ensure that the same
   // behavior and response format is used
   return { name: 'Test', location: 'Anywhere' };
@@ -707,9 +672,9 @@ const testUserMachine = userMachine.withConfig({
 });
 
 describe('userMachine', () => {
-  it('should go to the "success" state when a user is found', (done) => {
+  it('should go to the "success" state when a user is found', done => {
     interpret(testUserMachine)
-      .onTransition((state) => {
+      .onTransition(state => {
         if (state.matches('success')) {
           assert.deepEqual(state.context.user, {
             name: 'Test',
@@ -739,7 +704,7 @@ const machine = Machine({
 });
 
 const service = invoke(machine)
-  .onTransition((state) => {
+  .onTransition(state => {
     state.children.notifier; // service from createNotifier()
     state.children.logger; // service from createLogger()
   })

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -868,8 +868,12 @@ export class Interpreter<
             return;
           }
 
+          const resolvedData = data
+            ? mapContext(data, context, _event)
+            : undefined;
+
           const source = isFunction(serviceCreator)
-            ? serviceCreator(context, _event.data)
+            ? serviceCreator(context, _event.data, { data: resolvedData })
             : serviceCreator;
 
           if (isPromiseLike(source)) {
@@ -884,9 +888,7 @@ export class Interpreter<
           } else if (isMachine(source)) {
             // TODO: try/catch here
             this.state.children[id] = this.spawnMachine(
-              data
-                ? source.withContext(mapContext(data, context, _event))
-                : source,
+              data ? source.withContext(resolvedData) : source,
               {
                 id,
                 autoForward

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -203,6 +203,10 @@ export type InvokeCallback = (
   onReceive: Receiver<EventObject>
 ) => any;
 
+export interface InvokeMeta {
+  data: any;
+}
+
 /**
  * Returns either a Promises or a callback handler (for streams of events) given the
  * machine's current `context` and `event` that invoked the service.
@@ -222,7 +226,8 @@ export type InvokeCreator<
   TFinalContext = any
 > = (
   context: TContext,
-  event: TEvent
+  event: TEvent,
+  meta: InvokeMeta
 ) =>
   | PromiseLike<TFinalContext>
   | StateMachine<TFinalContext, any, any>

--- a/packages/core/test/invoke.test.ts
+++ b/packages/core/test/invoke.test.ts
@@ -2363,3 +2363,49 @@ describe('invoke', () => {
     });
   });
 });
+
+describe('services option', () => {
+  it('should resolve service from options with string src', (done) => {
+    const machine = createMachine(
+      {
+        initial: 'pending',
+        context: {
+          count: 42
+        },
+        states: {
+          pending: {
+            invoke: {
+              src: 'stringService',
+              data: {
+                newCount: (ctx) => ctx.count * 2
+              },
+              onDone: 'success'
+            }
+          },
+          success: {
+            type: 'final'
+          }
+        }
+      },
+      {
+        services: {
+          stringService: (ctx, _, { data }) => {
+            expect(ctx).toEqual({ count: 42 });
+
+            expect(data).toEqual({ newCount: 84 });
+
+            return new Promise((res) => {
+              res();
+            });
+          }
+        }
+      }
+    );
+
+    const service = interpret(machine).onDone(() => {
+      done();
+    });
+
+    service.start();
+  });
+});

--- a/packages/core/test/invoke.test.ts
+++ b/packages/core/test/invoke.test.ts
@@ -2377,6 +2377,7 @@ describe('services option', () => {
             invoke: {
               src: 'stringService',
               data: {
+                staticVal: 'hello',
                 newCount: (ctx) => ctx.count * 2
               },
               onDone: 'success'
@@ -2392,7 +2393,7 @@ describe('services option', () => {
           stringService: (ctx, _, { data }) => {
             expect(ctx).toEqual({ count: 42 });
 
-            expect(data).toEqual({ newCount: 84 });
+            expect(data).toEqual({ newCount: 84, staticVal: 'hello' });
 
             return new Promise((res) => {
               res();


### PR DESCRIPTION
The resolved value of the `invoke.data` property is now available in the "invoke meta" object, which is passed as the 3rd argument to the service creator in `options.services`. This will work for all types of invoked services now, including promises, observables, and callbacks. The behavior of `invoke.data` with invoked machines is unchanged.

```js
const machine = createMachine({
  initial: 'pending',
  context: {
    id: 42
  },
  states: {
    pending: {
      invoke: {
        src: 'fetchUser',
        data: {
          userId: (context) => context.id
        },
        onDone: 'success'
      }
    },
    success: {
      type: 'final'
    }
  }
},
{
  services: {
    fetchUser: (ctx, _, { data }) => {
      return fetch(`some/api/user/${data.userId}`)
        .then(response => response.json());
    }
  }
}
```
