### PR TITLE
Added isInline property to activities and services for easier introspection by xstate-codegen

### DIFF
--- a/.changeset/strange-goats-vanish.md
+++ b/.changeset/strange-goats-vanish.md
@@ -1,0 +1,5 @@
+---
+"xstate": patch
+---
+
+Added isInline property to activities and services for easier introspection by tools like xstate-codegen.

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -146,6 +146,7 @@ export function toActivityDefinition<TContext, TEvent extends EventObject>(
 
   return {
     id: isString(action) ? action : actionObject.id,
+    isInline: isString(action),
     ...actionObject,
     type: actionObject.type
   };

--- a/packages/core/src/invokeUtils.ts
+++ b/packages/core/src/invokeUtils.ts
@@ -5,6 +5,7 @@ import {
   InvokeDefinition,
   InvokeSourceDefinition
 } from './types';
+import { isString } from './utils';
 
 export function toInvokeSource(
   src: string | InvokeSourceDefinition
@@ -27,6 +28,7 @@ export function toInvokeDefinition<TContext, TEvent extends EventObject>(
   return {
     type: actionTypes.invoke,
     ...invokeConfig,
+    isInline: isString(invokeConfig),
     toJSON() {
       const { onDone, onError, ...invokeDef } = invokeConfig;
       return {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -186,6 +186,7 @@ export interface ActivityDefinition<TContext, TEvent extends EventObject>
   extends ActionObject<TContext, TEvent> {
   id: string;
   type: string;
+  isInline: boolean;
 }
 
 export type Sender<TEvent extends EventObject> = (event: Event<TEvent>) => void;
@@ -255,6 +256,10 @@ export interface InvokeDefinition<TContext, TEvent extends EventObject>
    * Data should be mapped to match the child machine's context shape.
    */
   data?: Mapper<TContext, TEvent, any> | PropertyMapper<TContext, TEvent, any>;
+  /**
+   * Whether or not the service is declared inline
+   */
+  isInline: boolean;
 }
 
 export interface Delay {
@@ -608,10 +613,10 @@ export type DelayFunctionMap<TContext, TEvent extends EventObject> = Record<
   DelayConfig<TContext, TEvent>
 >;
 
-export type ServiceConfig<TContext, TEvent extends EventObject = AnyEventObject> =
-  | string
-  | StateMachine<any, any, any>
-  | InvokeCreator<TContext, TEvent>;
+export type ServiceConfig<
+  TContext,
+  TEvent extends EventObject = AnyEventObject
+> = string | StateMachine<any, any, any> | InvokeCreator<TContext, TEvent>;
 
 export type DelayConfig<TContext, TEvent extends EventObject> =
   | number

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -186,6 +186,9 @@ export interface ActivityDefinition<TContext, TEvent extends EventObject>
   extends ActionObject<TContext, TEvent> {
   id: string;
   type: string;
+  /**
+   * Whether or not the activity is declared inline
+   */
   isInline: boolean;
 }
 

--- a/packages/core/test/actionCreators.test.ts
+++ b/packages/core/test/actionCreators.test.ts
@@ -15,7 +15,8 @@ describe('action creators', () => {
           activity: {
             type: 'test',
             exec: undefined,
-            id: 'test'
+            id: 'test',
+            isInline: true
           }
         });
       });
@@ -29,7 +30,8 @@ describe('action creators', () => {
           activity: {
             type: 'test',
             id: undefined,
-            foo: 'bar'
+            foo: 'bar',
+            isInline: false
           }
         });
       });
@@ -48,7 +50,8 @@ describe('action creators', () => {
             type: 'test',
             id: undefined,
             foo: 'bar',
-            src: 'someSrc'
+            src: 'someSrc',
+            isInline: false
           }
         });
       });

--- a/packages/core/test/activities.test.ts
+++ b/packages/core/test/activities.test.ts
@@ -61,7 +61,12 @@ describe('activities with guarded transitions', () => {
     state = machine.transition(state, 'E');
     expect(state.activities.B_ACTIVITY).toBeTruthy();
     expect(state.actions).toEqual([
-      start({ type: 'B_ACTIVITY', id: 'B_ACTIVITY', exec: undefined })
+      start({
+        type: 'B_ACTIVITY',
+        id: 'B_ACTIVITY',
+        exec: undefined,
+        isInline: true
+      })
     ]);
   });
 });


### PR DESCRIPTION
In developing xstate-codegen, I've been having a tricky time working out which activities are declared inline (i.e, in the state machine definition) and which are strings.

I don't know the difference between this:

```js
{
  invoke: {
    src: 'makeFetch'
  }
}
```

And this:

```js
{
  invoke: {
    src: () => Promise.resolve('data'),
  }
}
```

This is important because I need to figure out which services and activities are required for the MachineOptions type.