### PR TITLE
Node data stricter types

### DIFF
--- a/.changeset/fluffy-terms-sleep.md
+++ b/.changeset/fluffy-terms-sleep.md
@@ -1,0 +1,5 @@
+---
+'xstate': minor
+---
+
+Improved type inference for `InvokeConfig['data']`. This has required renaming `data` property on `StateNode` instances to `doneData`. This property was never meant to be a part of the public API, so we don't consider this to be a breaking change.

--- a/.changeset/old-dolphins-wink.md
+++ b/.changeset/old-dolphins-wink.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+`StateMachine<any, any, any>` is no longer a part of the `InvokeConfig` type, but rather it creates a union with `InvokeConfig` in places where it is needed. This change shouldn't affect consumers' code.

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -225,7 +225,9 @@ class StateNode<
   /**
    * The data sent with the "done.state._id_" event if this is a final state node.
    */
-  public data?: Mapper<TContext, TEvent> | PropertyMapper<TContext, TEvent>;
+  public doneData?:
+    | Mapper<TContext, TEvent, any>
+    | PropertyMapper<TContext, TEvent, any>;
   /**
    * The string delimiter for serializing the path to a string. The default is "."
    */
@@ -373,7 +375,7 @@ class StateNode<
       this.config.exit || this.config.onExit
     ).map((action) => toActionObject(action));
     this.meta = this.config.meta;
-    this.data =
+    this.doneData =
       this.type === 'final'
         ? (this.config as FinalStateNodeConfig<TContext, TEvent>).data
         : undefined;
@@ -483,7 +485,7 @@ class StateNode<
       activities: this.activities || [],
       meta: this.meta,
       order: this.order || -1,
-      data: this.data,
+      data: this.doneData,
       invoke: this.invoke
     };
   }
@@ -959,10 +961,12 @@ class StateNode<
         }
 
         events.push(
-          done(sn.id, sn.data), // TODO: deprecate - final states should not emit done events for their own state.
+          done(sn.id, sn.doneData), // TODO: deprecate - final states should not emit done events for their own state.
           done(
             parent.id,
-            sn.data ? mapContext(sn.data, currentContext, _event) : undefined
+            sn.doneData
+              ? mapContext(sn.doneData, currentContext, _event)
+              : undefined
           )
         );
 

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -974,7 +974,7 @@ class StateNode<
               isInFinalState(transition.configuration, parentNode)
             )
           ) {
-            events.push(done(grandparent.id, grandparent.data));
+            events.push(done(grandparent.id));
           }
         }
 

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -305,8 +305,8 @@ export class Interpreter<
       );
 
       const doneData =
-        finalChildStateNode && finalChildStateNode.data
-          ? mapContext(finalChildStateNode.data, state.context, _event)
+        finalChildStateNode && finalChildStateNode.doneData
+          ? mapContext(finalChildStateNode.doneData, state.context, _event)
           : undefined;
 
       for (const listener of this.doneListeners) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -62,7 +62,7 @@ export type ActionFunction<TContext, TEvent extends EventObject> = (
   context: TContext,
   event: TEvent,
   meta: ActionMeta<TContext, TEvent>
-) => any | void;
+) => void;
 
 export interface ChooseConditon<TContext, TEvent extends EventObject> {
   cond?: Condition<TContext, TEvent>;
@@ -585,7 +585,7 @@ export interface FinalStateNodeConfig<TContext, TEvent extends EventObject>
    * The data to be sent with the "done.state.<id>" event. The data can be
    * static or dynamic (based on assigners).
    */
-  data?: Assigner<TContext, TEvent> | PropertyAssigner<TContext, TEvent> | any;
+  data?: Mapper<TContext, TEvent> | PropertyMapper<TContext, TEvent>;
 }
 
 export type SimpleOrStateNodeConfig<
@@ -903,7 +903,7 @@ export type Mapper<TContext, TEvent extends EventObject> = (
 ) => any;
 
 export type PropertyMapper<TContext, TEvent extends EventObject> = Partial<{
-  [key: string]: ((context: TContext, event: TEvent) => any) | any;
+  [key: string]: (context: TContext, event: TEvent) => any;
 }>;
 
 export interface AnyAssignAction<TContext, TEvent extends EventObject>
