### PR TITLE
Change order of TContext, TEvent, TStateSchema

### DIFF
--- a/.changeset/eight-guests-wait.md
+++ b/.changeset/eight-guests-wait.md
@@ -1,0 +1,14 @@
+---
+'xstate': major
+---
+
+All generic types containing `TContext` and `TEvent` will now follow the same, consistent order:
+
+1. `TContext`
+2. `TEvent`
+3. ... All other generic types, including `TStateSchema,`TTypestate`, etc.
+
+```diff
+-const service = interpret<SomeCtx, SomeSchema, SomeEvent>(someMachine);
++const service = interpret<SomeCtx, SomeEvent, SomeSchema>(someMachine);
+```

--- a/packages/core/src/Actor.ts
+++ b/packages/core/src/Actor.ts
@@ -58,7 +58,7 @@ export function fromCallback<TEvent extends EventObject>(
 }
 
 export function fromMachine<TContext, TEvent extends EventObject>(
-  machine: MachineNode<TContext, any, TEvent>,
+  machine: MachineNode<TContext, TEvent>,
   parent: ActorRef<any>,
   name: string,
   options?: Partial<InterpreterOptions>
@@ -70,7 +70,7 @@ export function fromMachine<TContext, TEvent extends EventObject>(
 }
 
 export function fromService<TContext, TEvent extends EventObject>(
-  service: Interpreter<TContext, any, TEvent>,
+  service: Interpreter<TContext, TEvent>,
   name: string = registry.bookId()
 ): ActorRef<TEvent> {
   return new ObservableActorRef(createServiceBehavior(service), name);

--- a/packages/core/src/Machine.ts
+++ b/packages/core/src/Machine.ts
@@ -13,26 +13,26 @@ export function Machine<
   TContext = any,
   TEvent extends EventObject = AnyEventObject
 >(
-  config: MachineConfig<TContext, any, TEvent>,
+  config: MachineConfig<TContext, TEvent, any>,
   options?: Partial<MachineOptions<TContext, TEvent>>
-): MachineNode<TContext, any, TEvent>;
+): MachineNode<TContext, TEvent>;
 export function Machine<
   TContext = DefaultContext,
-  TStateSchema extends StateSchema = any,
-  TEvent extends EventObject = AnyEventObject
+  TEvent extends EventObject = AnyEventObject,
+  TStateSchema extends StateSchema = any
 >(
-  config: MachineConfig<TContext, TStateSchema, TEvent>,
+  config: MachineConfig<TContext, TEvent, TStateSchema>,
   options?: Partial<MachineOptions<TContext, TEvent>>
-): MachineNode<TContext, TStateSchema, TEvent>;
+): MachineNode<TContext, TEvent, TStateSchema>;
 export function Machine<
   TContext = DefaultContext,
-  TStateSchema extends StateSchema = any,
-  TEvent extends EventObject = AnyEventObject
+  TEvent extends EventObject = AnyEventObject,
+  TStateSchema extends StateSchema = any
 >(
-  config: MachineConfig<TContext, TStateSchema, TEvent>,
+  config: MachineConfig<TContext, TEvent, TStateSchema>,
   options?: Partial<MachineOptions<TContext, TEvent>>
-): MachineNode<TContext, TStateSchema, TEvent> {
-  return new MachineNode<TContext, TStateSchema, TEvent, any>(config, options);
+): MachineNode<TContext, TEvent, TStateSchema> {
+  return new MachineNode<TContext, TEvent, TStateSchema, any>(config, options);
 }
 
 export function createMachine<
@@ -40,8 +40,8 @@ export function createMachine<
   TEvent extends EventObject = AnyEventObject,
   TTypestate extends Typestate<TContext> = { value: any; context: TContext }
 >(
-  config: MachineConfig<TContext, any, TEvent>,
+  config: MachineConfig<TContext, TEvent, any>,
   options?: Partial<MachineOptions<TContext, TEvent>>
-): MachineNode<TContext, any, TEvent, TTypestate> {
-  return new MachineNode<TContext, any, TEvent, TTypestate>(config, options);
+): MachineNode<TContext, TEvent, TTypestate> {
+  return new MachineNode<TContext, TEvent, TTypestate>(config, options);
 }

--- a/packages/core/src/MachineNode.ts
+++ b/packages/core/src/MachineNode.ts
@@ -62,10 +62,10 @@ function resolveContext<TContext>(
 
 export class MachineNode<
   TContext = any,
-  TStateSchema extends StateSchema = any,
   TEvent extends EventObject = EventObject,
+  TStateSchema extends StateSchema = any,
   TTypestate extends Typestate<TContext> = any
-> extends StateNode<TContext, TStateSchema, TEvent> {
+> extends StateNode<TContext, TEvent, TStateSchema> {
   public context: TContext;
   /**
    * The machine's own version.
@@ -88,7 +88,7 @@ export class MachineNode<
     /**
      * The raw config used to create the machine.
      */
-    public config: MachineConfig<TContext, TStateSchema, TEvent>,
+    public config: MachineConfig<TContext, TEvent, TStateSchema>,
     options?: Partial<MachineOptions<TContext, TEvent>>
   ) {
     super(config, {
@@ -111,7 +111,7 @@ export class MachineNode<
     // Document order
     let order = 0;
 
-    function dfs(stateNode: StateNode<TContext, any, TEvent>): void {
+    function dfs(stateNode: StateNode<TContext, TEvent>): void {
       stateNode.order = order++;
 
       for (const child of getChildren(stateNode)) {
@@ -151,7 +151,7 @@ export class MachineNode<
    */
   public withConfig(
     options: Partial<MachineOptions<TContext, TEvent>>
-  ): MachineNode<TContext, TStateSchema, TEvent> {
+  ): MachineNode<TContext, TEvent, TStateSchema> {
     const { actions, guards, behaviors, delays } = this.options;
 
     return new MachineNode(this.config, {
@@ -172,7 +172,7 @@ export class MachineNode<
    */
   public withContext(
     context: Partial<TContext>
-  ): MachineNode<TContext, TStateSchema, TEvent> {
+  ): MachineNode<TContext, TEvent, TStateSchema> {
     return this.withConfig({
       context: resolveContext(this.context, context)
     });
@@ -291,7 +291,7 @@ export class MachineNode<
     >;
   }
 
-  public getStateNodeById(id: string): StateNode<TContext, any, TEvent> {
+  public getStateNodeById(id: string): StateNode<TContext, TEvent> {
     return getStateNodeById(this, id);
   }
 }

--- a/packages/core/src/State.ts
+++ b/packages/core/src/State.ts
@@ -84,7 +84,7 @@ export class State<
   /**
    * The enabled state nodes representative of the state value.
    */
-  public configuration: Array<StateNode<TContext, any, TEvent>>;
+  public configuration: Array<StateNode<TContext, TEvent>>;
   /**
    * The next events that will cause a transition from the current state.
    */

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -51,13 +51,13 @@ const EMPTY_OBJECT = {};
 
 interface StateNodeOptions<TContext, TEvent extends EventObject> {
   _key: string;
-  _parent?: StateNode<TContext, any, TEvent>;
+  _parent?: StateNode<TContext, TEvent>;
 }
 
 export class StateNode<
   TContext = any,
-  TStateSchema extends StateSchema = any,
-  TEvent extends EventObject = EventObject
+  TEvent extends EventObject = EventObject,
+  TStateSchema extends StateSchema = any
 > {
   /**
    * The relative key of the state node, which represents its location in the overall state value.
@@ -84,7 +84,7 @@ export class StateNode<
   /**
    * The child state nodes.
    */
-  public states: StateNodesConfig<TContext, TStateSchema, TEvent>;
+  public states: StateNodesConfig<TContext, TEvent, TStateSchema>;
   /**
    * The type of history on this state node. Can be:
    *
@@ -103,11 +103,11 @@ export class StateNode<
   /**
    * The parent state node.
    */
-  public parent?: StateNode<TContext, any, TEvent>;
+  public parent?: StateNode<TContext, TEvent>;
   /**
    * The root machine node.
    */
-  public machine: MachineNode<TContext, any, TEvent>;
+  public machine: MachineNode<TContext, TEvent>;
   /**
    * The meta data associated with this state node, which will be returned in State instances.
    */
@@ -146,13 +146,13 @@ export class StateNode<
     invoke: undefined as Array<InvokeDefinition<TContext, TEvent>> | undefined
   };
 
-  public idMap: Record<string, StateNode<TContext, any, TEvent>> = {};
+  public idMap: Record<string, StateNode<TContext, TEvent>> = {};
 
   constructor(
     /**
      * The raw config used to create the machine.
      */
-    public config: StateNodeConfig<TContext, TStateSchema, TEvent>,
+    public config: StateNodeConfig<TContext, TEvent, TStateSchema>,
     options: StateNodeOptions<TContext, TEvent>
   ) {
     const isMachine = !this.parent;
@@ -160,7 +160,7 @@ export class StateNode<
     this.key = this.config.key || options._key;
     this.machine = this.parent
       ? this.parent.machine
-      : ((this as unknown) as MachineNode<TContext, TStateSchema, TEvent>);
+      : ((this as unknown) as MachineNode<TContext, TEvent, TStateSchema>);
     this.path = this.parent ? this.parent.path.concat(this.key) : [];
     this.id =
       this.config.id ||
@@ -180,7 +180,7 @@ export class StateNode<
     this.states = (this.config.states
       ? mapValues(
           this.config.states,
-          (stateConfig: StateNodeConfig<TContext, any, TEvent>, key) => {
+          (stateConfig: StateNodeConfig<TContext, TEvent>, key) => {
             const stateNode = new StateNode(stateConfig, {
               _parent: this,
               _key: key
@@ -192,7 +192,7 @@ export class StateNode<
             return stateNode;
           }
         )
-      : EMPTY_OBJECT) as StateNodesConfig<TContext, TStateSchema, TEvent>;
+      : EMPTY_OBJECT) as StateNodesConfig<TContext, TEvent, TStateSchema>;
 
     // History config
     this.history =
@@ -215,7 +215,7 @@ export class StateNode<
   /**
    * The well-structured state node definition.
    */
-  public get definition(): StateNodeDefinition<TContext, TStateSchema, TEvent> {
+  public get definition(): StateNodeDefinition<TContext, TEvent, TStateSchema> {
     return {
       id: this.id,
       key: this.key,
@@ -237,12 +237,9 @@ export class StateNode<
           }
         : undefined,
       history: this.history,
-      states: mapValues(
-        this.states,
-        (state: StateNode<TContext, any, TEvent>) => {
-          return state.definition;
-        }
-      ) as StatesDefinition<TContext, TStateSchema, TEvent>,
+      states: mapValues(this.states, (state: StateNode<TContext, TEvent>) => {
+        return state.definition;
+      }) as StatesDefinition<TContext, TEvent, TStateSchema>,
       on: this.on,
       transitions: this.transitions,
       entry: this.entry,

--- a/packages/core/src/behavior.ts
+++ b/packages/core/src/behavior.ts
@@ -238,11 +238,11 @@ export function createObservableBehavior<
 }
 
 export function createMachineBehavior<TContext, TEvent extends EventObject>(
-  machine: MachineNode<TContext, any, TEvent>,
+  machine: MachineNode<TContext, TEvent>,
   parent?: ActorRef<any>,
   options?: Partial<InterpreterOptions>
 ): Behavior<TEvent, State<TContext, TEvent>> {
-  let service: Interpreter<TContext, any, TEvent>;
+  let service: Interpreter<TContext, TEvent>;
   let subscription: Subscription;
 
   const behavior: Behavior<TEvent, State<TContext, TEvent>> = {
@@ -295,7 +295,7 @@ export function createMachineBehavior<TContext, TEvent extends EventObject>(
 }
 
 export function createServiceBehavior<TContext, TEvent extends EventObject>(
-  service: Interpreter<TContext, any, TEvent>
+  service: Interpreter<TContext, TEvent>
 ): Behavior<TEvent, State<TContext, TEvent>> {
   const behavior: Behavior<TEvent, State<TContext, TEvent>> = {
     receive: (actorContext, event) => {

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -834,8 +834,8 @@ export class Interpreter<
  */
 export function interpret<
   TContext = DefaultContext,
-  TStateSchema extends StateSchema = any,
   TEvent extends EventObject = EventObject,
+  TStateSchema extends StateSchema = any,
   TTypestate extends Typestate<TContext> = any
 >(
   machine: MachineNode<TContext, TEvent, TStateSchema, TTypestate>,

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -89,8 +89,8 @@ const defaultOptions: InterpreterOptions = ((global) => ({
 
 export class Interpreter<
   TContext,
-  TStateSchema extends StateSchema = any,
   TEvent extends EventObject = EventObject,
+  TStateSchema extends StateSchema = any,
   TTypestate extends Typestate<TContext> = any
 > {
   /**
@@ -137,7 +137,7 @@ export class Interpreter<
    * @param options Interpreter options
    */
   constructor(
-    public machine: MachineNode<TContext, TStateSchema, TEvent, TTypestate>,
+    public machine: MachineNode<TContext, TEvent, TStateSchema, TTypestate>,
     options?: Partial<InterpreterOptions>
   ) {
     const resolvedOptions: InterpreterOptions = {
@@ -314,7 +314,7 @@ export class Interpreter<
    */
   public onStop(
     listener: Listener
-  ): Interpreter<TContext, TStateSchema, TEvent> {
+  ): Interpreter<TContext, TEvent, TStateSchema> {
     this.stopListeners.add(listener);
     return this;
   }
@@ -327,7 +327,7 @@ export class Interpreter<
    */
   public onError(
     listener: ErrorListener
-  ): Interpreter<TContext, TStateSchema, TEvent> {
+  ): Interpreter<TContext, TEvent, TStateSchema> {
     this.errorListeners.add(listener);
     return this;
   }
@@ -348,7 +348,7 @@ export class Interpreter<
    */
   public onDone(
     listener: EventListener<DoneEvent>
-  ): Interpreter<TContext, TStateSchema, TEvent> {
+  ): Interpreter<TContext, TEvent, TStateSchema> {
     this.doneListeners.add(listener);
     return this;
   }
@@ -359,7 +359,7 @@ export class Interpreter<
    */
   public off(
     listener: (...args: any[]) => void
-  ): Interpreter<TContext, TStateSchema, TEvent> {
+  ): Interpreter<TContext, TEvent, TStateSchema> {
     this.listeners.delete(listener);
     this.stopListeners.delete(listener);
     this.doneListeners.delete(listener);
@@ -375,7 +375,7 @@ export class Interpreter<
     initialState?:
       | State<TContext, TEvent, TStateSchema, TTypestate>
       | StateValue
-  ): Interpreter<TContext, TStateSchema, TEvent, TTypestate> {
+  ): Interpreter<TContext, TEvent, TStateSchema, TTypestate> {
     if (this._status === InterpreterStatus.Running) {
       // Do not restart the service if it is already started
       return this;
@@ -408,7 +408,7 @@ export class Interpreter<
    *
    * This will also notify the `onStop` listeners.
    */
-  public stop(): Interpreter<TContext, TStateSchema, TEvent> {
+  public stop(): Interpreter<TContext, TEvent, TStateSchema> {
     this.listeners.clear();
     for (const listener of this.stopListeners) {
       // call listener, then remove
@@ -838,13 +838,13 @@ export function interpret<
   TEvent extends EventObject = EventObject,
   TTypestate extends Typestate<TContext> = any
 >(
-  machine: MachineNode<TContext, TStateSchema, TEvent, TTypestate>,
+  machine: MachineNode<TContext, TEvent, TStateSchema, TTypestate>,
   options?: Partial<InterpreterOptions>
 ) {
   const interpreter = new Interpreter<
     TContext,
-    TStateSchema,
     TEvent,
+    TStateSchema,
     TTypestate
   >(machine, options);
 

--- a/packages/core/src/patterns.ts
+++ b/packages/core/src/patterns.ts
@@ -34,8 +34,8 @@ const defaultSequencePatternOptions = {
 };
 
 export function sequence<
-  TStateSchema extends StateSchema,
-  TEvent extends EventObject
+  TEvent extends EventObject,
+  TStateSchema extends StateSchema
 >(
   items: string[],
   options?: Partial<SequencePatternOptions<TEvent>>

--- a/packages/core/src/patterns.ts
+++ b/packages/core/src/patterns.ts
@@ -41,7 +41,7 @@ export function sequence<
   options?: Partial<SequencePatternOptions<TEvent>>
 ): {
   initial: string;
-  states: StatesConfig<any, TStateSchema, TEvent>;
+  states: StatesConfig<any, TEvent, TStateSchema>;
 } {
   const resolvedOptions = { ...defaultSequencePatternOptions, ...options };
   const states = {} as Record<keyof TStateSchema['states'], any>;
@@ -55,7 +55,7 @@ export function sequence<
       : toEventObject(resolvedOptions.prevEvent);
 
   items.forEach((item, i) => {
-    const state: StateNodeConfig<TEvent, TStateSchema, TEvent> = {
+    const state: StateNodeConfig<TEvent, TEvent, TStateSchema> = {
       on: {}
     };
 
@@ -76,6 +76,6 @@ export function sequence<
 
   return {
     initial: items[0] as string,
-    states: states as StatesConfig<any, TStateSchema, TEvent>
+    states: states as StatesConfig<any, TEvent, TStateSchema>
   };
 }

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -77,27 +77,25 @@ import {
 import { isActorRef } from './Actor';
 import { MachineNode } from './MachineNode';
 
-type Configuration<TC, TE extends EventObject> = Iterable<
-  StateNode<TC, any, TE>
->;
+type Configuration<TC, TE extends EventObject> = Iterable<StateNode<TC, TE>>;
 
 type AdjList<TC, TE extends EventObject> = Map<
-  StateNode<TC, any, TE>,
-  Array<StateNode<TC, any, TE>>
+  StateNode<TC, TE>,
+  Array<StateNode<TC, TE>>
 >;
 
 export const isAtomicStateNode = (stateNode: StateNode<any, any, any>) =>
   stateNode.type === 'atomic' || stateNode.type === 'final';
 
 export function getChildren<TC, TE extends EventObject>(
-  stateNode: StateNode<TC, any, TE>
-): Array<StateNode<TC, any, TE>> {
+  stateNode: StateNode<TC, TE>
+): Array<StateNode<TC, TE>> {
   return keys(stateNode.states).map((key) => stateNode.states[key]);
 }
 
 export function getProperAncestors<TContext, TEvent extends EventObject>(
-  stateNode: StateNode<TContext, any, TEvent>,
-  toStateNode: StateNode<TContext, any, TEvent> | null
+  stateNode: StateNode<TContext, TEvent>,
+  toStateNode: StateNode<TContext, TEvent> | null
 ): Array<typeof stateNode> {
   const ancestors: Array<typeof stateNode> = [];
 
@@ -112,8 +110,8 @@ export function getProperAncestors<TContext, TEvent extends EventObject>(
 }
 
 export function getAllStateNodes<TC, TE extends EventObject>(
-  stateNode: StateNode<TC, any, TE>
-): Array<StateNode<TC, any, TE>> {
+  stateNode: StateNode<TC, TE>
+): Array<StateNode<TC, TE>> {
   const stateNodes = [stateNode];
 
   if (isAtomicStateNode(stateNode)) {
@@ -126,8 +124,8 @@ export function getAllStateNodes<TC, TE extends EventObject>(
 }
 
 export function getConfiguration<TC, TE extends EventObject>(
-  stateNodes: Iterable<StateNode<TC, any, TE>>
-): Iterable<StateNode<TC, any, TE>> {
+  stateNodes: Iterable<StateNode<TC, TE>>
+): Iterable<StateNode<TC, TE>> {
   const configuration = new Set(stateNodes);
   const mutConfiguration = new Set(stateNodes);
 
@@ -169,7 +167,7 @@ export function getConfiguration<TC, TE extends EventObject>(
 }
 
 function getValueFromAdj<TC, TE extends EventObject>(
-  baseNode: StateNode<TC, any, TE>,
+  baseNode: StateNode<TC, TE>,
   adjList: AdjList<TC, TE>
 ): StateValue {
   const childStateNodes = adjList.get(baseNode);
@@ -220,7 +218,7 @@ export function getAdjList<TC, TE extends EventObject>(
 }
 
 export function getStateValue<TC, TE extends EventObject>(
-  rootNode: StateNode<TC, any, TE>,
+  rootNode: StateNode<TC, TE>,
   configuration: Configuration<TC, TE>
 ): StateValue {
   const config = getConfiguration(configuration);
@@ -240,14 +238,14 @@ export function has<T>(iterable: Iterable<T>, item: T): boolean {
 }
 
 export function nextEvents<TC, TE extends EventObject>(
-  configuration: Array<StateNode<TC, any, TE>>
+  configuration: Array<StateNode<TC, TE>>
 ): Array<TE['type']> {
   return flatten([...new Set(configuration.map((sn) => sn.ownEvents))]);
 }
 
 export function isInFinalState<TC, TE extends EventObject>(
-  configuration: Array<StateNode<TC, any, TE>>,
-  stateNode: StateNode<TC, any, TE>
+  configuration: Array<StateNode<TC, TE>>,
+  stateNode: StateNode<TC, TE>
 ): boolean {
   if (stateNode.type === 'compound') {
     return getChildren(stateNode).some(
@@ -266,7 +264,7 @@ export function isInFinalState<TC, TE extends EventObject>(
 export const isStateId = (str: string) => str[0] === STATE_IDENTIFIER;
 
 export function getCandidates<TEvent extends EventObject>(
-  stateNode: StateNode<any, any, TEvent>,
+  stateNode: StateNode<any, TEvent>,
   eventName: TEvent['type'] | NullEvent['type'] | '*'
 ) {
   const transient = eventName === NULL_EVENT;
@@ -284,7 +282,7 @@ export function getCandidates<TEvent extends EventObject>(
  * All delayed transitions from the config.
  */
 export function getDelayedTransitions<TContext, TEvent extends EventObject>(
-  stateNode: StateNode<TContext, any, TEvent>
+  stateNode: StateNode<TContext, TEvent>
 ): Array<DelayedTransitionDefinition<TContext, TEvent>> {
   const afterConfig = stateNode.config.after;
   if (!afterConfig) {
@@ -330,7 +328,7 @@ export function getDelayedTransitions<TContext, TEvent extends EventObject>(
 }
 
 export function formatTransition<TContext, TEvent extends EventObject>(
-  stateNode: StateNode<TContext, any, TEvent>,
+  stateNode: StateNode<TContext, TEvent>,
   transitionConfig: TransitionConfig<TContext, TEvent> & {
     event: TEvent['type'] | NullEvent['type'] | '*';
   }
@@ -375,7 +373,7 @@ export function formatTransition<TContext, TEvent extends EventObject>(
   return transition;
 }
 export function formatTransitions<TContext, TEvent extends EventObject>(
-  stateNode: StateNode<TContext, any, TEvent>
+  stateNode: StateNode<TContext, TEvent>
 ): Array<TransitionDefinition<TContext, TEvent>> {
   let onConfig: Array<
     TransitionConfig<TContext, EventObject> & {
@@ -461,7 +459,7 @@ export function formatTransitions<TContext, TEvent extends EventObject>(
 }
 
 export function formatInitialTransition<TContext, TEvent extends EventObject>(
-  stateNode: StateNode<TContext, any, TEvent>,
+  stateNode: StateNode<TContext, TEvent>,
   _target: SingleOrArray<string> | InitialTransitionConfig<TContext, TEvent>
 ): InitialTransitionDefinition<TContext, TEvent> {
   if (isString(_target) || isArray(_target)) {
@@ -521,9 +519,9 @@ export function formatInitialTransition<TContext, TEvent extends EventObject>(
 }
 
 export function resolveTarget<TContext, TEvent extends EventObject>(
-  stateNode: StateNode<TContext, any, TEvent>,
-  _target: Array<string | StateNode<TContext, any, TEvent>> | undefined
-): Array<StateNode<TContext, any, TEvent>> | undefined {
+  stateNode: StateNode<TContext, TEvent>,
+  _target: Array<string | StateNode<TContext, TEvent>> | undefined
+): Array<StateNode<TContext, TEvent>> | undefined {
   if (_target === undefined) {
     // an undefined target signals that the state node should not transition from that state when receiving that event
     return undefined;
@@ -558,8 +556,8 @@ export function resolveTarget<TContext, TEvent extends EventObject>(
 }
 
 function resolveHistoryTarget<TContext, TEvent extends EventObject>(
-  stateNode: StateNode<TContext, any, TEvent> & { type: 'history' }
-): Array<StateNode<TContext, any, TEvent>> {
+  stateNode: StateNode<TContext, TEvent> & { type: 'history' }
+): Array<StateNode<TContext, TEvent>> {
   const normalizedTarget = normalizeTarget<TContext, TEvent>(stateNode.target);
   if (!normalizedTarget) {
     return stateNode.parent!.initial.target;
@@ -570,14 +568,14 @@ function resolveHistoryTarget<TContext, TEvent extends EventObject>(
 }
 
 function isHistoryNode<TContext, TEvent extends EventObject>(
-  stateNode: StateNode<TContext, any, TEvent>
-): stateNode is StateNode<TContext, any, TEvent> & { type: 'history' } {
+  stateNode: StateNode<TContext, TEvent>
+): stateNode is StateNode<TContext, TEvent> & { type: 'history' } {
   return stateNode.type === 'history';
 }
 
 export function getInitialStateNodes<TContext, TEvent extends EventObject>(
-  stateNode: StateNode<TContext, any, TEvent>
-): Array<StateNode<TContext, any, TEvent>> {
+  stateNode: StateNode<TContext, TEvent>
+): Array<StateNode<TContext, TEvent>> {
   const transitions = [
     {
       target: [stateNode],
@@ -587,8 +585,8 @@ export function getInitialStateNodes<TContext, TEvent extends EventObject>(
       toJSON: null as any // TODO: fix
     }
   ];
-  const mutStatesToEnter = new Set<StateNode<TContext, any, TEvent>>();
-  const mutStatesForDefaultEntry = new Set<StateNode<TContext, any, TEvent>>();
+  const mutStatesToEnter = new Set<StateNode<TContext, TEvent>>();
+  const mutStatesForDefaultEntry = new Set<StateNode<TContext, TEvent>>();
 
   computeEntrySet(
     transitions,
@@ -603,9 +601,9 @@ export function getInitialStateNodes<TContext, TEvent extends EventObject>(
  * Returns the child state node from its relative `stateKey`, or throws.
  */
 export function getStateNode<TContext, TEvent extends EventObject>(
-  stateNode: StateNode<TContext, any, TEvent>,
+  stateNode: StateNode<TContext, TEvent>,
   stateKey: string
-): StateNode<TContext, any, TEvent> {
+): StateNode<TContext, TEvent> {
   if (isStateId(stateKey)) {
     return getStateNodeById(stateNode.machine, stateKey);
   }
@@ -628,9 +626,9 @@ export function getStateNode<TContext, TEvent extends EventObject>(
  * @param stateId The state ID. The prefix "#" is removed.
  */
 export function getStateNodeById<TContext, TEvent extends EventObject>(
-  fromStateNode: StateNode<TContext, any, TEvent>,
+  fromStateNode: StateNode<TContext, TEvent>,
   stateId: string
-): StateNode<TContext, any, TEvent> {
+): StateNode<TContext, TEvent> {
   const resolvedStateId = isStateId(stateId)
     ? stateId.slice(STATE_IDENTIFIER.length)
     : stateId;
@@ -651,9 +649,9 @@ export function getStateNodeById<TContext, TEvent extends EventObject>(
  * @param statePath The string or string array relative path to the state node.
  */
 function getStateNodeByPath<TContext, TEvent extends EventObject>(
-  stateNode: StateNode<TContext, any, TEvent>,
+  stateNode: StateNode<TContext, TEvent>,
   statePath: string | string[]
-): StateNode<TContext, any, TEvent> {
+): StateNode<TContext, TEvent> {
   if (typeof statePath === 'string' && isStateId(statePath)) {
     try {
       return getStateNodeById(stateNode, statePath.slice(1));
@@ -666,7 +664,7 @@ function getStateNodeByPath<TContext, TEvent extends EventObject>(
     statePath,
     stateNode.machine.delimiter
   ).slice();
-  let currentStateNode: StateNode<TContext, any, TEvent> = stateNode;
+  let currentStateNode: StateNode<TContext, TEvent> = stateNode;
   while (arrayStatePath.length) {
     const key = arrayStatePath.shift()!;
     if (!key.length) {
@@ -683,9 +681,9 @@ function getStateNodeByPath<TContext, TEvent extends EventObject>(
  * @param state The state value or State instance
  */
 export function getStateNodes<TContext, TEvent extends EventObject>(
-  stateNode: StateNode<TContext, any, TEvent>,
+  stateNode: StateNode<TContext, TEvent>,
   state: StateValue | State<TContext, TEvent>
-): Array<StateNode<TContext, any, TEvent>> {
+): Array<StateNode<TContext, TEvent>> {
   const stateValue =
     state instanceof State
       ? state.value
@@ -698,7 +696,6 @@ export function getStateNodes<TContext, TEvent extends EventObject>(
   const childStateKeys = keys(stateValue);
   const childStateNodes: Array<StateNode<
     TContext,
-    any,
     TEvent
   >> = childStateKeys
     .map((subStateKey) => getStateNode(stateNode, subStateKey))
@@ -716,12 +713,12 @@ export function getStateNodes<TContext, TEvent extends EventObject>(
       );
 
       return allSubStateNodes.concat(subStateNodes);
-    }, [] as Array<StateNode<TContext, any, TEvent>>)
+    }, [] as Array<StateNode<TContext, TEvent>>)
   );
 }
 
 export function evaluateGuard<TContext, TEvent extends EventObject>(
-  machine: MachineNode<TContext, any, TEvent>,
+  machine: MachineNode<TContext, TEvent>,
   guard: Guard<TContext, TEvent>,
   context: TContext,
   _event: SCXML.Event<TEvent>,
@@ -754,7 +751,7 @@ export function evaluateGuard<TContext, TEvent extends EventObject>(
 }
 
 export function transitionLeafNode<TContext, TEvent extends EventObject>(
-  stateNode: StateNode<TContext, any, TEvent>,
+  stateNode: StateNode<TContext, TEvent>,
   stateValue: string,
   state: State<TContext, TEvent>,
   _event: SCXML.Event<TEvent>
@@ -770,7 +767,7 @@ export function transitionLeafNode<TContext, TEvent extends EventObject>(
 }
 
 export function transitionCompoundNode<TContext, TEvent extends EventObject>(
-  stateNode: StateNode<TContext, any, TEvent>,
+  stateNode: StateNode<TContext, TEvent>,
   stateValue: StateValueMap,
   state: State<TContext, TEvent>,
   _event: SCXML.Event<TEvent>
@@ -792,7 +789,7 @@ export function transitionCompoundNode<TContext, TEvent extends EventObject>(
   return next;
 }
 export function transitionParallelNode<TContext, TEvent extends EventObject>(
-  stateNode: StateNode<TContext, any, TEvent>,
+  stateNode: StateNode<TContext, TEvent>,
   stateValue: StateValueMap,
   state: State<TContext, TEvent>,
   _event: SCXML.Event<TEvent>
@@ -831,7 +828,7 @@ export function transitionParallelNode<TContext, TEvent extends EventObject>(
 }
 
 export function transitionNode<TContext, TEvent extends EventObject>(
-  stateNode: StateNode<TContext, any, TEvent>,
+  stateNode: StateNode<TContext, TEvent>,
   stateValue: StateValue,
   state: State<TContext, TEvent>,
   _event: SCXML.Event<TEvent>
@@ -851,16 +848,16 @@ export function transitionNode<TContext, TEvent extends EventObject>(
 }
 
 function getHistoryNodes<TContext, TEvent extends EventObject>(
-  stateNode: StateNode<TContext, any, TEvent>
-): Array<StateNode<TContext, any, TEvent>> {
+  stateNode: StateNode<TContext, TEvent>
+): Array<StateNode<TContext, TEvent>> {
   return getChildren(stateNode).filter((sn) => {
     return sn.type === 'history';
   });
 }
 
 function isDescendant<TC, TE extends EventObject>(
-  childStateNode: StateNode<TC, any, TE>,
-  parentStateNode: StateNode<TC, any, TE>
+  childStateNode: StateNode<TC, TE>,
+  parentStateNode: StateNode<TC, TE>
 ): boolean {
   let marker = childStateNode;
   while (marker.parent && marker.parent !== parentStateNode) {
@@ -871,9 +868,9 @@ function isDescendant<TC, TE extends EventObject>(
 }
 
 function getPathFromRootToNode<TC, TE extends EventObject>(
-  stateNode: StateNode<TC, any, TE>
-): Array<StateNode<TC, any, TE>> {
-  const path: Array<StateNode<TC, any, TE>> = [];
+  stateNode: StateNode<TC, TE>
+): Array<StateNode<TC, TE>> {
+  const path: Array<StateNode<TC, TE>> = [];
   let marker = stateNode.parent;
 
   while (marker) {
@@ -906,7 +903,7 @@ export function removeConflictingTransitions<
   TEvent extends EventObject
 >(
   enabledTransitions: Array<TransitionDefinition<TContext, TEvent>>,
-  configuration: Set<StateNode<TContext, any, TEvent>>,
+  configuration: Set<StateNode<TContext, TEvent>>,
   state: State<TContext, TEvent>
 ): Array<TransitionDefinition<TContext, TEvent>> {
   const filteredTransitions = new Set<TransitionDefinition<TContext, TEvent>>();
@@ -943,12 +940,12 @@ export function removeConflictingTransitions<
 }
 
 function findLCCA<TContext, TEvent extends EventObject>(
-  stateNodes: Array<StateNode<TContext, any, TEvent>>
-): StateNode<TContext, any, TEvent> {
+  stateNodes: Array<StateNode<TContext, TEvent>>
+): StateNode<TContext, TEvent> {
   const [head] = stateNodes;
 
   let current = getPathFromRootToNode(head);
-  let candidates: Array<StateNode<TContext, any, TEvent>> = [];
+  let candidates: Array<StateNode<TContext, TEvent>> = [];
 
   stateNodes.forEach((stateNode) => {
     const path = getPathFromRootToNode(stateNode);
@@ -964,12 +961,12 @@ function findLCCA<TContext, TEvent extends EventObject>(
 function getEffectiveTargetStates<TC, TE extends EventObject>(
   transition: TransitionDefinition<TC, TE>,
   state: State<TC, TE>
-): Array<StateNode<TC, any, TE>> {
+): Array<StateNode<TC, TE>> {
   if (!transition.target) {
     return [];
   }
 
-  const targets = new Set<StateNode<TC, any, TE>>();
+  const targets = new Set<StateNode<TC, TE>>();
 
   for (const s of transition.target) {
     if (isHistoryNode(s)) {
@@ -996,7 +993,7 @@ function getEffectiveTargetStates<TC, TE extends EventObject>(
 function getTransitionDomain<TContext, TEvent extends EventObject>(
   transition: TransitionDefinition<TContext, TEvent>,
   state: State<TContext, TEvent>
-): StateNode<TContext, any, TEvent> | null {
+): StateNode<TContext, TEvent> | null {
   const targetStates = getEffectiveTargetStates(transition, state);
 
   if (!targetStates) {
@@ -1020,7 +1017,7 @@ function getTransitionDomain<TContext, TEvent extends EventObject>(
 
 function exitStates<TContext, TEvent extends EventObject>(
   transitions: Array<TransitionDefinition<TContext, TEvent>>,
-  mutConfiguration: Set<StateNode<TContext, any, TEvent>>,
+  mutConfiguration: Set<StateNode<TContext, TEvent>>,
   state: State<TContext, TEvent>
 ) {
   const statesToExit = computeExitSet(transitions, mutConfiguration, state);
@@ -1049,15 +1046,15 @@ function exitStates<TContext, TEvent extends EventObject>(
 
 export function enterStates<TContext, TEvent extends EventObject>(
   transitions: Array<TransitionDefinition<TContext, TEvent>>,
-  mutConfiguration: Set<StateNode<TContext, any, TEvent>>,
+  mutConfiguration: Set<StateNode<TContext, TEvent>>,
   state: State<TContext, TEvent>
 ) {
   const statesToInvoke: typeof mutConfiguration = new Set();
   const internalQueue: Array<SCXML.Event<TEvent>> = [];
 
   const actions: Array<ActionObject<TContext, TEvent>> = [];
-  const mutStatesToEnter = new Set<StateNode<TContext, any, TEvent>>();
-  const mutStatesForDefaultEntry = new Set<StateNode<TContext, any, TEvent>>();
+  const mutStatesToEnter = new Set<StateNode<TContext, TEvent>>();
+  const mutStatesForDefaultEntry = new Set<StateNode<TContext, TEvent>>();
 
   computeEntrySet(
     transitions,
@@ -1126,10 +1123,10 @@ export function enterStates<TContext, TEvent extends EventObject>(
 
 function computeExitSet<TContext, TEvent extends EventObject>(
   transitions: Array<TransitionDefinition<TContext, TEvent>>,
-  configuration: Set<StateNode<TContext, any, TEvent>>,
+  configuration: Set<StateNode<TContext, TEvent>>,
   state: State<TContext, TEvent>
-): Array<StateNode<TContext, any, TEvent>> {
-  const statesToExit = new Set<StateNode<TContext, any, TEvent>>();
+): Array<StateNode<TContext, TEvent>> {
+  const statesToExit = new Set<StateNode<TContext, TEvent>>();
 
   for (const t of transitions) {
     if (t.target && t.target.length) {
@@ -1149,8 +1146,8 @@ function computeExitSet<TContext, TEvent extends EventObject>(
 function computeEntrySet<TContext, TEvent extends EventObject>(
   transitions: Array<TransitionDefinition<TContext, TEvent>>,
   state: State<TContext, TEvent>,
-  mutStatesToEnter: Set<StateNode<TContext, any, TEvent>>,
-  mutStatesForDefaultEntry: Set<StateNode<TContext, any, TEvent>>
+  mutStatesToEnter: Set<StateNode<TContext, TEvent>>,
+  mutStatesForDefaultEntry: Set<StateNode<TContext, TEvent>>
 ) {
   for (const t of transitions) {
     for (const s of t.target || []) {
@@ -1176,7 +1173,7 @@ function computeEntrySet<TContext, TEvent extends EventObject>(
 }
 
 function addDescendantStatesToEnter<TContext, TEvent extends EventObject>(
-  stateNode: StateNode<TContext, any, TEvent>,
+  stateNode: StateNode<TContext, TEvent>,
   state: State<TContext, TEvent>,
   mutStatesToEnter: Set<typeof stateNode>,
   mutStatesForDefaultEntry: Set<typeof stateNode>
@@ -1271,8 +1268,8 @@ function addDescendantStatesToEnter<TContext, TEvent extends EventObject>(
 }
 
 function addAncestorStatesToEnter<TContext, TEvent extends EventObject>(
-  stateNode: StateNode<TContext, any, TEvent>,
-  toStateNode: StateNode<TContext, any, TEvent> | null,
+  stateNode: StateNode<TContext, TEvent>,
+  toStateNode: StateNode<TContext, TEvent> | null,
   state: State<TContext, TEvent>,
   mutStatesToEnter: Set<typeof stateNode>,
   mutStatesForDefaultEntry: Set<typeof stateNode>
@@ -1306,8 +1303,8 @@ function addAncestorStatesToEnter<TContext, TEvent extends EventObject>(
 export function microstep<TContext, TEvent extends EventObject>(
   transitions: Array<TransitionDefinition<TContext, TEvent>>,
   currentState: State<TContext, TEvent> | undefined,
-  mutConfiguration: Set<StateNode<TContext, any, TEvent>>,
-  machine: MachineNode<TContext, any, TEvent>,
+  mutConfiguration: Set<StateNode<TContext, TEvent>>,
+  machine: MachineNode<TContext, TEvent>,
   _event: SCXML.Event<TEvent>,
   service?: ActorRef<TEvent>
 ): {
@@ -1383,7 +1380,7 @@ export function microstep<TContext, TEvent extends EventObject>(
 
 function selectEventlessTransitions<TContext, TEvent extends EventObject>(
   state: State<TContext, TEvent>,
-  machine: MachineNode<TContext, any, TEvent>
+  machine: MachineNode<TContext, TEvent>
 ): Transitions<TContext, TEvent> {
   const enabledTransitions: Set<TransitionDefinition<
     TContext,
@@ -1427,7 +1424,7 @@ export function resolveMicroTransition<
   TEvent extends EventObject,
   TTypestate extends Typestate<TContext>
 >(
-  machine: MachineNode<TContext, any, TEvent>,
+  machine: MachineNode<TContext, TEvent>,
   transitions: Transitions<TContext, TEvent>,
   currentState?: State<TContext, TEvent>,
   _event: SCXML.Event<TEvent> = initEvent as SCXML.Event<TEvent>,
@@ -1548,7 +1545,7 @@ export function resolveMicroTransition<
 
 function resolveActionsAndContext<TContext, TEvent extends EventObject>(
   actions: Array<ActionObject<TContext, TEvent>>,
-  machine: MachineNode<TContext, any, TEvent, any>,
+  machine: MachineNode<TContext, TEvent, any>,
   _event: SCXML.Event<TEvent>,
   currentState: State<TContext, TEvent, any, any> | undefined,
   service?: ActorRef<TEvent>
@@ -1690,7 +1687,7 @@ export function macrostep<
 >(
   state: State<TContext, TEvent, any, TTypestate>,
   event: Event<TEvent> | SCXML.Event<TEvent> | null,
-  machine: MachineNode<TContext, any, TEvent, any>,
+  machine: MachineNode<TContext, TEvent, any>,
   service?: ActorRef<TEvent>
 ): typeof state {
   // Assume the state is at rest (no raised events)
@@ -1730,17 +1727,17 @@ export function macrostep<
 
 function resolveHistoryValue<TContext, TEvent extends EventObject>(
   currentState: State<TContext, TEvent, any, any> | undefined,
-  exitSet: Array<StateNode<TContext, any, TEvent>>
+  exitSet: Array<StateNode<TContext, TEvent>>
 ): HistoryValue<TContext, TEvent> {
   const historyValue: Record<
     string,
-    Array<StateNode<TContext, any, TEvent>>
+    Array<StateNode<TContext, TEvent>>
   > = currentState ? currentState.historyValue : {};
   if (currentState && currentState.configuration) {
     // From SCXML algorithm: https://www.w3.org/TR/scxml/#exitStates
     for (const exitStateNode of exitSet) {
       for (const historyNode of getHistoryNodes(exitStateNode)) {
-        let predicate: (sn: StateNode<TContext, any, TEvent>) => boolean;
+        let predicate: (sn: StateNode<TContext, TEvent>) => boolean;
         if (historyNode.history === 'deep') {
           predicate = (sn) =>
             isAtomicStateNode(sn) && isDescendant(sn, exitStateNode);
@@ -1764,7 +1761,7 @@ function resolveHistoryValue<TContext, TEvent extends EventObject>(
  * @param stateValue The partial state value to resolve.
  */
 export function resolveStateValue<TContext, TEvent extends EventObject>(
-  rootNode: StateNode<TContext, any, TEvent>,
+  rootNode: StateNode<TContext, TEvent>,
   stateValue: StateValue
 ): StateValue {
   const configuration = getConfiguration(
@@ -1775,7 +1772,7 @@ export function resolveStateValue<TContext, TEvent extends EventObject>(
 
 export function toState<TContext, TEvent extends EventObject>(
   state: StateValue | State<TContext, TEvent>,
-  machine: MachineNode<TContext, any, TEvent>
+  machine: MachineNode<TContext, TEvent>
 ): State<TContext, TEvent> {
   if (state instanceof State) {
     return state;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -134,7 +134,7 @@ export type Condition<TContext, TEvent extends EventObject> =
 export type TransitionTarget<
   TContext,
   TEvent extends EventObject
-> = SingleOrArray<string | StateNode<TContext, any, TEvent>>;
+> = SingleOrArray<string | StateNode<TContext, TEvent>>;
 
 export type TransitionTargets<TContext> = Array<
   string | StateNode<TContext, any>
@@ -254,44 +254,44 @@ export type SingleOrArray<T> = T[] | T;
 
 export type StateNodesConfig<
   TContext,
-  TStateSchema extends StateSchema,
-  TEvent extends EventObject
+  TEvent extends EventObject,
+  TStateSchema extends StateSchema
 > = {
   [K in keyof TStateSchema['states']]: StateNode<
     TContext,
-    TStateSchema['states'][K],
-    TEvent
+    TEvent,
+    TStateSchema['states'][K]
   >;
 };
 
 export type StatesConfig<
   TContext,
-  TStateSchema extends StateSchema,
-  TEvent extends EventObject
+  TEvent extends EventObject,
+  TStateSchema extends StateSchema
 > = {
   [K in keyof TStateSchema['states']]: StateNodeConfig<
     TContext,
-    TStateSchema['states'][K],
-    TEvent
+    TEvent,
+    TStateSchema['states'][K]
   >;
 };
 
 export type StatesDefinition<
   TContext,
-  TStateSchema extends StateSchema,
-  TEvent extends EventObject
+  TEvent extends EventObject,
+  TStateSchema extends StateSchema
 > = {
   [K in keyof TStateSchema['states']]: StateNodeDefinition<
     TContext,
-    TStateSchema['states'][K],
-    TEvent
+    TEvent,
+    TStateSchema['states'][K]
   >;
 };
 
 export type TransitionConfigTarget<TContext, TEvent extends EventObject> =
   | string
   | undefined
-  | StateNode<TContext, any, TEvent>;
+  | StateNode<TContext, TEvent>;
 
 export type TransitionConfigOrTarget<
   TContext,
@@ -367,8 +367,8 @@ export interface InvokeConfig<TContext, TEvent extends EventObject> {
 
 export interface StateNodeConfig<
   TContext,
-  TStateSchema extends StateSchema,
-  TEvent extends EventObject
+  TEvent extends EventObject,
+  TStateSchema extends StateSchema = any
 > {
   /**
    * The relative key of the state node, which represents its location in the overall state value.
@@ -407,7 +407,7 @@ export interface StateNodeConfig<
   /**
    * The mapping of state node keys to their state node configurations (recursive).
    */
-  states?: StatesConfig<TContext, TStateSchema, TEvent> | undefined;
+  states?: StatesConfig<TContext, TEvent, TStateSchema> | undefined;
   /**
    * The services to invoke upon entering this state node. These services will be stopped upon exiting this state node.
    */
@@ -440,7 +440,7 @@ export interface StateNodeConfig<
   /**
    * @private
    */
-  parent?: StateNode<TContext, any, TEvent>;
+  parent?: StateNode<TContext, TEvent>;
   strict?: boolean | undefined;
   /**
    * The meta data associated with this state node, which will be returned in State instances.
@@ -470,8 +470,8 @@ export interface StateNodeConfig<
 
 export interface StateNodeDefinition<
   TContext,
-  TStateSchema extends StateSchema,
-  TEvent extends EventObject
+  TEvent extends EventObject,
+  TStateSchema extends StateSchema
 > {
   id: string;
   version?: string | undefined;
@@ -480,7 +480,7 @@ export interface StateNodeDefinition<
   type: 'atomic' | 'compound' | 'parallel' | 'final' | 'history';
   initial: InitialTransitionDefinition<TContext, TEvent> | undefined;
   history: boolean | 'shallow' | 'deep' | undefined;
-  states: StatesDefinition<TContext, TStateSchema, TEvent>;
+  states: StatesDefinition<TContext, TEvent, TStateSchema>;
   on: TransitionDefinitionMap<TContext, TEvent>;
   transitions: Array<TransitionDefinition<TContext, TEvent>>;
   entry: Array<ActionObject<TContext, TEvent>>;
@@ -493,7 +493,7 @@ export interface StateNodeDefinition<
 
 export type AnyStateNodeDefinition = StateNodeDefinition<any, any, any>;
 export interface AtomicStateNodeConfig<TContext, TEvent extends EventObject>
-  extends StateNodeConfig<TContext, StateSchema, TEvent> {
+  extends StateNodeConfig<TContext, TEvent> {
   initial?: undefined;
   parallel?: false | undefined;
   states?: undefined;
@@ -518,11 +518,11 @@ export interface FinalStateNodeConfig<TContext, TEvent extends EventObject>
 
 export type SimpleOrStateNodeConfig<
   TContext,
-  TStateSchema extends StateSchema,
-  TEvent extends EventObject
+  TEvent extends EventObject,
+  TStateSchema extends StateSchema
 > =
   | AtomicStateNodeConfig<TContext, TEvent>
-  | StateNodeConfig<TContext, TStateSchema, TEvent>;
+  | StateNodeConfig<TContext, TEvent, TStateSchema>;
 
 export type ActionFunctionMap<TContext, TEvent extends EventObject> = Record<
   string,
@@ -547,9 +547,9 @@ export interface MachineOptions<TContext, TEvent extends EventObject> {
 }
 export interface MachineConfig<
   TContext,
-  TStateSchema extends StateSchema,
-  TEvent extends EventObject
-> extends StateNodeConfig<TContext, TStateSchema, TEvent> {
+  TEvent extends EventObject,
+  TStateSchema extends StateSchema
+> extends StateNodeConfig<TContext, TEvent, TStateSchema> {
   /**
    * The initial context (extended state)
    */
@@ -567,7 +567,7 @@ export interface HistoryStateNode<TContext> extends StateNode<TContext> {
 
 export type HistoryValue<TContext, TEvent extends EventObject> = Record<
   string,
-  Array<StateNode<TContext, any, TEvent>>
+  Array<StateNode<TContext, TEvent>>
 >;
 
 export type StateFrom<TMachine extends MachineNode<any, any, any>> = ReturnType<
@@ -816,8 +816,8 @@ export interface ChooseAction<TContext, TEvent extends EventObject>
 
 export interface TransitionDefinition<TContext, TEvent extends EventObject>
   extends TransitionConfig<TContext, TEvent> {
-  target: Array<StateNode<TContext, any, TEvent>> | undefined;
-  source: StateNode<TContext, any, TEvent>;
+  target: Array<StateNode<TContext, TEvent>> | undefined;
+  source: StateNode<TContext, TEvent>;
   actions: Array<ActionObject<TContext, TEvent>>;
   cond?: Guard<TContext, TEvent>;
   eventType: TEvent['type'] | NullEvent['type'] | '*';
@@ -834,7 +834,7 @@ export interface InitialTransitionDefinition<
   TContext,
   TEvent extends EventObject
 > extends TransitionDefinition<TContext, TEvent> {
-  target: Array<StateNode<TContext, any, TEvent>>;
+  target: Array<StateNode<TContext, TEvent>>;
   cond?: never;
 }
 
@@ -860,8 +860,8 @@ export interface Edge<
   TEventType extends TEvent['type'] = string
 > {
   event: TEventType;
-  source: StateNode<TContext, any, TEvent>;
-  target: StateNode<TContext, any, TEvent>;
+  source: StateNode<TContext, TEvent>;
+  target: StateNode<TContext, TEvent>;
   cond?: Condition<TContext, TEvent & { type: TEventType }>;
   actions: Array<Action<TContext, TEvent>>;
   meta?: MetaObject;
@@ -944,7 +944,7 @@ export interface StateConfig<TContext, TEvent extends EventObject> {
   historyValue?: HistoryValue<TContext, TEvent>;
   actions?: Array<ActionObject<TContext, TEvent>>;
   meta?: any;
-  configuration: Array<StateNode<TContext, any, TEvent>>;
+  configuration: Array<StateNode<TContext, TEvent>>;
   transitions: Array<TransitionDefinition<TContext, TEvent>>;
   children: Record<string, ActorRef<any>>;
   done?: boolean;
@@ -1107,7 +1107,6 @@ export interface ActorRef<TEvent extends EventObject, TEmitted = any>
 
 export type ActorRefFrom<T extends Spawnable> = T extends MachineNode<
   infer TC,
-  any,
   infer TE
 >
   ? ActorRef<TE, State<TC, TE>>

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -456,8 +456,8 @@ export function toTransitionConfigArray<TContext, TEvent extends EventObject>(
 }
 
 export function normalizeTarget<TContext, TEvent extends EventObject>(
-  target: SingleOrArray<string | StateNode<TContext, any, TEvent>> | undefined
-): Array<string | StateNode<TContext, any, TEvent>> | undefined {
+  target: SingleOrArray<string | StateNode<TContext, TEvent>> | undefined
+): Array<string | StateNode<TContext, TEvent>> | undefined {
   if (target === undefined || target === TARGETLESS_KEY) {
     return undefined;
   }

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -703,7 +703,7 @@ describe('actions config', () => {
   interface Context {
     count: number;
   }
-  interface State {
+  interface StateSchema {
     states: {
       a: {};
       b: {};
@@ -712,7 +712,7 @@ describe('actions config', () => {
 
   // tslint:disable-next-line:no-empty
   const definedAction = () => {};
-  const simpleMachine = Machine<Context, State, EventType>(
+  const simpleMachine = Machine<Context, EventType, StateSchema>(
     {
       initial: 'a',
       context: {
@@ -770,7 +770,7 @@ describe('actions config', () => {
   });
 
   it('should be able to reference action implementations from action objects', () => {
-    const machine = Machine<Context, State, EventType>(
+    const machine = Machine<Context, EventType, StateSchema>(
       {
         initial: 'a',
         context: {
@@ -1475,7 +1475,7 @@ describe('sendParent', () => {
       type: 'CHILD';
     }
 
-    const child = Machine<ChildContext, any, ChildEvent>({
+    const child = Machine<ChildContext, ChildEvent>({
       id: 'child',
       initial: 'start',
       states: {

--- a/packages/core/test/machine.test.ts
+++ b/packages/core/test/machine.test.ts
@@ -26,7 +26,7 @@ interface LightStateSchema {
   };
 }
 
-const lightMachine = Machine<undefined, LightStateSchema>({
+const lightMachine = Machine<undefined, any, LightStateSchema>({
   key: 'light',
   initial: 'green',
   states: {

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -34,7 +34,7 @@ describe('StateSchema', () => {
     elapsed: number;
   }
 
-  const lightMachine = Machine<LightContext, LightStateSchema, LightEvent>({
+  const lightMachine = Machine<LightContext, LightEvent, LightStateSchema>({
     key: 'light',
     initial: 'green',
     meta: { interval: 1000 },
@@ -118,8 +118,8 @@ describe('Parallel StateSchema', () => {
 
   const parallelMachine = Machine<
     ParallelContext,
-    ParallelStateSchema,
-    ParallelEvent
+    ParallelEvent,
+    ParallelStateSchema
   >({
     type: 'parallel',
     states: {
@@ -166,8 +166,8 @@ describe('Nested parallel stateSchema', () => {
 
   const nestedParallelMachine = Machine<
     ParallelContext,
-    ParallelStateSchema,
-    ParallelEvent
+    ParallelEvent,
+    ParallelStateSchema
   >({
     initial: 'foo',
     states: {
@@ -230,8 +230,8 @@ describe('Raise events', () => {
 
     const raiseGreetingMachine = Machine<
       GreetingContext,
-      GreetingStateSchema,
-      GreetingEvent
+      GreetingEvent,
+      GreetingStateSchema
     >({
       key: 'greeting',
       context: greetingContext,

--- a/packages/xstate-graph/src/graph.ts
+++ b/packages/xstate-graph/src/graph.ts
@@ -78,7 +78,7 @@ export function getAdjacencyMap<
   TContext = DefaultContext,
   TEvent extends EventObject = AnyEventObject
 >(
-  node: MachineNode<TContext, any, TEvent> | MachineNode<TContext, any, TEvent>,
+  node: MachineNode<TContext, TEvent> | MachineNode<TContext, TEvent>,
   options?: Partial<ValueAdjMapOptions<TContext, TEvent>>
 ): AdjacencyMap<TContext, TEvent> {
   const optionsWithDefaults = {
@@ -143,7 +143,7 @@ export function getShortestPaths<
   TContext = DefaultContext,
   TEvent extends EventObject = EventObject
 >(
-  machine: MachineNode<TContext, any, TEvent>,
+  machine: MachineNode<TContext, TEvent>,
   options?: Partial<ValueAdjMapOptions<TContext, TEvent>>
 ): StatePathsMap<TContext, TEvent> {
   if (!machine.states) {
@@ -238,7 +238,7 @@ export function getSimplePaths<
   TContext = DefaultContext,
   TEvent extends EventObject = EventObject
 >(
-  machine: MachineNode<TContext, any, TEvent>,
+  machine: MachineNode<TContext, TEvent>,
   options?: Partial<ValueAdjMapOptions<TContext, TEvent>>
 ): StatePathsMap<TContext, TEvent> {
   const optionsWithDefaults = {
@@ -314,7 +314,7 @@ export function getSimplePathsAsArray<
   TContext = DefaultContext,
   TEvent extends EventObject = EventObject
 >(
-  machine: MachineNode<TContext, any, TEvent>,
+  machine: MachineNode<TContext, TEvent>,
   options?: ValueAdjMapOptions<TContext, TEvent>
 ): Array<StatePaths<TContext, TEvent>> {
   const result = getSimplePaths(machine, options);

--- a/packages/xstate-react/src/useMachine.ts
+++ b/packages/xstate-react/src/useMachine.ts
@@ -102,14 +102,14 @@ export function useMachine<
   TEvent extends EventObject,
   TTypestate extends Typestate<TContext> = any
 >(
-  machine: MachineNode<TContext, any, TEvent, TTypestate>,
+  machine: MachineNode<TContext, TEvent, TTypestate>,
   options: Partial<InterpreterOptions> &
     Partial<UseMachineOptions<TContext, TEvent>> &
     Partial<MachineOptions<TContext, TEvent>> = {}
 ): [
   State<TContext, TEvent, any, TTypestate>,
-  Interpreter<TContext, any, TEvent, TTypestate>['send'],
-  Interpreter<TContext, any, TEvent, TTypestate>
+  Interpreter<TContext, TEvent, TTypestate>['send'],
+  Interpreter<TContext, TEvent, TTypestate>
 ] {
   if (process.env.NODE_ENV !== 'production') {
     const [initialMachine] = useState(machine);

--- a/packages/xstate-react/src/useService.ts
+++ b/packages/xstate-react/src/useService.ts
@@ -7,11 +7,11 @@ export function useService<
   TEvent extends EventObject,
   TTypestate extends Typestate<TContext> = any
 >(
-  service: Interpreter<TContext, any, TEvent, TTypestate>
+  service: Interpreter<TContext, TEvent, TTypestate>
 ): [
   State<TContext, TEvent, any, TTypestate>,
-  Interpreter<TContext, any, TEvent, TTypestate>['send'],
-  Interpreter<TContext, any, TEvent, TTypestate>
+  Interpreter<TContext, TEvent, TTypestate>['send'],
+  Interpreter<TContext, TEvent, TTypestate>
 ] {
   const subscription: Subscription<State<
     TContext,

--- a/packages/xstate-react/test/types.test.tsx
+++ b/packages/xstate-react/test/types.test.tsx
@@ -30,7 +30,7 @@ describe('useService', () => {
       }
     });
 
-    const todosMachine = Machine<TodosCtx, any, { type: 'CREATE' }>({
+    const todosMachine = Machine<TodosCtx, { type: 'CREATE' }>({
       context: { todos: [] },
       initial: 'working',
       states: { working: {} },

--- a/packages/xstate-vue/src/index.ts
+++ b/packages/xstate-vue/src/index.ts
@@ -30,14 +30,14 @@ interface UseMachineOptions<TContext, TEvent extends EventObject> {
 }
 
 export function useMachine<TContext, TEvent extends EventObject>(
-  machine: MachineNode<TContext, any, TEvent>,
+  machine: MachineNode<TContext, TEvent>,
   options: Partial<InterpreterOptions> &
     Partial<UseMachineOptions<TContext, TEvent>> &
     Partial<MachineOptions<TContext, TEvent>> = {}
 ): {
   state: Ref<State<TContext, TEvent>>;
-  send: Interpreter<TContext, any, TEvent>['send'];
-  service: Interpreter<TContext, any, TEvent>;
+  send: Interpreter<TContext, TEvent>['send'];
+  service: Interpreter<TContext, TEvent>;
 } {
   const {
     context,
@@ -88,17 +88,15 @@ export function useMachine<TContext, TEvent extends EventObject>(
 }
 
 export function useService<TContext, TEvent extends EventObject>(
-  service:
-    | Interpreter<TContext, any, TEvent>
-    | Ref<Interpreter<TContext, any, TEvent>>
+  service: Interpreter<TContext, TEvent> | Ref<Interpreter<TContext, TEvent>>
 ): {
   state: Ref<State<TContext, TEvent>>;
-  send: Interpreter<TContext, any, TEvent>['send'];
-  service: Ref<Interpreter<TContext, any, TEvent>>;
+  send: Interpreter<TContext, TEvent>['send'];
+  service: Ref<Interpreter<TContext, TEvent>>;
 } {
   const serviceRef = isRef(service)
     ? service
-    : ref<Interpreter<TContext, any, TEvent>>(service);
+    : ref<Interpreter<TContext, TEvent>>(service);
   const state = ref<State<TContext, TEvent>>(serviceRef.value.state);
 
   watch(serviceRef, (watchedService, _, onCleanup) => {


### PR DESCRIPTION
This PR makes the order of `TContext, TEvent, TStateSchema` consistent across the codebase.