### PR TITLE
Add `always`

### DIFF
--- a/.changeset/tidy-feet-occur.md
+++ b/.changeset/tidy-feet-occur.md
@@ -1,0 +1,27 @@
+---
+'xstate': minor
+---
+
+New property introduced for eventless (transient) transitions: **`always`**, which indicates a transition that is always taken when in that state. Empty string transition configs for [transient transitions](https://xstate.js.org/docs/guides/transitions.html#transient-transitions) are deprecated in favor of `always`:
+
+```diff
+// ...
+states: {
+  playing: {
++   always: [
++     { target: 'win', cond: 'didPlayerWin' },
++     { target: 'lose', cond: 'didPlayerLose' },
++   ],
+    on: {
+      // ⚠️ Deprecation warning
+-     '': [
+-       { target: 'win', cond: 'didPlayerWin' },
+-       { target: 'lose', cond: 'didPlayerLose' },
+-     ]
+    }
+  }
+}
+// ...
+```
+
+The old empty string syntax (`'': ...`) will continue to work until V5.

--- a/docs/packages/xstate-fsm/index.md
+++ b/docs/packages/xstate-fsm/index.md
@@ -72,7 +72,7 @@ const toggleMachine = createMachine({
 
 const toggleService = interpret(toggleMachine).start();
 
-toggleService.subscribe(state => {
+toggleService.subscribe((state) => {
   console.log(state.value);
 });
 
@@ -182,7 +182,7 @@ Using the string or object syntax is useful for handling actions in a custom way
 ```js
 const nextState = machine.transition(/* ... */);
 
-nextState.actions.forEach(action => {
+nextState.actions.forEach((action) => {
   if (action.type === 'focus') {
     // do focus
   }
@@ -220,7 +220,7 @@ const yellowState = machine.transition('green', 'TIMER');
 const redState = machine.transition(yellowState, 'TIMER');
 // => { value: 'red', ... }
 
-const greenState = machine.transition(redState, { type: 'TIMER' });
+const greenState = machine.transition(yellowState, { type: 'TIMER' });
 // => { value: 'green', ... }
 ```
 
@@ -255,7 +255,7 @@ const machine = createMachine({
 
 const service = interpret(machine);
 
-const subscription = service.subscribe(state => {
+const subscription = service.subscribe((state) => {
   console.log(state);
 });
 
@@ -364,7 +364,7 @@ const userMachine = createMachine<UserContext, UserEvent, UserState>({
 
 const userService = interpret(userMachine);
 
-userService.subscribe(state => {
+userService.subscribe((state) => {
   if (state.matches('success')) {
     // from UserState, `user` will be defined
     state.context.user.name;
@@ -396,7 +396,7 @@ const lightMachine = createMachine({
       }
     },
     red: {
-      entry: assign({ redLights: ctx => ctx.redLights + 1 }),
+      entry: assign({ redLights: (ctx) => ctx.redLights + 1 }),
       on: {
         TIMER: 'green'
       }
@@ -406,7 +406,7 @@ const lightMachine = createMachine({
 
 const lightService = interpret(lightMachine);
 
-lightService.subscribe(state => {
+lightService.subscribe((state) => {
   console.log(state);
 });
 

--- a/docs/packages/xstate-react/index.md
+++ b/docs/packages/xstate-react/index.md
@@ -125,7 +125,7 @@ This special `useMachine` hook is imported from `@xstate/react/lib/fsm`
 **Arguments**
 
 - `machine` - An [XState finite state machine (FSM)](https://xstate.js.org/docs/packages/xstate-fsm/).
-- `options` (optional) - The following [XState finite state machine config](https://xstate.js.org/docs/packages/xstate-fsm/#machine-config) options: `actions`.
+- `options` - An optional `options` object.
 
 **Returns** a tuple of `[state, send, service]`:
 

--- a/docs/packages/xstate-vue/index.md
+++ b/docs/packages/xstate-vue/index.md
@@ -70,7 +70,7 @@ export default {
 
 ### `useMachine(machine, options?)`
 
-A [Vue 3 composition function](https://vue-composition-api-rfc.netlify.com/) that interprets the given `machine` and starts a service that runs for the lifetime of the component.
+A [Vue composition function](https://vue-composition-api-rfc.netlify.com/) that interprets the given `machine` and starts a service that runs for the lifetime of the component.
 
 **Arguments**
 

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -1832,20 +1832,27 @@ class StateNode<
     } else {
       const {
         [WILDCARD]: wildcardConfigs = [],
-        ...strictOnConfigs
+        ...strictTransitionConfigs
       } = this.config.on;
 
       onConfig = flatten(
-        keys(strictOnConfigs)
+        keys(strictTransitionConfigs)
           .map((key) => {
-            const arrayified = toTransitionConfigArray<TContext, EventObject>(
-              key,
-              strictOnConfigs![key as string]
-            );
-            if (!IS_PRODUCTION) {
-              validateArrayifiedTransitions(this, key, arrayified);
+            if (!IS_PRODUCTION && key === NULL_EVENT) {
+              warn(
+                false,
+                `Empty string transition configs (e.g., \`{ on: { '': ... }}\`) for transient transitions are deprecated. Specify the transition in the \`{ always: ... }\` property instead. ` +
+                  `Please check the \`on\` configuration for "#${this.id}".`
+              );
             }
-            return arrayified;
+            const transitionConfigArray = toTransitionConfigArray<
+              TContext,
+              EventObject
+            >(key, strictTransitionConfigs[key as string]);
+            if (!IS_PRODUCTION) {
+              validateArrayifiedTransitions(this, key, transitionConfigArray);
+            }
+            return transitionConfigArray;
           })
           .concat(
             toTransitionConfigArray(

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -497,6 +497,12 @@ export interface StateNodeConfig<
    * The delayed transitions are taken after the specified delay in an interpreter.
    */
   after?: DelayedTransitions<TContext, TEvent>;
+
+  /**
+   * An eventless transition that is always taken when this state node is active.
+   * Equivalent to a transition specified as an empty `''`' string in the `on` property.
+   */
+  always?: TransitionConfigOrTarget<TContext, TEvent>;
   /**
    * The activities to be started upon entering the state node,
    * and stopped upon exiting the state node.

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -539,9 +539,7 @@ describe('entry/exit actions', () => {
             entry: () => {
               actual.push('entered one');
             },
-            on: {
-              '': 'two'
-            }
+            always: 'two'
           },
           two: {
             exit: () => {

--- a/packages/core/test/after.test.ts
+++ b/packages/core/test/after.test.ts
@@ -94,9 +94,7 @@ describe('delayed transitions', () => {
             },
             three: {
               entry: () => actual.push('entered three'),
-              on: {
-                '': '#end'
-              }
+              always: '#end'
             }
           },
           after: {

--- a/packages/core/test/fixtures/omni.ts
+++ b/packages/core/test/fixtures/omni.ts
@@ -82,18 +82,14 @@ const omniMachine = Machine({
           type: 'compound',
           states: {
             transient: {
-              on: {
-                '': 'one'
-              }
+              always: 'one'
             },
             transientCond: {
-              on: {
-                '': [
-                  { target: 'two', cond: (ctx) => ctx.count === 2 },
-                  { target: 'three', cond: (ctx) => ctx.count === 3 },
-                  { target: 'one' }
-                ]
-              }
+              always: [
+                { target: 'two', cond: (ctx) => ctx.count === 2 },
+                { target: 'three', cond: (ctx) => ctx.count === 3 },
+                { target: 'one' }
+              ]
             },
             one: {},
             two: {},

--- a/packages/core/test/guards.test.ts
+++ b/packages/core/test/guards.test.ts
@@ -156,14 +156,10 @@ describe('guard conditions', () => {
             }
           },
           A3: {
-            on: {
-              '': 'A4'
-            }
+            always: 'A4'
           },
           A4: {
-            on: {
-              '': 'A5'
-            }
+            always: 'A5'
           },
           A5: {}
         }
@@ -172,6 +168,12 @@ describe('guard conditions', () => {
         initial: 'B0',
         states: {
           B0: {
+            always: [
+              {
+                target: 'B4',
+                cond: (_state, _event, { state: s }) => s.matches('A.A4')
+              }
+            ],
             on: {
               T1: [
                 {
@@ -189,12 +191,6 @@ describe('guard conditions', () => {
                 {
                   target: 'B3',
                   cond: (_state, _event, { state: s }) => s.matches('A.A3')
-                }
-              ],
-              '': [
-                {
-                  target: 'B4',
-                  cond: (_state, _event, { state: s }) => s.matches('A.A4')
                 }
               ]
             }

--- a/packages/core/test/history.test.ts
+++ b/packages/core/test/history.test.ts
@@ -304,10 +304,8 @@ describe('transient history', () => {
         on: { EVENT: 'B' }
       },
       B: {
-        on: {
-          // eventless transition
-          '': 'C'
-        }
+        // eventless transition
+        always: 'C'
       },
       C: {}
     }

--- a/packages/core/test/interpreter.test.ts
+++ b/packages/core/test/interpreter.test.ts
@@ -1579,7 +1579,7 @@ Event: {\\"type\\":\\"SOME_EVENT\\"}"
         initial: 'idle',
         states: {
           idle: { on: { START: 'transient' } },
-          transient: { on: { '': 'next' } },
+          transient: { always: 'next' },
           next: { on: { FINISH: 'end' } },
           end: { type: 'final' }
         }
@@ -1606,9 +1606,10 @@ Event: {\\"type\\":\\"SOME_EVENT\\"}"
           states: {
             idle: { on: { START: 'transient' } },
             transient: {
-              on: {
-                '': [{ target: 'end', cond: 'alwaysFalse' }, { target: 'next' }]
-              }
+              always: [
+                { target: 'end', cond: 'alwaysFalse' },
+                { target: 'next' }
+              ]
             },
             next: { on: { FINISH: 'end' } },
             end: { type: 'final' }
@@ -1649,11 +1650,9 @@ Event: {\\"type\\":\\"SOME_EVENT\\"}"
               actions: assign({ count: (ctx) => ctx.count + 1 })
             }
           },
-          on: {
-            '': {
-              target: 'finished',
-              cond: (ctx) => ctx.count >= 5
-            }
+          always: {
+            target: 'finished',
+            cond: (ctx) => ctx.count >= 5
           }
         },
         finished: {
@@ -1705,13 +1704,13 @@ Event: {\\"type\\":\\"SOME_EVENT\\"}"
         initial: 'active',
         states: {
           active: {
+            always: {
+              target: 'finished',
+              cond: (ctx) => ctx.count >= 5
+            },
             on: {
               INC: {
                 actions: assign({ count: (ctx) => ctx.count + 1 })
-              },
-              '': {
-                target: 'finished',
-                cond: (ctx) => ctx.count >= 5
               }
             }
           },

--- a/packages/core/test/invoke.test.ts
+++ b/packages/core/test/invoke.test.ts
@@ -109,11 +109,11 @@ const intervalMachine = Machine<{
           return () => clearInterval(ivl);
         }
       },
+      always: {
+        target: 'finished',
+        cond: (ctx) => ctx.count === 3
+      },
       on: {
-        '': {
-          target: 'finished',
-          cond: (ctx) => ctx.count === 3
-        },
         INC: { actions: assign({ count: (ctx) => ctx.count + 1 }) },
         SKIP: 'wait'
       }
@@ -157,13 +157,13 @@ describe('invoke', () => {
               id: 'someService',
               autoForward: true
             },
+            always: {
+              target: 'stop',
+              cond: (ctx) => ctx.count === 2
+            },
             on: {
               INC: {
                 actions: assign({ count: (ctx) => ctx.count + 1 })
-              },
-              '': {
-                target: 'stop',
-                cond: (ctx) => ctx.count === 2
               }
             }
           },
@@ -225,13 +225,13 @@ describe('invoke', () => {
               id: 'someService',
               autoForward: true
             },
+            always: {
+              target: 'stop',
+              cond: (ctx) => ctx.count === -3
+            },
             on: {
               DEC: { actions: assign({ count: (ctx) => ctx.count - 1 }) },
-              FORWARD_DEC: undefined,
-              '': {
-                target: 'stop',
-                cond: (ctx) => ctx.count === -3
-              }
+              FORWARD_DEC: undefined
             }
           },
           stop: {
@@ -1425,7 +1425,7 @@ describe('invoke', () => {
               on: { BEGIN: 'first' }
             },
             first: {
-              on: { '': 'second' }
+              always: 'second'
             },
             second: {
               invoke: {
@@ -1876,11 +1876,11 @@ describe('invoke', () => {
                   })
                 )
             },
+            always: {
+              target: 'counted',
+              cond: (ctx) => ctx.count === 5
+            },
             on: {
-              '': {
-                target: 'counted',
-                cond: (ctx) => ctx.count === 5
-              },
               COUNT: { actions: assign({ count: (_, e) => e.value }) }
             }
           },
@@ -2195,9 +2195,7 @@ describe('invoke', () => {
                 serviceCalled = true;
               }
             },
-            on: {
-              '': 'inactive'
-            }
+            always: 'inactive'
           },
           inactive: {
             after: { 10: 'complete' }

--- a/packages/core/test/transient.test.ts
+++ b/packages/core/test/transient.test.ts
@@ -241,6 +241,62 @@ describe('transient states (eventless transitions)', () => {
     expect(state.value).toEqual({ A: 'A4', B: 'B4' });
   });
 
+  it('should execute all eventless transitions in the same microstep (with `always`)', () => {
+    const machine = Machine({
+      type: 'parallel',
+      states: {
+        A: {
+          initial: 'A1',
+          states: {
+            A1: {
+              on: {
+                E: 'A2' // the external event
+              }
+            },
+            A2: {
+              always: 'A3'
+            },
+            A3: {
+              always: {
+                target: 'A4',
+                in: 'B.B3'
+              }
+            },
+            A4: {}
+          }
+        },
+
+        B: {
+          initial: 'B1',
+          states: {
+            B1: {
+              on: {
+                E: 'B2'
+              }
+            },
+            B2: {
+              always: {
+                target: 'B3',
+                in: 'A.A2'
+              }
+            },
+            B3: {
+              always: {
+                target: 'B4',
+                in: 'A.A3'
+              }
+            },
+            B4: {}
+          }
+        }
+      }
+    });
+
+    const state = machine.transition(machine.initialState, 'E');
+
+    expect(state.value).toEqual({ A: 'A4', B: 'B4' });
+  });
+
   it('should check for automatic transitions even after microsteps are done', () => {
     const machine = Machine({
       type: 'parallel',
@@ -292,6 +348,53 @@ describe('transient states (eventless transitions)', () => {
     expect(state.value).toEqual({ A: 'A2', B: 'B2', C: 'C2' });
   });
 
+  it('should check for automatic transitions even after microsteps are done (with `always`)', () => {
+    const machine = Machine({
+      type: 'parallel',
+      states: {
+        A: {
+          initial: 'A1',
+          states: {
+            A1: {
+              on: {
+                A: 'A2'
+              }
+            },
+            A2: {}
+          }
+        },
+        B: {
+          initial: 'B1',
+          states: {
+            B1: {
+              always: {
+                target: 'B2',
+                cond: (_xs, _e, { state: s }) => s.matches('A.A2')
+              }
+            },
+            B2: {}
+          }
+        },
+        C: {
+          initial: 'C1',
+          states: {
+            C1: {
+              always: {
+                target: 'C2',
+                in: 'A.A2'
+              }
+            },
+            C2: {}
+          }
+        }
+      }
+    });
+
+    let state = machine.initialState; // A1, B1, C1
+    state = machine.transition(state, 'A'); // A2, B2, C2
+    expect(state.value).toEqual({ A: 'A2', B: 'B2', C: 'C2' });
+  });
+
   it('should determine the resolved initial state from the transient state', () => {
     expect(greetingMachine.initialState.value).toEqual('morning');
   });
@@ -327,6 +430,36 @@ describe('transient states (eventless transitions)', () => {
           entry: raise('BAR'),
           on: {
             '': 'c',
+            BAR: 'd'
+          }
+        },
+        c: {
+          on: {
+            BAR: 'e'
+          }
+        },
+        d: {},
+        e: {}
+      }
+    });
+
+    const state = machine.transition('a', 'FOO');
+    expect(state.value).toBe('e');
+  });
+
+  it('should select eventless transition before processing raised events (with `always`)', () => {
+    const machine = Machine({
+      initial: 'a',
+      states: {
+        a: {
+          on: {
+            FOO: 'b'
+          }
+        },
+        b: {
+          entry: raise('BAR'),
+          always: 'c',
+          on: {
             BAR: 'd'
           }
         },
@@ -402,6 +535,26 @@ describe('transient states (eventless transitions)', () => {
     expect(state.value).toBe('pass');
   });
 
+  it('should not select wildcard for eventless transition (with `always`)', () => {
+    const machine = Machine({
+      initial: 'a',
+      states: {
+        a: {
+          on: { FOO: 'b' }
+        },
+        b: {
+          always: 'pass',
+          on: [{ event: '*', target: 'fail' }]
+        },
+        fail: {},
+        pass: {}
+      }
+    });
+
+    const state = machine.transition('a', 'FOO');
+    expect(state.value).toBe('pass');
+  });
+
   it('should work with transient transition on root', (done) => {
     const machine = createMachine<any, any>({
       id: 'machine',
@@ -429,6 +582,43 @@ describe('transient states (eventless transitions)', () => {
           }
         ]
       }
+    });
+
+    const service = interpret(machine).onDone(() => {
+      done();
+    });
+
+    service.start();
+
+    service.send('ADD');
+  });
+
+  it('should work with transient transition on root (with `always`)', (done) => {
+    const machine = createMachine<any, any>({
+      id: 'machine',
+      initial: 'first',
+      context: { count: 0 },
+      states: {
+        first: {
+          on: {
+            ADD: {
+              actions: assign({ count: (ctx) => ctx.count + 1 })
+            }
+          }
+        },
+        success: {
+          type: 'final'
+        }
+      },
+
+      always: [
+        {
+          target: '.success',
+          cond: (ctx) => {
+            return ctx.count > 0;
+          }
+        }
+      ]
     });
 
     const service = interpret(machine).onDone(() => {

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -76,9 +76,7 @@ describe('StateSchema', () => {
             }
           },
           stop: {
-            on: {
-              '': { target: 'green' }
-            }
+            always: { target: 'green' }
           }
         }
       }


### PR DESCRIPTION
This PR adds support for the `always` transition, which works exactly the same as eventless transitions:

```diff
on: {
- '': 'someTarget'
},
+always: 'someTarget'
```

As the tests show, this is not a breaking change. The original way for defining eventless transitions will continue to work.

TODO: 
- [x] Docs
- [x] Tests