### PR TITLE
chore(dep/vue) bump peerDep composition-api to 0.6

### DIFF
--- a/.changeset/tiny-guests-wash.md
+++ b/.changeset/tiny-guests-wash.md
@@ -1,0 +1,10 @@
+---
+'@xstate/vue': minor
+---
+
+chore(dep/vue) bump peerDep of @vue/composition-api to 0.6.x.
+
+- breaking changes in 0.6.x, adapated code. Will make it easier for
+  this library to also be updated to Vue 3.
+- Uses new watcher option since it was changed to be lazy by default
+- now using shallow ref since xstate objects should not be refs deeply.

--- a/.changeset/tiny-guests-wash.md
+++ b/.changeset/tiny-guests-wash.md
@@ -2,9 +2,4 @@
 '@xstate/vue': minor
 ---
 
-chore(dep/vue) bump peerDep of @vue/composition-api to 0.6.x.
-
-- breaking changes in 0.6.x, adapated code. Will make it easier for
-  this library to also be updated to Vue 3.
-- Uses new watcher option since it was changed to be lazy by default
-- now using shallow ref since xstate objects should not be refs deeply.
+Upgraded package for compatibility with the newest `@vue/composition-api@^0.6.0`, which means that a peer dependency requirement has changed to this version, which is a **breaking change**. The only observable behavior change is that exposed refs are now **shallow**.

--- a/packages/xstate-vue/package.json
+++ b/packages/xstate-vue/package.json
@@ -41,7 +41,7 @@
     "url": "https://github.com/davidkpiano/xstate/issues"
   },
   "peerDependencies": {
-    "@vue/composition-api": "^0.3.4",
+    "@vue/composition-api": "^0.6.5",
     "@xstate/fsm": "^1.0.0",
     "vue": "^2.6.10",
     "xstate": "^4.7.8"
@@ -57,7 +57,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/vue": "^4.1.0",
-    "@vue/composition-api": "^0.3.4",
+    "@vue/composition-api": "~0.6.5",
     "@vue/test-utils": "^1.0.0-beta.30",
     "@xstate/fsm": "*",
     "babel-core": "^6.26.3",

--- a/packages/xstate-vue/package.json
+++ b/packages/xstate-vue/package.json
@@ -41,7 +41,7 @@
     "url": "https://github.com/davidkpiano/xstate/issues"
   },
   "peerDependencies": {
-    "@vue/composition-api": "^0.6.5",
+    "@vue/composition-api": "^0.6.0",
     "@xstate/fsm": "^1.0.0",
     "vue": "^2.6.10",
     "xstate": "^4.7.8"
@@ -57,7 +57,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/vue": "^4.1.0",
-    "@vue/composition-api": "~0.6.5",
+    "@vue/composition-api": "^0.6.5",
     "@vue/test-utils": "^1.0.0-beta.30",
     "@xstate/fsm": "*",
     "babel-core": "^6.26.3",

--- a/packages/xstate-vue/src/fsm.ts
+++ b/packages/xstate-vue/src/fsm.ts
@@ -1,5 +1,5 @@
 import {
-  ref,
+  shallowRef,
   isRef,
   watch,
   onMounted,
@@ -50,7 +50,7 @@ export function useMachine<
     )
   ).start();
 
-  const state = ref<StateMachine.State<TContext, TEvent, any>>(
+  const state = shallowRef<StateMachine.State<TContext, TEvent, any>>(
     getServiceValue(service)
   );
 
@@ -80,21 +80,27 @@ export function useService<
     service
   )
     ? service
