### PR TITLE
Prevent multiple `.initialState` reads.

### DIFF
--- a/packages/core/src/Actor.ts
+++ b/packages/core/src/Actor.ts
@@ -44,6 +44,7 @@ export function createNullActor(id: string): Actor {
  * @param invokeDefinition The meta information needed to invoke the actor.
  */
 export function createInvocableActor<TC, TE extends EventObject>(
+  isInitial: Boolean,
   invokeDefinition: InvokeDefinition<TC, TE>,
   machine: StateMachine<TC, any, TE>,
   context: TC,
@@ -56,6 +57,7 @@ export function createInvocableActor<TC, TE extends EventObject>(
     : undefined;
   const tempActor = serviceCreator
     ? createDeferredActor(
+        isInitial,
         serviceCreator as Spawnable,
         invokeDefinition.id,
         resolvedData
@@ -68,6 +70,7 @@ export function createInvocableActor<TC, TE extends EventObject>(
 }
 
 export function createDeferredActor(
+  isInitial: Boolean,
   entity: Spawnable,
   id: string,
   data?: any
@@ -75,7 +78,7 @@ export function createDeferredActor(
   const tempActor = createNullActor(id);
   tempActor.deferred = true;
 
-  if (isMachine(entity)) {
+  if (!isInitial && isMachine(entity)) {
     tempActor.state = (data ? entity.withContext(data) : entity).initialState;
   }
 

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -1100,7 +1100,7 @@ class StateNode<
 
     stateTransition.configuration = [...resolvedConfig];
 
-    return this.resolveTransition(stateTransition, currentState, _event);
+    return this.resolveTransition(false, stateTransition, currentState, _event);
   }
 
   private resolveRaisedTransition(
@@ -1121,6 +1121,7 @@ class StateNode<
   }
 
   private resolveTransition(
+    isInitial: Boolean,
     stateTransition: StateTransition<TContext, TEvent>,
     currentState?: State<TContext, TEvent>,
     _event: SCXML.Event<TEvent> = initEvent as SCXML.Event<TEvent>,
@@ -1192,6 +1193,7 @@ class StateNode<
     const children = invokeActions.reduce(
       (acc, action) => {
         acc[action.activity.id] = createInvocableActor(
+          isInitial,
           action.activity,
           this.machine,
           updatedContext,
@@ -1503,6 +1505,7 @@ class StateNode<
     const configuration = this.getStateNodes(stateValue);
 
     return this.resolveTransition(
+      true,
       {
         configuration,
         entrySet: configuration,

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -1309,7 +1309,7 @@ export function spawn(
     if (service) {
       return service.spawn(entity, resolvedOptions.name, resolvedOptions);
     } else {
-      return createDeferredActor(entity, resolvedOptions.name);
+      return createDeferredActor(false, entity, resolvedOptions.name);
     }
   });
 }


### PR DESCRIPTION
Boolean flag proof of concept. Existing tests still pass.

***

This is a *straw man* solution for #1397. The approach appears to address the underlying issue, but to my unfamiliar eyes I'm unsure if it is a complete solution. Also, I only ran the xstate tests, it's unclear if downstream dependencies will rely on the existing behavior.

I personally hate adding boolean flags into method signatures, especially when they have to be drilled down into a much later invocation. I have no issue with trying to find a different way to accomplish this task.

Possibly the most-important step here is to land test cases for this problem to ensure correctness.

**Next Steps (unordered)**
- [ ] Identify if this (or something similar) is a palatable solution.
- [ ] Review for *actual* correctness instead of implied correctness by somebody who knows the lib.
- [ ] Port test case from [sandbox](https://codesandbox.io/s/sweet-shannon-dvzox).
- [ ] Add additional test cases for adjacent scenarios.

Thoughts?