### PR TITLE
[v5] Assigner function should completely replace context

### DIFF
--- a/.changeset/dry-readers-clean.md
+++ b/.changeset/dry-readers-clean.md
@@ -1,0 +1,26 @@
+---
+'xstate': major
+---
+
+Passing an assigner function to `assign((ctx, e) => ...)` will now be expected to assign to the _entire_ `context`, instead of just partially.
+
+```js
+// ...
+{
+  context: {
+    name: 'David',
+    temp: 'value'
+  },
+  // ...
+  entry: assign((ctx, event) => {
+    return {
+      name: event.name
+    }
+  })
+}
+
+// The context will now be, e.g.:
+// { name: 'Jenny' }
+// instead of:
+// { name: 'Jenny', temp: 'value' }
+```

--- a/packages/core/src/scxml.ts
+++ b/packages/core/src/scxml.ts
@@ -147,9 +147,10 @@ function mapAction<
     case 'assign': {
       return actions.assign<TContext, TEvent>((context, e, meta) => {
         const fnBody = `
-            return {'${element.attributes!.location}': ${
-          element.attributes!.expr
-        }};
+            return {
+              ...context,
+              '${element.attributes!.location}': ${element.attributes!.expr}
+            };
           `;
 
         return evaluateExecutableContent(context, e, meta, fnBody);

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -783,7 +783,7 @@ export type Assigner<TContext, TEvent extends EventObject> = (
   context: TContext,
   event: TEvent,
   meta: AssignMeta<TContext, TEvent>
-) => Partial<TContext>;
+) => TContext;
 
 export type PropertyAssigner<TContext, TEvent extends EventObject> = {
   [K in keyof TContext]?:

--- a/packages/core/src/updateContext.ts
+++ b/packages/core/src/updateContext.ts
@@ -64,9 +64,9 @@ export function updateContext<TContext, TEvent extends EventObject>(
           spawn: spawner
         };
 
-        let partialUpdate: Partial<TContext> = {};
+        const partialUpdate: Partial<TContext> = {};
         if (isFunction(assignment)) {
-          partialUpdate = assignment(acc, _event.data, meta);
+          return assignment(acc, _event.data, meta);
         } else {
           for (const key of keys(assignment)) {
             const propAssignment = assignment[key];

--- a/packages/core/test/assign.test.ts
+++ b/packages/core/test/assign.test.ts
@@ -8,7 +8,6 @@ import {
 } from '../src';
 import { invokeMachine } from '../src/invoke';
 import { ActorRef } from '../src/types';
-import { stringify } from 'querystring';
 
 interface CounterContext {
   count: number;


### PR DESCRIPTION
This PR addresses #989 in that `assign(fn)` should _completely_ replace context, instead of partially replacing it.

```js
// ...
{
  context: {
    name: 'David',
    temp: 'value'
  },
  // ...
  entry: assign((ctx, event) => {
    return {
      name: event.name
    }
  })
}
// The context will now be, e.g.:
// { name: 'Jenny' }
// instead of:
// { name: 'Jenny', temp: 'value' }
```