### PR TITLE
Export TestPath

### DIFF
--- a/.changeset/real-buses-film.md
+++ b/.changeset/real-buses-film.md
@@ -1,0 +1,5 @@
+---
+'@xstate/test': patch
+---
+
+TestPath interface is now exported

--- a/.changeset/real-buses-film.md
+++ b/.changeset/real-buses-film.md
@@ -2,4 +2,4 @@
 '@xstate/test': patch
 ---
 
-TestPath interface is now exported
+`TestPath` interface got exported to be publicly available.

--- a/packages/xstate-test/src/types.ts
+++ b/packages/xstate-test/src/types.ts
@@ -21,7 +21,7 @@ export interface TestSegmentResult {
     error: null | Error;
   };
 }
-interface TestPath<T> {
+export interface TestPath<T> {
   weight: number;
   segments: Array<TestSegment<T>>;
   description: string;


### PR DESCRIPTION
TestPath interface is not currently exported. Having this type exported is useful when writing tests.