### PR TITLE
Add react Calculator example in the Examples section

### DIFF
--- a/docs/examples/calculator.md
+++ b/docs/examples/calculator.md
@@ -1,4 +1,17 @@
 # Calculator
+## React
+- Uses React, @xstate/react and Xstate 4.x.
+- [GitHub repository](https://github.com/GiancarlosIO/xstate-react-calculator)
+
+<iframe
+     src="https://codesandbox.io/embed/github/GiancarlosIO/xstate-react-calculator/tree/master/?fontsize=14&hidenavigation=1&theme=dark"
+     style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
+     title="GiancarlosIO/xstate-react-calculator"
+     allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+     sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+   ></iframe>
+
+## Vue
 - Uses Vue 2.x, @xstate/vue and Xstate 4.x.
 - [GitHub repository](https://github.com/Glutnix/xstate-vue-calculator/tree/master/)
 - Based on [earlier work by Mukesh Soni](https://github.com/mukeshsoni/statechart-calculator) (React, Xstate 3.x)


### PR DESCRIPTION
Can we add a react calculator example in the docs? 🤔
This project uses xstate 4.x. I'm still working on the typescript and testing side but the calculator itself is finished.