### PR TITLE
[@xstate/immer] Add createPatch()

### DIFF
--- a/packages/xstate-immer/package.json
+++ b/packages/xstate-immer/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "immer": "^6.0.3",
+    "immer": "^7.0.5",
     "xstate": "^4.9.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7373,6 +7373,11 @@ immer@^6.0.3:
   resolved "https://registry.yarnpkg.com/immer/-/immer-6.0.3.tgz#94d5051cd724668160a900d66d85ec02816f29bd"
   integrity sha512-12VvNrfSrXZdm/BJgi/KDW2soq5freVSf3I1+4CLunUM8mAGx2/0Njy0xBVzi5zewQZiwM7z1/1T+8VaI7NkmQ==
 
+immer@^7.0.5:
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-7.0.5.tgz#8af347db5b60b40af8ae7baf1784ea4d35b5208e"
+  integrity sha512-TtRAKZyuqld2eYjvWgXISLJ0ZlOl1OOTzRmrmiY8SlB0dnAhZ1OiykIDL5KDFNaPHDXiLfGQFNJGtet8z8AEmg==
+
 import-cwd@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-cwd/-/import-cwd-2.1.0.tgz#aa6cf36e722761285cb371ec6519f53e2435b0a9"


### PR DESCRIPTION
This PR:

- Bumps the peer dependency of `immer` to 7.0.5 (we can roll this back if needed)
- Adds support for `createPatch()`, which creates an event function that can represent "mutations" to parts of the `context` as patches, which can be handled in transitions:

```js
import { createMachine } from 'xstate';
import { createPatch } from '@xstate/immer';

// creates a "patch" event function that modifies user
const userPatch = createPatch('user');

const userMachine = createMachine({
  context: {
    user: {
      name: '',
      age: undefined,
      // ...
    }
  },
  initial: 'editing',
  states: {
    editing: {
      on: {
        [userPatch.type]: { actions: userPatch.action }
        // or, shorthand:
        // ...userPatch.transition
      }
    }
  }
});

const userService = interpret(userMachine).start();

// ...

// update the user name and age, assuming you have reference
// to the current `user` from context
userService.send(userPatch(user, u => {
  u.name = 'David';
  u.age = 30;
}));
```