-    : ref(service);
-  const state = ref<StateMachine.State<TContext, TEvent, TState>>(
+    : shallowRef(service);
+  const state = shallowRef<StateMachine.State<TContext, TEvent, TState>>(
     serviceRef.value.state
   );
 
-  watch(serviceRef, (service, _, onCleanup) => {
-    state.value = getServiceValue(service);
+  watch(
+    serviceRef,
+    (service, _, onCleanup) => {
+      state.value = getServiceValue(service);
 
-    const { unsubscribe } = service.subscribe((currentState) => {
-      if (currentState.changed) {
-        state.value = currentState;
-      }
-    });
-    onCleanup(unsubscribe);
-  });
+      const { unsubscribe } = service.subscribe((currentState) => {
+        if (currentState.changed) {
+          state.value = currentState;
+        }
+      });
+      onCleanup(unsubscribe);
+    },
+    {
+      immediate: true
+    }
+  );
 
   const send = (event: TEvent | TEvent['type']) => serviceRef.value.send(event);
 

--- a/packages/xstate-vue/src/index.ts
+++ b/packages/xstate-vue/src/index.ts
@@ -1,5 +1,5 @@
 import {
-  ref,
+  shallowRef,
   watch,
   isRef,
   onMounted,
@@ -68,7 +68,7 @@ export function useMachine<TContext, TEvent extends EventObject>(
     rehydratedState ? State.create(rehydratedState) : undefined
   );
 
-  const state = ref<State<TContext, TEvent>>(service.state);
+  const state = shallowRef<State<TContext, TEvent>>(service.state);
 
   onMounted(() => {
     service.onTransition((currentState) => {
@@ -98,18 +98,24 @@ export function useService<TContext, TEvent extends EventObject>(
 } {
   const serviceRef = isRef(service)
     ? service
-    : ref<Interpreter<TContext, any, TEvent>>(service);
-  const state = ref<State<TContext, TEvent>>(serviceRef.value.state);
+    : shallowRef<Interpreter<TContext, any, TEvent>>(service);
+  const state = shallowRef<State<TContext, TEvent>>(serviceRef.value.state);
 
-  watch(serviceRef, (service, _, onCleanup) => {
-    state.value = service.state;
-    const { unsubscribe } = service.subscribe((currentState) => {
-      if (currentState.changed) {
-        state.value = currentState;
-      }
-    });
-    onCleanup(() => unsubscribe());
-  });
+  watch(
+    serviceRef,
+    (service, _, onCleanup) => {
+      state.value = service.state;
+      const { unsubscribe } = service.subscribe((currentState) => {
+        if (currentState.changed) {
+          state.value = currentState;
+        }
+      });
+      onCleanup(() => unsubscribe());
+    },
+    {
+      immediate: true
+    }
+  );
 
   const send = (event: TEvent | TEvent['type']) => serviceRef.value.send(event);
 

--- a/packages/xstate-vue/test/UseMachine.vue
+++ b/packages/xstate-vue/test/UseMachine.vue
@@ -13,7 +13,7 @@
 <script lang="ts">
 import { PropType } from 'vue';
 import { useMachine } from '../src';
-import { Machine, assign, Interpreter, spawn, doneInvoke, State } from 'xstate';
+import { Machine, assign, State } from 'xstate';
 import { watch } from '@vue/composition-api';
 
 const context = {

--- a/packages/xstate-vue/test/UseMachine.vue
+++ b/packages/xstate-vue/test/UseMachine.vue
@@ -11,6 +11,7 @@
 </template>
 
 <script lang="ts">
+import { PropType } from 'vue';
 import { useMachine } from '../src';
 import { Machine, assign, Interpreter, spawn, doneInvoke, State } from 'xstate';
 import { watch } from '@vue/composition-api';
@@ -45,8 +46,12 @@ const fetchMachine = Machine<typeof context, any>({
 });
 
 export default {
-  props: ['persistedState'],
-  setup({ persistedState }): { persistedState: State<any, any> } {
+  props: {
+    persistedState: {
+      type: Object as PropType<State<any>>
+    }
+  },
+  setup({ persistedState }) {
     const onFetch = () =>
       new Promise((res) => setTimeout(() => res('some data'), 50));
 

--- a/packages/xstate-vue/test/UseService.vue
+++ b/packages/xstate-vue/test/UseService.vue
@@ -6,22 +6,15 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue'
+import { PropType } from 'vue';
 import { useService } from '../src';
-import {
-  Machine,
-  assign,
-  Interpreter,
-  spawn,
-  doneInvoke,
-  State,
-} from 'xstate';
-import { watchEffect, ref, Ref } from '@vue/composition-api';
+import { Interpreter } from 'xstate';
+import { watchEffect } from '@vue/composition-api';
 
 export default {
   props: {
     service: {
-      type: Object as PropType<Interpreter<any>>,
+      type: Object as PropType<Interpreter<any>>
     }
   },
   setup(props) {

--- a/packages/xstate-vue/test/UseService.vue
+++ b/packages/xstate-vue/test/UseService.vue
@@ -6,6 +6,7 @@
 </template>
 
 <script lang="ts">
+import Vue, { PropType } from 'vue'
 import { useService } from '../src';
 import {
   Machine,
@@ -14,20 +15,24 @@ import {
   spawn,
   doneInvoke,
   State,
-  Service
 } from 'xstate';
-import { watch, ref } from '@vue/composition-api';
+import { watchEffect, ref, Ref } from '@vue/composition-api';
 
 export default {
-  props: ['service'],
-  setup(props): { service: Service } {
+  props: {
+    service: {
+      type: Object as PropType<Interpreter<any>>,
+    }
+  },
+  setup(props) {
     let { state, send } = useService(props.service);
 
-    watch(() => {
+    watchEffect(() => {
       let currentState = useService(props.service);
       state.value = currentState.state.value;
       send = currentState.send;
     });
+
     return { state, send };
   }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1991,12 +1991,12 @@
     source-map "~0.6.1"
     vue-template-es2015-compiler "^1.9.0"
 
-"@vue/composition-api@^0.3.4":
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/@vue/composition-api/-/composition-api-0.3.4.tgz#43d2c3377173cfe1d02e51e3342bcf0fbde9c4b6"
-  integrity sha512-aMbg/pEk0PSQAIFyWWLqbAmaCCTx1kFq+49KZslIBJH9Wqos7eEPLtMv4gGxd/EcciBIgfbtUXaXGg/O3mheRA==
+"@vue/composition-api@~0.6.5":
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/@vue/composition-api/-/composition-api-0.6.5.tgz#890b4ab3777ee95c6d633872db2bf53a45446d5b"
+  integrity sha512-IRdtn6/59yPNmvzlu5JTAR3SK0kK5T69wtz8oefSY8FFUPoOe7A2BlcVCypRX7jTmpBADhrHkAiklc8ffmPOuQ==
   dependencies:
-    tslib "^1.9.3"
+    tslib "^2.0.0"
 
 "@vue/test-utils@^1.0.0-beta.29", "@vue/test-utils@^1.0.0-beta.30", "@vue/test-utils@^1.0.0-beta.31":
   version "1.0.0-beta.32"
@@ -13745,6 +13745,11 @@ tslib@^1.10.0, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
   integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==
+
+tslib@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.0.tgz#18d13fc2dce04051e20f074cc8387fd8089ce4f3"
+  integrity sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==
 
 tslint@^5.11.0:
   version "5.20.1"


### PR DESCRIPTION
- breaking changes in composition-api 0.6.x, so I've adapted the code to conform. This is not backwards compat with previous version of @xstate/vue but peerDependencies have been updated. Luckily the changes are more in-line with Vue 3, so this will make it easier to upgrade to Vue 3 when needed.
- Uses new watcher option since it was changed to be lazy by default
- now using shallow ref since xstate objects should not be refs deeply