### PR TITLE
updated State interface value type

### DIFF
--- a/.changeset/modern-mugs-lie.md
+++ b/.changeset/modern-mugs-lie.md
@@ -2,4 +2,4 @@
 '@xstate/fsm': patch
 ---
 
-Improved typing of State interface
+`State['value']` is now correctly typed to `TState['value']`. It's important in situations when typestates are used as it now correctly is limited to values of those typestates and not widened to just `string`.

--- a/.changeset/modern-mugs-lie.md
+++ b/.changeset/modern-mugs-lie.md
@@ -1,0 +1,5 @@
+---
+'@xstate/fsm': patch
+---
+
+Improved typing of State interface

--- a/packages/xstate-fsm/src/types.ts
+++ b/packages/xstate-fsm/src/types.ts
@@ -59,7 +59,7 @@ export namespace StateMachine {
     TEvent extends EventObject,
     TState extends Typestate<TContext>
   > {
-    value: string;
+    value: TState['value'];
     context: TContext;
     actions: Array<ActionObject<TContext, TEvent>>;
     changed?: boolean | undefined;


### PR DESCRIPTION
Fixes typing of value in State interface 
I was using an enum for the states and discovered that the `value` is still strings no matter what


```ts
export enum States {
  flow = 'flow',
  search = 'search',
  default = 'default',
}

type HeaderState =
  | {
      value: States.flow
      context:{
    }
  | {
      value: States.search
      context: {}
    }
  | {
      value: States.default
      context: {}
    }

const machine = createMachine<HeaderMachineContext, HeaderEvents, HeaderState>(...)

...

machineState.value // the type should be `States` instead of `string`
```