### PR TITLE
[@xstate/fsm] Allow to rehydrate interpreted state machine 

### DIFF
--- a/.changeset/light-news-add.md
+++ b/.changeset/light-news-add.md
@@ -2,4 +2,12 @@
 '@xstate/fsm': minor
 ---
 
-You can now rehydrate the state of a service by calling `start` with `initialState` argument.
+You can now rehydrate the state of a service by calling `start` with `initialState` argument:
+
+```js
+interpret(someMachine).start('active');
+
+interpret(anotherMachine).start({
+  value: 'active',
+  context: { count: 42 }
+});

--- a/.changeset/light-news-add.md
+++ b/.changeset/light-news-add.md
@@ -1,0 +1,5 @@
+---
+'@xstate/fsm': minor
+---
+
+The service can rehydrate the state on start

--- a/.changeset/light-news-add.md
+++ b/.changeset/light-news-add.md
@@ -2,4 +2,4 @@
 '@xstate/fsm': minor
 ---
 
-The service can rehydrate the state on start
+You can now rehydrate the state of a service by calling `start` with `initialState` argument.

--- a/docs/packages/xstate-fsm/index.md
+++ b/docs/packages/xstate-fsm/index.md
@@ -291,9 +291,11 @@ Sends an `event` to the interpreted machine. The event can be a string (e.g., `"
 | -------- | ----------------------------------- | ------------------------------------------------ |
 | `event`  | `string` or `{ type: string, ... }` | The event to be sent to the interpreted machine. |
 
-### `service.start()`
+### `service.start(initialState?)`
 
 Starts the interpreted machine.
+
+If `initialState` value is provided, rehydrates the state of the interpreted machine.
 
 Events sent to the interpreted machine will not trigger any transitions until the service is started. All listeners (via `service.subscribe(listener)`) will receive the `machine.initialState`.
 

--- a/docs/packages/xstate-fsm/index.md
+++ b/docs/packages/xstate-fsm/index.md
@@ -295,7 +295,9 @@ Sends an `event` to the interpreted machine. The event can be a string (e.g., `"
 
 Starts the interpreted machine.
 
-If `initialState` value is provided, rehydrates the state of the interpreted machine.
+| Argument       | Type                                           | Description                                                                                         |
+| -------------- | ---------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `initialState` | `string` or `{value: string, context: object}` | Optional. The state the interpreted machine will start. If not provided, starts with initial state. |
 
 Events sent to the interpreted machine will not trigger any transitions until the service is started. All listeners (via `service.subscribe(listener)`) will receive the `machine.initialState`.
 

--- a/packages/xstate-fsm/src/index.ts
+++ b/packages/xstate-fsm/src/index.ts
@@ -237,10 +237,7 @@ export function interpret<
       };
     },
     start: (initialState: TState['value']) => {
-      if (
-        initialState &&
-        Array.from(Object.keys(machine.config.states)).includes(initialState)
-      ) {
+      if (initialState && initialState in machine.config.states) {
         state = machine.getStateByValue(initialState);
       }
       status = InterpreterStatus.Running;

--- a/packages/xstate-fsm/src/index.ts
+++ b/packages/xstate-fsm/src/index.ts
@@ -95,24 +95,17 @@ export function createMachine<
     });
   }
 
-  const getStateByValue = (
-    state: TState['value']
-  ): StateMachine.State<TContext, TEvent, TState> => {
-    return {
-      value: state,
-      actions: toArray(fsmConfig.states[state].entry).map((action) =>
-        toActionObject(action, options.actions)
-      ),
-      context: fsmConfig.context!,
-      matches: createMatcher(state)
-    };
-  };
-
   const machine = {
     config: fsmConfig,
     _options: options,
-    initialState: getStateByValue(fsmConfig.initial),
-    getStateByValue,
+    initialState: {
+      value: fsmConfig.initial,
+      actions: toArray(
+        fsmConfig.states[fsmConfig.initial].entry
+      ).map((action) => toActionObject(action, options.actions)),
+      context: fsmConfig.context!,
+      matches: createMatcher(fsmConfig.initial)
+    },
     transition: (
       state: string | StateMachine.State<TContext, TEvent, TState>,
       event: string | (Record<string, any> & { type: string })
@@ -247,7 +240,12 @@ export function interpret<
         }
       }
       if (initialState) {
-        state = machine.getStateByValue(initialState);
+        state = {
+          value: initialState,
+          actions: [],
+          context: machine.config.context!,
+          matches: createMatcher(initialState)
+        };
       }
       status = InterpreterStatus.Running;
       executeStateActions(state, INIT_EVENT);

--- a/packages/xstate-fsm/src/index.ts
+++ b/packages/xstate-fsm/src/index.ts
@@ -237,7 +237,16 @@ export function interpret<
       };
     },
     start: (initialState: TState['value']) => {
-      if (initialState && initialState in machine.config.states) {
+      if (!IS_PRODUCTION) {
+        if (initialState && !(initialState in machine.config.states)) {
+          throw new Error(
+            `Cannot start service in state '${initialState}'. The state is not found on machine${
+              machine.config.id ? ` '${machine.config.id}'` : ''
+            }.`
+          );
+        }
+      }
+      if (initialState) {
         state = machine.getStateByValue(initialState);
       }
       status = InterpreterStatus.Running;

--- a/packages/xstate-fsm/src/index.ts
+++ b/packages/xstate-fsm/src/index.ts
@@ -87,16 +87,14 @@ export function createMachine<
   } = {}
 ): StateMachine.Machine<TContext, TEvent, TState> {
   if (!IS_PRODUCTION) {
-    Object
-      .keys(fsmConfig['states'])
-      .forEach((state) => {
-        if (fsmConfig['states'][state].states) {
-          throw new Error(`Nested finite states not supported. 
+    Object.keys(fsmConfig.states).forEach((state) => {
+      if (fsmConfig.states[state].states) {
+        throw new Error(`Nested finite states not supported.
             Please check the configuration for the "${state}" state.`);
-        }
-      });
+      }
+    });
   }
