### PR TITLE
Add support for invoke source object

### DIFF
--- a/.changeset/light-news-add.md
+++ b/.changeset/light-news-add.md
@@ -11,3 +11,4 @@ interpret(anotherMachine).start({
   value: 'active',
   context: { count: 42 }
 });
+```

--- a/.changeset/soft-bulldogs-relax.md
+++ b/.changeset/soft-bulldogs-relax.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+The JSON definition for `stateNode.invoke` objects will no longer include the `onDone` and `onError` transitions, since those transitions are already merged into the `transitions` array. This solves the issue of reviving a serialized machine from JSON, where before, the `onDone` and `onError` transitions for invocations were wrongly duplicated.

--- a/.changeset/swift-pigs-taste.md
+++ b/.changeset/swift-pigs-taste.md
@@ -1,0 +1,35 @@
+---
+'xstate': minor
+---
+
+The `invoke.src` property now accepts an object that describes the invoke source with its `type` and other related metadata. This can be read from the `services` option in the `meta.src` argument:
+
+```js
+const machine = createMachine(
+  {
+    initial: 'searching',
+    states: {
+      searching: {
+        invoke: {
+          src: {
+            type: 'search',
+            endpoint: 'example.com'
+          }
+          // ...
+        }
+        // ...
+      }
+    }
+  },
+  {
+    services: {
+      search: (context, event, { src }) => {
+        console.log(src);
+        // => { endpoint: 'example.com' }
+      }
+    }
+  }
+);
+```
+
+Specifying a string for `invoke.src` will continue to work the same; e.g., if `src: 'search'` was specified, this would be the same as `src: { type: 'search' }`.

--- a/docs/guides/communication.md
+++ b/docs/guides/communication.md
@@ -23,6 +23,7 @@ An invocation is defined in a state node's configuration with the `invoke` prope
   - a function that returns a "callback handler"
   - a function that returns an observable
   - a string, which refers to any of the 4 listed options defined in this machine's `options.services`
+  - <Badge text="4.12"> an invoke source object, which contains the source string in `{ type: src }`, as well as any other metadata.
 - `id` - the unique identifier for the invoked service
 - `onDone` - (optional) the [transition](./transitions.md) to be taken when:
   - the child machine reaches its [final state](./final.md), or
@@ -648,6 +649,36 @@ const userMachine = Machine({
     getUser: (context, event) => fetchUser(context.user.id)
   }
 });
+```
+
+<Badge text="4.12" /> The invoke `src` can also be specified as an object that describes the invoke source with its `type` and other related metadata. This can be read from the `services` option in the `meta.src` argument:
+
+```js
+const machine = createMachine(
+  {
+    initial: 'searching',
+    states: {
+      searching: {
+        invoke: {
+          src: {
+            type: 'search',
+            endpoint: 'example.com'
+          }
+          // ...
+        }
+        // ...
+      }
+    }
+  },
+  {
+    services: {
+      search: (context, event, { src }) => {
+        console.log(src);
+        // => { endpoint: 'example.com' }
+      }
+    }
+  }
+);
 ```
 
 ## Testing

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,8 +48,8 @@
   },
   "homepage": "https://github.com/davidkpiano/xstate/tree/master/packages/core#readme",
   "devDependencies": {
-    "@babel/cli": "^7.6.0",
-    "@babel/core": "^7.6.0",
+    "@babel/cli": "^7.10.5",
+    "@babel/core": "^7.10.5",
     "@scion-scxml/test-framework": "^2.0.15",
     "babel-plugin-annotate-pure-calls": "^0.4.0",
     "jest": "^24.8.0",

--- a/packages/core/src/Actor.ts
+++ b/packages/core/src/Actor.ts
@@ -7,7 +7,7 @@ import {
   Spawnable,
   SCXML
 } from './types';
-import { isMachine, mapContext } from './utils';
+import { isMachine, mapContext, toInvokeSource } from './utils';
 
 export interface Actor<
   TContext = any,
@@ -49,7 +49,8 @@ export function createInvocableActor<TC, TE extends EventObject>(
   context: TC,
   _event: SCXML.Event<TE>
 ): Actor {
-  const serviceCreator = machine?.options.services?.[invokeDefinition.src];
+  const invokeSrc = toInvokeSource(invokeDefinition.src);
+  const serviceCreator = machine?.options.services?.[invokeSrc.type];
   const resolvedData = invokeDefinition.data
     ? mapContext(invokeDefinition.data, context, _event)
     : undefined;

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -96,6 +96,7 @@ import {
   isLeafNode
 } from './stateUtils';
 import { Actor, createInvocableActor } from './Actor';
+import { toInvokeDefinition } from './invokeUtils';
 
 const NULL_EVENT = '';
 const STATE_IDENTIFIER = '#';
@@ -387,18 +388,17 @@ class StateNode<
           ...this.machine.options.services
         };
 
-        return {
-          type: actionTypes.invoke,
+        return toInvokeDefinition({
           src: invokeConfig.id,
           id: invokeConfig.id
-        };
+        });
       } else if (isString(invokeConfig.src)) {
-        return {
+        return toInvokeDefinition({
           ...invokeConfig,
-          type: actionTypes.invoke,
+
           id: invokeConfig.id || (invokeConfig.src as string),
           src: invokeConfig.src as string
-        };
+        });
       } else if (isMachine(invokeConfig.src) || isFunction(invokeConfig.src)) {
         const invokeSrc = `${this.id}:invocation[${i}]`; // TODO: util function
         this.machine.options.services = {
@@ -406,21 +406,19 @@ class StateNode<
           ...this.machine.options.services
         };
 
-        return {
-          type: actionTypes.invoke,
+        return toInvokeDefinition({
           id: invokeSrc,
           ...invokeConfig,
           src: invokeSrc
-        };
+        });
       } else {
         const invokeSource = invokeConfig.src as InvokeSourceDefinition;
 
-        return {
-          type: actionTypes.invoke,
+        return toInvokeDefinition({
           id: invokeSource.type,
           ...invokeConfig,
           src: invokeSource
-        };
+        });
       }
     });
     this.activities = toArray(this.config.activities)

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -48,9 +48,9 @@ import {
   warn,
   toGuard,
   evaluateGuard,
-  toArray
+  toArray,
+  isArray
 } from './utils';
