### PR TITLE
[@xstate/react] Rehydration should initialize machine first. Fixes #1334

### DIFF
--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -425,6 +425,12 @@ class StateNode<
       .concat(this.invoke)
       .map((activity) => toActivityDefinition(activity));
     this.transition = this.transition.bind(this);
+
+    // TODO: this is the real fix for initialization once
+    // state node getters are deprecated
+    // if (!this.parent) {
+    //   this._init();
+    // }
   }
 
   private _init(): void {
@@ -1514,7 +1520,7 @@ class StateNode<
    * entering the initial state.
    */
   public get initialState(): State<TContext, TEvent, TStateSchema, TTypestate> {
-    this._init();
+    this._init(); // TODO: this should be in the constructor (see note in constructor)
     const { initialStateValue } = this;
 
     if (!initialStateValue) {

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -41,6 +41,7 @@ describe('StateSchema', () => {
     context: { elapsed: 0 },
     states: {
       green: {
+        id: 'green',
         meta: { name: 'greenLight' },
         on: {
           TIMER: 'yellow',
@@ -76,7 +77,7 @@ describe('StateSchema', () => {
             }
           },
           stop: {
-            always: { target: 'green' }
+            always: { target: '#green' }
           }
         }
       }

--- a/packages/xstate-react/src/useMachine.ts
+++ b/packages/xstate-react/src/useMachine.ts
@@ -161,9 +161,10 @@ export function useMachine<
   });
 
   const [state, setState] = useState(() => {
-    return rehydratedState
-      ? State.create(rehydratedState)
-      : resolvedMachine.initialState;
+    // Always read the initial state to properly initialize the machine
+    // https://github.com/davidkpiano/xstate/issues/1334
+    const { initialState } = resolvedMachine;
+    return rehydratedState ? State.create(rehydratedState) : initialState;
   });
 
   const effectActionsRef = useRef<

--- a/packages/xstate-react/test/useMachine.test.tsx
+++ b/packages/xstate-react/test/useMachine.test.tsx
@@ -670,9 +670,7 @@ describe('useMachine (strict mode)', () => {
 
     const persistedState = JSON.stringify(testMachine.initialState);
 
-    let currentState = testMachine.resolveState(
-      State.create(State.create(JSON.parse(persistedState)))
-    );
+    let currentState;
 
     const Test = () => {
       const [state, send] = useMachine(testMachine, {

--- a/packages/xstate-react/test/useMachine.test.tsx
+++ b/packages/xstate-react/test/useMachine.test.tsx
@@ -649,7 +649,7 @@ describe('useMachine (strict mode)', () => {
   });
 
   // https://github.com/davidkpiano/xstate/issues/1334
-  it('should work with a rehydrated state', (done) => {
+  it('delayed transitions should work when initializing from a rehydrated state', (done) => {
     const testMachine = Machine({
       id: 'app',
       initial: 'idle',


### PR DESCRIPTION
This PR fixes #1334 (in a workaround-ish way) by always reading the `machine.initialState` first, which will trigger `machine._init()` to properly initialize all transitions, which includes resolving delayed transitions.

The real fix for this is to do the transition resolution eagerly in the machine's constructor after adding all state nodes, but this would be a breaking change in v4 for state node getters (which will be deprecated in v5), so that will wait til the next major version.

This is not a breaking change.