@@ -1166,7 +1166,7 @@ export namespace SCXML {
 
 // Taken from RxJS
 export interface Unsubscribable {
-  unsubscribe(): any | void;
+  unsubscribe(): void;
 }
 export interface Subscribable<T> {
   subscribe(

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -515,9 +515,7 @@ export function toGuard<TContext, TEvent extends EventObject>(
   return condition;
 }
 
-export function isObservable<T>(
-  value: Subscribable<T> | any
-): value is Subscribable<T> {
+export function isObservable<T>(value: any): value is Subscribable<T> {
   try {
     return 'subscribe' in value && isFunction(value.subscribe);
   } catch (e) {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -309,17 +309,17 @@ export function toArray<T>(value: T[] | T | undefined): T[] {
 }
 
 export function mapContext<TContext, TEvent extends EventObject>(
-  mapper: Mapper<TContext, TEvent> | PropertyMapper<TContext, TEvent>,
+  mapper: Mapper<TContext, TEvent, any> | PropertyMapper<TContext, TEvent, any>,
   context: TContext,
   _event: SCXML.Event<TEvent>
 ): any {
   if (isFunction(mapper)) {
-    return (mapper as Mapper<TContext, TEvent>)(context, _event.data);
+    return mapper(context, _event.data);
   }
 
   const result = {} as any;
 
-  for (const key of keys(mapper)) {
+  for (const key of Object.keys(mapper)) {
     const subMapper = mapper[key];
 
     if (isFunction(subMapper)) {

--- a/packages/xstate-react/src/types.ts
+++ b/packages/xstate-react/src/types.ts
@@ -3,7 +3,7 @@ import { EventObject } from 'xstate';
 export type Sender<TEvent extends EventObject> = (event: TEvent) => void;
 
 export interface Subscription {
-  unsubscribe(): any | void;
+  unsubscribe(): void;
 }
 
 export interface Observer<T> {

--- a/packages/xstate-scxml/src/index.ts
+++ b/packages/xstate-scxml/src/index.ts
@@ -135,8 +135,8 @@ function stateNodeToSCXML(stateNode: StateNode<any, any, any>): XMLElement {
   elements.push(...transitionElements);
   elements.push(...childStates);
 
-  if (stateNode.type === 'final' && stateNode.data) {
-    elements.push(doneDataToSCXML(stateNode.data));
+  if (stateNode.type === 'final' && stateNode.doneData) {
+    elements.push(doneDataToSCXML(stateNode.doneData));
   }
 
   return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1991,10 +1991,10 @@
     source-map "~0.6.1"
     vue-template-es2015-compiler "^1.9.0"
 
-"@vue/composition-api@~0.6.5":
-  version "0.6.5"
-  resolved "https://registry.yarnpkg.com/@vue/composition-api/-/composition-api-0.6.5.tgz#890b4ab3777ee95c6d633872db2bf53a45446d5b"
-  integrity sha512-IRdtn6/59yPNmvzlu5JTAR3SK0kK5T69wtz8oefSY8FFUPoOe7A2BlcVCypRX7jTmpBADhrHkAiklc8ffmPOuQ==
+"@vue/composition-api@^0.6.5":
+  version "0.6.7"
+  resolved "https://registry.yarnpkg.com/@vue/composition-api/-/composition-api-0.6.7.tgz#4481b547cea65dc936432f7efcf1a39f9c69420c"
+  integrity sha512-WAWEQK4urEsMNe3OyOp7VnMmegRZT2yRB3fDGLRXPMdfuo4+nM+uMEhUgDiUg9LFSXfLWhjwuFOJ2hnS2X7AUw==
   dependencies:
     tslib "^2.0.0"
 


### PR DESCRIPTION
Addresses https://github.com/davidkpiano/xstate/discussions/1261

I still need to write changeset for this but I would like to get feedback first.

1. I've removed all `| any` that I could find because it's like multiplying by 0 - you always get ~0~ any, all other union members are just lost
2. Had to rename `StateNode#data` to `StateNode#doneData` because TS couldn't infer things correctly due to overlapping `.data` properties in both `InvokeConfig` and `StateNode` which are both allowed for `invoke` property. A simplified version of the problem can be checked out [here](https://www.typescriptlang.org/play/index.html#code/C4TwDgpgBAsghmSAnAPAFQMIHsB2wIAewANFGgKIBuEepaACnEnALYDOUh+OAJhwN4BfAHxQAvFAAUAY2AEAXGWx4upCJUUVqeAJTjRDJqzYAoE9IA2cNhwDKwOPgByWHhHTL8ROlRrBh-FBQJkFgAK4ARhYAltJQPI5wAPyK8IgQqJi4XiRkvrRQcDggwiaCZqCQUACSOJRYANYQygBm0QDmHtmqedr+UPwhUGxI0opswEjROO3EQwkOKbAIyF0q3r1+pEUlZRXg0K0dazk+faKDQdP1TYq1N824bZ1Z67lafqIA9F9QAD5QeyOCAuNwoHbbYqlcomFphHCyaK4KDSJAQYEnHofPDCGRPDqKI4vTxY-L+HSKIHOVzuV6nTY4gZDNHAMJIHBQHBhCwWQocHZ7cxojGBaRYeH4JCKLksCIZKCCUiBSoQRQAcgAYgB5LVqhW4y5Qa6NVVMoJBEZjKBqhJsNVzc3xRKKGRyNSUPRiC7lILlQQ6IA) after uncommenting that single comment in the `Config` type