-  
+
   const machine = {
     config: fsmConfig,
     _options: options,

--- a/packages/xstate-fsm/src/types.ts
+++ b/packages/xstate-fsm/src/types.ts
@@ -96,6 +96,9 @@ export namespace StateMachine {
   > {
     config: StateMachine.Config<TContext, TEvent>;
     initialState: State<TContext, TEvent, TState>;
+    getStateByValue: (
+      state: TState['value']
+    ) => State<TContext, TEvent, TState>;
     transition: (
       state: string | State<TContext, TEvent, TState>,
       event: TEvent['type'] | TEvent
@@ -117,7 +120,9 @@ export namespace StateMachine {
     ) => {
       unsubscribe: () => void;
     };
-    start: () => Service<TContext, TEvent, TState>;
+    start: (
+      initialState?: TState['value']
+    ) => Service<TContext, TEvent, TState>;
     stop: () => Service<TContext, TEvent, TState>;
     readonly status: InterpreterStatus;
     readonly state: State<TContext, TEvent, TState>;

--- a/packages/xstate-fsm/src/types.ts
+++ b/packages/xstate-fsm/src/types.ts
@@ -96,9 +96,6 @@ export namespace StateMachine {
   > {
     config: StateMachine.Config<TContext, TEvent>;
     initialState: State<TContext, TEvent, TState>;
-    getStateByValue: (
-      state: TState['value']
-    ) => State<TContext, TEvent, TState>;
     transition: (
       state: string | State<TContext, TEvent, TState>,
       event: TEvent['type'] | TEvent

--- a/packages/xstate-fsm/test/fsm.test.ts
+++ b/packages/xstate-fsm/test/fsm.test.ts
@@ -281,25 +281,6 @@ describe('interpreter', () => {
 
     interpret(machine).start();
     expect(executed).toBe(true);
-
-    executed = false;
-    const rehydratedMachine = createMachine({
-      initial: 'foo',
-      states: {
-        foo: {
-          on: {
-            NEXT: 'bar'
-          }
-        },
-        bar: {
-          entry: () => {
-            executed = true;
-          }
-        }
-      }
-    });
-    interpret(rehydratedMachine).start('bar');
-    expect(executed).toBe(true);
   });
 
   it('should lookup string actions in options', () => {


### PR DESCRIPTION
## Intent

The main `xstate` library provides a lot of functionality, but also quite big in size. For most of the frontend projects, the minimalistic implementation is more than enough. But it is impossible to restore the state of the FSM after page reload. This PR targets to solve this issue.

It also makes it possible to improve `@xstate/react` and rehydrate the FSM state when using `@xstate/fsm`


## What

The solution is inspired by the main library:
Method `start` of the interpreted machine set machine in a state, provided by optional `initialState` parameter.
