### PR TITLE
Fixed an issue with initial state of invoked machines being read without custom data

### DIFF
--- a/.changeset/curly-apples-remain.md
+++ b/.changeset/curly-apples-remain.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Fixed an issue with initial state of invoked machines being read without custom data passed to them which could lead to a crash when evaluating transient transitions for the initial state.

--- a/packages/core/src/Actor.ts
+++ b/packages/core/src/Actor.ts
@@ -53,12 +53,13 @@ export function createInvocableActor<TC, TE extends EventObject>(
   tempActor.deferred = true;
 
   if (isMachine(serviceCreator)) {
-    tempActor.state = serviceCreator.getInitialState(
-      serviceCreator.initialStateValue!,
-      invokeDefinition.data
-        ? mapContext(invokeDefinition.data, context, _event)
-        : undefined
-    );
+    const resolvedData = invokeDefinition.data
+      ? mapContext(invokeDefinition.data, context, _event)
+      : undefined;
+    tempActor.state = (resolvedData
+      ? serviceCreator.withContext(resolvedData)
+      : serviceCreator
+    ).initialState;
   }
 
   tempActor.meta = invokeDefinition;

--- a/packages/core/src/Actor.ts
+++ b/packages/core/src/Actor.ts
@@ -2,10 +2,11 @@ import {
   EventObject,
   Subscribable,
   InvokeDefinition,
-  AnyEventObject
+  AnyEventObject,
+  SCXML
 } from './types';
 import { StateMachine } from '.';
-import { isMachine } from './utils';
+import { isMachine, mapContext } from './utils';
 
 export interface Actor<
   TContext = any,
@@ -43,14 +44,21 @@ export function createNullActor(id: string): Actor {
  */
 export function createInvocableActor<TC, TE extends EventObject>(
   invokeDefinition: InvokeDefinition<TC, TE>,
-  machine: StateMachine<TC, any, TE>
+  machine: StateMachine<TC, any, TE>,
+  context: TC,
+  _event: SCXML.Event<TE>
 ): Actor {
   const tempActor = createNullActor(invokeDefinition.id);
   const serviceCreator = machine.options.services?.[invokeDefinition.src];
   tempActor.deferred = true;
 
   if (isMachine(serviceCreator)) {
-    tempActor.state = serviceCreator.initialState;
+    tempActor.state = serviceCreator.getInitialState(
+      serviceCreator.initialStateValue!,
+      invokeDefinition.data
+        ? mapContext(invokeDefinition.data, context, _event)
+        : undefined
+    );
   }
 
   tempActor.meta = invokeDefinition;

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -1448,7 +1448,7 @@ class StateNode<
 
     return toStatePath(stateIdentifier, this.delimiter);
   }
-  public get initialStateValue(): StateValue | undefined {
+  private get initialStateValue(): StateValue | undefined {
     if (this.__cache.initialStateValue) {
       return this.__cache.initialStateValue;
     }

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -1177,7 +1177,9 @@ class StateNode<
       (acc, action) => {
         acc[action.activity.id] = createInvocableActor(
           action.activity,
-          this.machine
+          this.machine,
+          updatedContext,
+          _event
         );
 
         return acc;
@@ -1446,7 +1448,7 @@ class StateNode<
 
     return toStatePath(stateIdentifier, this.delimiter);
   }
-  private get initialStateValue(): StateValue | undefined {
+  public get initialStateValue(): StateValue | undefined {
     if (this.__cache.initialStateValue) {
       return this.__cache.initialStateValue;
     }

--- a/packages/core/test/transient.test.ts
+++ b/packages/core/test/transient.test.ts
@@ -632,9 +632,9 @@ describe('transient states (eventless transitions)', () => {
 
   it("shouldn't crash when invoking a machine with initial transient transition depending on custom data", () => {
     const timerMachine = Machine({
-      initial: 'intitial',
+      initial: 'initial',
       states: {
-        intitial: {
+        initial: {
           always: [
             {
               target: `finished`,

--- a/packages/xstate-react/test/useMachine.test.tsx
+++ b/packages/xstate-react/test/useMachine.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useMachine, useService } from '../src';
+import { useMachine, useService, useActor } from '../src';
 import {
   Machine,
   assign,
@@ -603,5 +603,48 @@ describe('useMachine (strict mode)', () => {
         <Test />
       </React.StrictMode>
     );
+  });
+
+  it('custom data should be available right away for the invoked actor', (done) => {
+    const childMachine = Machine({
+      initial: 'intitial',
+      context: {
+        value: 100
+      },
+      states: {
+        intitial: {}
+      }
+    });
+
+    const machine = Machine({
+      initial: 'active',
+      states: {
+        active: {
+          invoke: {
+            id: 'test',
+            src: childMachine,
+            data: {
+              value: () => 42
+            }
+          }
+        }
+      }
+    });
+
+    const Test = () => {
+      const [state] = useMachine(machine);
+      const [childState] = useActor(state.children.test);
+
+      expect(childState.context.value).toBe(42);
+
+      return null;
+    };
+
+    render(
+      <React.StrictMode>
+        <Test />
+      </React.StrictMode>
+    );
+    done();
   });
 });


### PR DESCRIPTION
fixes https://github.com/davidkpiano/xstate/issues/1277

This has a caveat though - in a normal situation a service creator is called here:
https://github.com/davidkpiano/xstate/blob/8226700aab94031f66133c6518430786aab4780c/packages/core/src/interpreter.ts#L871-L877
and it is called with different values - `_event` (nor `context`) is not guaranteed to be the same between those 2 points in time. I don't feel this is fixable easily in v4 though.

