### PR TITLE
xstate-fsm machine transition example update

### DIFF
--- a/docs/packages/xstate-fsm/index.md
+++ b/docs/packages/xstate-fsm/index.md
@@ -220,7 +220,7 @@ const yellowState = machine.transition('green', 'TIMER');
 const redState = machine.transition(yellowState, 'TIMER');
 // => { value: 'red', ... }
 
-const greenState = machine.transition(yellowState, { type: 'TIMER' });
+const greenState = machine.transition(redState, { type: 'TIMER' });
 // => { value: 'green', ... }
 ```
 


### PR DESCRIPTION
Corrected a bug in the xstate/fsm machine.transition() example.  Transitioning from redState to greenState.

Let me know if the changeset is required for this request, thanks!