### PR TITLE
[React] Re-export asEffect and asLayoutEffect

### DIFF
--- a/.changeset/mighty-terms-fry.md
+++ b/.changeset/mighty-terms-fry.md
@@ -1,0 +1,5 @@
+---
+'@xstate/react': patch
+---
+
+Make asEffect and asLayoutEffect public (importable).

--- a/packages/xstate-react/src/index.ts
+++ b/packages/xstate-react/src/index.ts
@@ -1,2 +1,2 @@
-export { useMachine } from './useMachine';
+export { useMachine, asEffect, asLayoutEffect } from './useMachine';
 export { useService } from './useService';


### PR DESCRIPTION
Make asEffect and asLayoutEffect public (importable). Fixes #1268 