### PR TITLE
allow running xstate in a web-worker

### DIFF
--- a/.changeset/nervous-shoes-retire.md
+++ b/.changeset/nervous-shoes-retire.md
@@ -1,5 +1,5 @@
 ---
-'xstate': minor
+'xstate': patch
 ---
 
-Add support for web-workers
+Fixed an issue with not being able to run XState in Web Workers due to assuming that `window` or `global` object is available in the executing environment, but none of those are actually available in the Web Workers context.

--- a/.changeset/nervous-shoes-retire.md
+++ b/.changeset/nervous-shoes-retire.md
@@ -1,0 +1,5 @@
+---
+'xstate': minor
+---
+
+Add support for web-workers

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -124,13 +124,7 @@ export class Interpreter<
     },
     logger: global.console.log.bind(console),
     devTools: false
-  }))(
-    typeof window !== 'undefined'
-      ? window
-      : typeof self !== 'undefined'
-      ? self
-      : global
-  );
+  }))(typeof self !== 'undefined' ? self : global);
   /**
    * The current state of the interpreted machine.
    */

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -124,7 +124,13 @@ export class Interpreter<
     },
     logger: global.console.log.bind(console),
     devTools: false
-  }))(typeof window === 'undefined' ? global : window);
+  }))(
+    typeof window !== 'undefined'
+      ? window
+      : typeof self !== 'undefined'
+      ? self
+      : global
+  );
   /**
    * The current state of the interpreted machine.
    */


### PR DESCRIPTION
Currently, the code of the interpreter assumes that the code runs either in the browser's main thread (`window` is defined) or in node. This PR allows it to run in a web-worker, in which the _global_ is `self`