### PR TITLE
Docs: clarify code is for Vue 3 (2nd try!)

### DIFF
--- a/docs/packages/xstate-vue/index.md
+++ b/docs/packages/xstate-vue/index.md
@@ -70,7 +70,7 @@ export default {
 
 ### `useMachine(machine, options?)`
 
-A [Vue composition function](https://vue-composition-api-rfc.netlify.com/) that interprets the given `machine` and starts a service that runs for the lifetime of the component.
+A [Vue 3 composition function](https://vue-composition-api-rfc.netlify.com/) that interprets the given `machine` and starts a service that runs for the lifetime of the component.
 
 **Arguments**
 


### PR DESCRIPTION
Sorry for the previous pull request. I got too excited and edited the wrong file. Embarrassing. Anyhow, even though the composition API means Vue 3 to those in the know, newer folks might not be aware of this so I clarified in this pull request.