### PR TITLE
Documentation: Clarify the XState FSM useMachine hook args

### DIFF
--- a/docs/packages/xstate-react/index.md
+++ b/docs/packages/xstate-react/index.md
@@ -125,7 +125,7 @@ This special `useMachine` hook is imported from `@xstate/react/lib/fsm`
 **Arguments**
 
 - `machine` - An [XState finite state machine (FSM)](https://xstate.js.org/docs/packages/xstate-fsm/).
-- `options` - An optional `options` object.
+- `options` - (optional) The following [XState finite state machine config](https://xstate.js.org/docs/packages/xstate-fsm/#machine-config) options: `actions`.
 
 **Returns** a tuple of `[state, send, service]`:
 

--- a/docs/packages/xstate-react/index.md
+++ b/docs/packages/xstate-react/index.md
@@ -125,7 +125,7 @@ This special `useMachine` hook is imported from `@xstate/react/lib/fsm`
 **Arguments**
 
 - `machine` - An [XState finite state machine (FSM)](https://xstate.js.org/docs/packages/xstate-fsm/).
-- `options` - (optional) The following [XState finite state machine config](https://xstate.js.org/docs/packages/xstate-fsm/#machine-config) options: `actions`.
+- `options` (optional) - The following [XState finite state machine config](https://xstate.js.org/docs/packages/xstate-fsm/#machine-config) options: `actions`.
 
 **Returns** a tuple of `[state, send, service]`:
 


### PR DESCRIPTION
Based on the Type definition, we only support `actions`: https://github.com/davidkpiano/xstate/blob/master/packages/xstate-react/src/fsm.ts#L35