### PR TITLE
add covid tracker example to the xstate doc

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -103,7 +103,8 @@ module.exports = {
         children: [
           '/examples/counter',
           '/examples/todomvc',
-          '/examples/calculator'
+          '/examples/calculator',
+          '/examples/covid-tracker'
         ]
       }
     ]

--- a/docs/examples/covid-tracker.md
+++ b/docs/examples/covid-tracker.md
@@ -1,0 +1,16 @@
+# Covid Tracker
+
+This example shows a current statistics about COVID-19 pandemic filtered by countries using XState and React. It contains:
+
+- `covidMachine` - handles country selection, including a "sub-state" responsible for fetching the list of all countries across the globe
+- `covidDataMachine` - handles fetching specific statistics (including `confirmed`, `deaths`, `recovered` cases) based on selected country
+
+The two child components `<Indicator />` and `<Chart />` that responsibles of rendering data, consumes the service from the `MachineProvider` context provider
+
+<iframe
+  src="https://codesandbox.io/embed/covid-state-machine-lromu?fontsize=14&hidenavigation=1&theme=dark"
+  style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
+  title="covid-state-machine"
+  allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+  sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+></iframe>


### PR DESCRIPTION
I went through the `Example` section of the XState documentation and it doesn't have an example regards of using XState to fetch data from the API, so I just add this example to demonstrate how fetching data should be done using XState and pass down to its descendant using React Context API