### PR TITLE
fix: use event generic in ServiceConfig type

### DIFF
--- a/.changeset/nine-gorillas-brake.md
+++ b/.changeset/nine-gorillas-brake.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Narrowed the `ServiceConfig` type definition to use a specific event type to prevent compilation errors on strictly-typed `MachineOptions`.

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -836,8 +836,9 @@ export class Interpreter<
         // Invoked services
         if (activity.type === ActionTypes.Invoke) {
           const invokeSource = toInvokeSource(activity.src);
-          const serviceCreator: ServiceConfig<TContext> | undefined = this
-            .machine.options.services
+          const serviceCreator:
+            | ServiceConfig<TContext, TEvent>
+            | undefined = this.machine.options.services
             ? this.machine.options.services[invokeSource.type]
             : undefined;
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -608,10 +608,10 @@ export type DelayFunctionMap<TContext, TEvent extends EventObject> = Record<
   DelayConfig<TContext, TEvent>
 >;
 
-export type ServiceConfig<TContext> =
+export type ServiceConfig<TContext, TEvent extends EventObject = AnyEventObject> =
   | string
   | StateMachine<any, any, any>
-  | InvokeCreator<TContext>;
+  | InvokeCreator<TContext, TEvent>;
 
 export type DelayConfig<TContext, TEvent extends EventObject> =
   | number
@@ -621,7 +621,7 @@ export interface MachineOptions<TContext, TEvent extends EventObject> {
   guards: Record<string, ConditionPredicate<TContext, TEvent>>;
   actions: ActionFunctionMap<TContext, TEvent>;
   activities: Record<string, ActivityConfig<TContext, TEvent>>;
-  services: Record<string, ServiceConfig<TContext>>;
+  services: Record<string, ServiceConfig<TContext, TEvent>>;
   delays: DelayFunctionMap<TContext, TEvent>;
   /**
    * @private


### PR DESCRIPTION
Hi. Ran into a typing problem when using `MachineConfig`. The following code does not compile in TypeScript with `"strict": true`

```typescript
type TestContext = {};
type TestEvent =
  | { type: 'EVENT_WITH_PAYLOAD'; payload: string }
  | { type: 'OTHER_EVENT_WITH_PAYLOAD'; payload: number };

const services = {
  testService: (_context: TestContext, _event: TestEvent) => Promise.resolve(),
  testService2: (_context: TestContext, _event: TestEvent) => Promise.resolve(),
};

const partialMachineOptions: Partial<MachineOptions<TestContext, TestEvent>> = {
  services, 
  // Type ... is not assignable to type 'Record<string, ServiceConfig<TestContext, AnyEventObject>>'
  // ...
  // Types of parameters '_event' and 'event' are incompatible. 
  // Type 'AnyEventObject' is not assignable to type 'TestEvent'.
};

```

This is because `ServiceConfig` expects an `InvokeCreator` that uses `AnyEventObject`. 

In TypeScript's strict mode, `TestEvent` is not compatible with `AnyEventObject` as all TestEvents are inferred as having a `payload` property. 

This PR fixes the problem by having `ServiceConfig` (like the other types in `MachineOptions`) use the supplied event generic. 