-import { isArray } from './utils';
 import { State } from './State';
 import { StateNode } from './StateNode';
 import { IS_PRODUCTION } from './environment';

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -48,7 +48,8 @@ import {
   toEventObject,
   toSCXMLEvent,
   reportUnhandledExceptionOnInvocation,
-  symbolObservable
+  symbolObservable,
+  toInvokeSource
 } from './utils';
 import { Scheduler } from './scheduler';
 import { Actor, isActor, createDeferredActor } from './Actor';
@@ -836,9 +837,10 @@ export class Interpreter<
 
         // Invoked services
         if (activity.type === ActionTypes.Invoke) {
+          const invokeSource = toInvokeSource(activity.src);
           const serviceCreator: ServiceConfig<TContext> | undefined = this
             .machine.options.services
-            ? this.machine.options.services[activity.src]
+            ? this.machine.options.services[invokeSource.type]
             : undefined;
 
           const { id, data } = activity;
@@ -873,7 +875,10 @@ export class Interpreter<
             : undefined;
 
           const source = isFunction(serviceCreator)
-            ? serviceCreator(context, _event.data, { data: resolvedData })
+            ? serviceCreator(context, _event.data, {
+                data: resolvedData,
+                src: invokeSource
+              })
             : serviceCreator;
 
           if (isPromiseLike(source)) {

--- a/packages/core/src/invokeUtils.ts
+++ b/packages/core/src/invokeUtils.ts
@@ -1,0 +1,39 @@
+import { actionTypes } from './actions';
+import {
+  EventObject,
+  InvokeConfig,
+  InvokeDefinition,
+  InvokeSourceDefinition
+} from './types';
+
+export function toInvokeSource(
+  src: string | InvokeSourceDefinition
+): InvokeSourceDefinition {
+  if (typeof src === 'string') {
+    const simpleSrc = { type: src };
+    simpleSrc.toString = () => src; // v4 compat - TODO: remove in v5
+    return simpleSrc;
+  }
+
+  return src;
+}
+
+export function toInvokeDefinition<TContext, TEvent extends EventObject>(
+  invokeConfig: InvokeConfig<TContext, TEvent> & {
+    src: string | InvokeSourceDefinition;
+    id: string;
+  }
+): InvokeDefinition<TContext, TEvent> {
+  return {
+    type: actionTypes.invoke,
+    ...invokeConfig,
+    toJSON() {
+      const { onDone, onError, ...invokeDef } = invokeConfig;
+      return {
+        ...invokeDef,
+        type: actionTypes.invoke,
+        src: toInvokeSource(invokeConfig.src)
+      };
+    }
+  };
+}

--- a/packages/core/src/machine.schema.json
+++ b/packages/core/src/machine.schema.json
@@ -237,7 +237,10 @@
           "type": "string"
         },
         "src": {
-          "type": "string"
+          "type": "object",
+          "properties": {
+            "type": { "type": "string" }
+          }
         },
         "autoForward": {
           "type": "boolean",

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -205,6 +205,7 @@ export type InvokeCallback = (
 
 export interface InvokeMeta {
   data: any;
+  src: InvokeSourceDefinition;
 }
 
 /**
@@ -239,7 +240,7 @@ export interface InvokeDefinition<TContext, TEvent extends EventObject>
   /**
    * The source of the machine to be invoked, or the machine itself.
    */
-  src: string;
+  src: string | InvokeSourceDefinition; // TODO: deprecate string (breaking change for V4)
   /**
    * If `true`, events sent to the parent service will be forwarded to the invoked service.
    *
@@ -366,6 +367,11 @@ export type TransitionsConfig<TContext, TEvent extends EventObject> =
   | TransitionsConfigMap<TContext, TEvent>
   | TransitionsConfigArray<TContext, TEvent>;
 
+export interface InvokeSourceDefinition {
+  [key: string]: any;
+  type: string;
+}
+
 export type InvokeConfig<TContext, TEvent extends EventObject> = {
   /**
    * The unique identifier for the invoked machine. If not specified, this
@@ -377,6 +383,7 @@ export type InvokeConfig<TContext, TEvent extends EventObject> = {
    */
   src:
     | string
+    | InvokeSourceDefinition
     | StateMachine<any, any, any>
     | InvokeCreator<TContext, TEvent, any>;
   /**

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -22,7 +22,8 @@ import {
   SingleOrArray,
   Guard,
   GuardPredicate,
-  GuardMeta
+  GuardMeta,
+  InvokeSourceDefinition
 } from './types';
 import {
   STATE_DELIMITER,
@@ -677,4 +678,14 @@ export function evaluateGuard<TContext, TEvent extends EventObject>(
   }
 
   return condFn(context, _event.data, guardMeta);
+}
+
+export function toInvokeSource(
+  src: string | InvokeSourceDefinition
+): InvokeSourceDefinition {
+  if (typeof src === 'string') {
+    return { type: src };
+  }
+
+  return src;
 }

--- a/packages/core/test/invoke.test.ts
+++ b/packages/core/test/invoke.test.ts
@@ -2360,6 +2360,41 @@ describe('invoke', () => {
         .start();
     });
   });
+
+  it('invoke `src` should accept invoke source definition', (done) => {
+    const machine = createMachine(
+      {
+        initial: 'searching',
+        states: {
+          searching: {
+            invoke: {
+              src: {
+                type: 'search',
+                endpoint: 'example.com'
+              },
+              onDone: 'success'
+            }
+          },
+          success: {
+            type: 'final'
+          }
+        }
+      },
+      {
+        services: {
+          search: async (_, __, meta) => {
+            expect(meta.src.endpoint).toEqual('example.com');
+
+            return await 42;
+          }
+        }
+      }
+    );
+
+    interpret(machine)
+      .onDone(() => done())
+      .start();
+  });
 });
 
 describe('services option', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,16 +2,16 @@
 # yarn lockfile v1
 
 
-"@babel/cli@^7.6.0":
-  version "7.8.4"
-  resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.8.4.tgz#505fb053721a98777b2b175323ea4f090b7d3c1c"
-  integrity sha512-XXLgAm6LBbaNxaGhMAznXXaxtCWfuv6PIDJ9Alsy9JYTOh+j2jJz+L/162kkfU1j/pTSxK1xGmlwI4pdIMkoag==
+"@babel/cli@^7.10.5":
+  version "7.10.5"
+  resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.10.5.tgz#57df2987c8cf89d0fc7d4b157ec59d7619f1b77a"
+  integrity sha512-j9H9qSf3kLdM0Ao3aGPbGZ73mEA9XazuupcS6cDGWuiyAcANoguhP0r2Lx32H5JGw4sSSoHG3x/mxVnHgvOoyA==
   dependencies:
     commander "^4.0.1"
     convert-source-map "^1.1.0"
     fs-readdir-recursive "^1.1.0"
     glob "^7.0.0"
-    lodash "^4.17.13"
+    lodash "^4.17.19"
     make-dir "^2.1.0"
     slash "^2.0.0"
     source-map "^0.5.0"
@@ -25,6 +25,13 @@
   dependencies:
     "@babel/highlight" "^7.8.3"
 
+"@babel/code-frame@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.4.tgz#168da1a36e90da68ae8d49c0f1b48c7c6249213a"
+  integrity sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==
+  dependencies:
+    "@babel/highlight" "^7.10.4"
+
 "@babel/compat-data@^7.8.6", "@babel/compat-data@^7.9.0":
   version "7.9.0"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.9.0.tgz#04815556fc90b0c174abd2c0c1bb966faa036a6c"
@@ -34,7 +41,7 @@
     invariant "^2.2.4"
     semver "^5.5.0"
 
-"@babel/core@^7.1.0", "@babel/core@^7.4.4", "@babel/core@^7.6.0", "@babel/core@^7.8.4":
+"@babel/core@^7.1.0", "@babel/core@^7.4.4", "@babel/core@^7.8.4":
   version "7.9.0"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.9.0.tgz#ac977b538b77e132ff706f3b8a4dbad09c03c56e"
   integrity sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==
@@ -54,6 +61,37 @@
     lodash "^4.17.13"
     resolve "^1.3.2"
     semver "^5.4.1"
+    source-map "^0.5.0"
+
+"@babel/core@^7.10.5":
+  version "7.10.5"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.10.5.tgz#1f15e2cca8ad9a1d78a38ddba612f5e7cdbbd330"
+  integrity sha512-O34LQooYVDXPl7QWCdW9p4NR+QlzOr7xShPPJz8GsuCU3/8ua/wqTr7gmnxXv+WBESiGU/G5s16i6tUvHkNb+w==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/generator" "^7.10.5"
+    "@babel/helper-module-transforms" "^7.10.5"
+    "@babel/helpers" "^7.10.4"
+    "@babel/parser" "^7.10.5"
+    "@babel/template" "^7.10.4"
+    "@babel/traverse" "^7.10.5"
+    "@babel/types" "^7.10.5"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.1"
+    json5 "^2.1.2"
+    lodash "^4.17.19"
+    resolve "^1.3.2"
+    semver "^5.4.1"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.10.5":
+  version "7.10.5"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.10.5.tgz#1b903554bc8c583ee8d25f1e8969732e6b829a69"
+  integrity sha512-3vXxr3FEW7E7lJZiWQ3bM4+v/Vyr9C+hpolQ8BGFr9Y8Ri2tFLWTixmwKBafDujO1WVah4fhZBeU1bieKdghig==
+  dependencies:
+    "@babel/types" "^7.10.5"
+    jsesc "^2.5.1"
     source-map "^0.5.0"
 
 "@babel/generator@^7.4.0", "@babel/generator@^7.4.4", "@babel/generator@^7.9.0":
@@ -147,6 +185,15 @@
     "@babel/traverse" "^7.8.3"
     "@babel/types" "^7.8.3"
 
+"@babel/helper-function-name@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz#d2d3b20c59ad8c47112fa7d2a94bc09d5ef82f1a"
+  integrity sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.10.4"
+    "@babel/template" "^7.10.4"
+    "@babel/types" "^7.10.4"
+
 "@babel/helper-function-name@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz#eeeb665a01b1f11068e9fb86ad56a1cb1a824cca"
@@ -155,6 +202,13 @@
     "@babel/helper-get-function-arity" "^7.8.3"
     "@babel/template" "^7.8.3"
     "@babel/types" "^7.8.3"
+
+"@babel/helper-get-function-arity@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz#98c1cbea0e2332f33f9a4661b8ce1505b2c19ba2"
+  integrity sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==
+  dependencies:
+    "@babel/types" "^7.10.4"
 
 "@babel/helper-get-function-arity@^7.8.3":
   version "7.8.3"
@@ -170,6 +224,13 @@
   dependencies:
     "@babel/types" "^7.8.3"
 
+"@babel/helper-member-expression-to-functions@^7.10.4":
+  version "7.10.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.5.tgz#172f56e7a63e78112f3a04055f24365af702e7ee"
+  integrity sha512-HiqJpYD5+WopCXIAbQDG0zye5XYVvcO9w/DHp5GsaGkRUaamLj2bEtu6i8rnGGprAhHM3qidCMgp71HF4endhA==
+  dependencies:
+    "@babel/types" "^7.10.5"
+
 "@babel/helper-member-expression-to-functions@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz#659b710498ea6c1d9907e0c73f206eee7dadc24c"
@@ -184,6 +245,26 @@
   dependencies:
     "@babel/types" "^7.8.3"
 
+"@babel/helper-module-imports@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz#4c5c54be04bd31670a7382797d75b9fa2e5b5620"
+  integrity sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==
+  dependencies:
+    "@babel/types" "^7.10.4"
+
+"@babel/helper-module-transforms@^7.10.5":
+  version "7.10.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.10.5.tgz#120c271c0b3353673fcdfd8c053db3c544a260d6"
+  integrity sha512-4P+CWMJ6/j1W915ITJaUkadLObmCRRSC234uctJfn/vHrsLNxsR8dwlcXv9ZhJWzl77awf+mWXSZEKt5t0OnlA==
+  dependencies:
+    "@babel/helper-module-imports" "^7.10.4"
+    "@babel/helper-replace-supers" "^7.10.4"
+    "@babel/helper-simple-access" "^7.10.4"
+    "@babel/helper-split-export-declaration" "^7.10.4"
+    "@babel/template" "^7.10.4"
+    "@babel/types" "^7.10.5"
+    lodash "^4.17.19"
+
 "@babel/helper-module-transforms@^7.9.0":
   version "7.9.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.9.0.tgz#43b34dfe15961918707d247327431388e9fe96e5"
@@ -196,6 +277,13 @@
     "@babel/template" "^7.8.6"
     "@babel/types" "^7.9.0"
     lodash "^4.17.13"
+
+"@babel/helper-optimise-call-expression@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz#50dc96413d594f995a77905905b05893cd779673"
+  integrity sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==
+  dependencies:
+    "@babel/types" "^7.10.4"
 
 "@babel/helper-optimise-call-expression@^7.8.3":
   version "7.8.3"
@@ -227,6 +315,16 @@
     "@babel/traverse" "^7.8.3"
     "@babel/types" "^7.8.3"
 
+"@babel/helper-replace-supers@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz#d585cd9388ea06e6031e4cd44b6713cbead9e6cf"
+  integrity sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==
+  dependencies:
+    "@babel/helper-member-expression-to-functions" "^7.10.4"
+    "@babel/helper-optimise-call-expression" "^7.10.4"
+    "@babel/traverse" "^7.10.4"
+    "@babel/types" "^7.10.4"
+
 "@babel/helper-replace-supers@^7.8.3", "@babel/helper-replace-supers@^7.8.6":
   version "7.8.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.8.6.tgz#5ada744fd5ad73203bf1d67459a27dcba67effc8"
@@ -237,6 +335,14 @@
     "@babel/traverse" "^7.8.6"
     "@babel/types" "^7.8.6"
 
+"@babel/helper-simple-access@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz#0f5ccda2945277a2a7a2d3a821e15395edcf3461"
+  integrity sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==
+  dependencies:
+    "@babel/template" "^7.10.4"
+    "@babel/types" "^7.10.4"
+
 "@babel/helper-simple-access@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz#7f8109928b4dab4654076986af575231deb639ae"
@@ -245,12 +351,24 @@
     "@babel/template" "^7.8.3"
     "@babel/types" "^7.8.3"
 
+"@babel/helper-split-export-declaration@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz#2c70576eaa3b5609b24cb99db2888cc3fc4251d1"
+  integrity sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==
+  dependencies:
+    "@babel/types" "^7.10.4"
+
 "@babel/helper-split-export-declaration@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz#31a9f30070f91368a7182cf05f831781065fc7a9"
   integrity sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==
   dependencies:
     "@babel/types" "^7.8.3"
+
+"@babel/helper-validator-identifier@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz#a78c7a7251e01f616512d31b10adcf52ada5e0d2"
+  integrity sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==
 
 "@babel/helper-validator-identifier@^7.9.0":
   version "7.9.0"
@@ -267,6 +385,15 @@
     "@babel/traverse" "^7.8.3"
     "@babel/types" "^7.8.3"
 
+"@babel/helpers@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.10.4.tgz#2abeb0d721aff7c0a97376b9e1f6f65d7a475044"
+  integrity sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==
+  dependencies:
+    "@babel/template" "^7.10.4"
+    "@babel/traverse" "^7.10.4"
+    "@babel/types" "^7.10.4"
+
 "@babel/helpers@^7.9.0":
   version "7.9.2"
   resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.9.2.tgz#b42a81a811f1e7313b88cba8adc66b3d9ae6c09f"
@@ -275,6 +402,15 @@
     "@babel/template" "^7.8.3"
     "@babel/traverse" "^7.9.0"
     "@babel/types" "^7.9.0"
+
+"@babel/highlight@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.10.4.tgz#7d1bdfd65753538fabe6c38596cdb76d9ac60143"
+  integrity sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.10.4"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
 
 "@babel/highlight@^7.8.3":
   version "7.9.0"
@@ -289,6 +425,11 @@
   version "7.9.4"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.9.4.tgz#68a35e6b0319bbc014465be43828300113f2f2e8"
   integrity sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA==
+
+"@babel/parser@^7.10.4", "@babel/parser@^7.10.5":
+  version "7.10.5"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.10.5.tgz#e7c6bf5a7deff957cec9f04b551e2762909d826b"
+  integrity sha512-wfryxy4bE1UivvQKSQDU4/X6dr+i8bctjUjj8Zyt3DQy7NtPizJXT8M52nqpNKL+nq2PW8lxk4ZqLj0fD4B4hQ==
 
 "@babel/plugin-proposal-async-generator-functions@^7.8.3":
   version "7.8.3"
@@ -836,6 +977,15 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/template@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.4.tgz#3251996c4200ebc71d1a8fc405fba940f36ba278"
+  integrity sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/parser" "^7.10.4"
+    "@babel/types" "^7.10.4"
+
 "@babel/template@^7.4.0", "@babel/template@^7.4.4", "@babel/template@^7.8.3", "@babel/template@^7.8.6":
   version "7.8.6"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.8.6.tgz#86b22af15f828dfb086474f964dcc3e39c43ce2b"
@@ -860,6 +1010,21 @@
     globals "^11.1.0"
     lodash "^4.17.13"
 
+"@babel/traverse@^7.10.4", "@babel/traverse@^7.10.5":
+  version "7.10.5"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.10.5.tgz#77ce464f5b258be265af618d8fddf0536f20b564"
+  integrity sha512-yc/fyv2gUjPqzTz0WHeRJH2pv7jA9kA7mBX2tXl/x5iOE81uaVPuGPtaYk7wmkx4b67mQ7NqI8rmT2pF47KYKQ==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/generator" "^7.10.5"
+    "@babel/helper-function-name" "^7.10.4"
+    "@babel/helper-split-export-declaration" "^7.10.4"
+    "@babel/parser" "^7.10.5"
+    "@babel/types" "^7.10.5"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.19"
+
 "@babel/types@^7.0.0", "@babel/types@^7.3.0", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.7.0", "@babel/types@^7.8.3", "@babel/types@^7.8.6", "@babel/types@^7.9.0":
   version "7.9.0"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.9.0.tgz#00b064c3df83ad32b2dbf5ff07312b15c7f1efb5"
@@ -867,6 +1032,15 @@
   dependencies:
     "@babel/helper-validator-identifier" "^7.9.0"
     lodash "^4.17.13"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.10.4", "@babel/types@^7.10.5":
+  version "7.10.5"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.10.5.tgz#d88ae7e2fde86bfbfe851d4d81afa70a997b5d15"
+  integrity sha512-ixV66KWfCI6GKoA/2H9v6bQdbfXEwwpOdQ8cRvb4F+eyvhlaHxWFMQB4+3d9QFJXZsiiiqVrewNV0DFEQpyT4Q==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.10.4"
+    lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
 "@braintree/sanitize-url@^3.1.0":
@@ -9008,6 +9182,11 @@ lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
+lodash@^4.17.19:
+  version "4.17.19"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
+  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
 log-symbols@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This PR adds support for invoke source objects. This is not a breaking change; `src: 'someString'` will continue to work.

```js
invoke: {
  src: {
    type: 'search',
    endpoint: 'google.com'
  },
  // ...
}

// ...

services: {
  search: (ctx, e, { src }) => {
    console.log(src);
    // => { type: 'search', endpoint: 'google.com' }
  }
}

// ...
```

TODO: 
- [x] Documentation
- [x] Changeset