### PR TITLE
fix(core): fix type ExtractStateValue to describe real state value

### DIFF
--- a/.changeset/ten-seahorses-smile.md
+++ b/.changeset/ten-seahorses-smile.md
@@ -1,0 +1,5 @@
+---
+'xstate': minor
+---
+
+Fix type `ExtractStateValue` so that it generates a type actually describing a `State.value`

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -92,16 +92,25 @@ export interface StateValueMap {
  */
 export type StateValue = string | StateValueMap;
 
+type KeysWithStates<
+  TStates extends Record<string, StateSchema> | undefined
+> = TStates extends object
+  ? {
+      [K in keyof TStates]-?: TStates[K] extends { states: object } ? K : never;
+    }[keyof TStates]
+  : never;
+
 export type ExtractStateValue<
-  TS extends StateSchema<any>,
-  TSS = TS['states']
-> = TSS extends undefined
-  ? never
-  : {
-      [K in keyof TSS]?:
-        | (TSS[K] extends { states: any } ? keyof TSS[K]['states'] : never)
-        | ExtractStateValue<TSS[K]>;
-    };
+  TSchema extends Required<Pick<StateSchema<any>, 'states'>>
+> =
+  | keyof TSchema['states']
+  | (KeysWithStates<TSchema['states']> extends never
+      ? never
+      : {
+          [K in KeysWithStates<TSchema['states']>]?: ExtractStateValue<
+            TSchema['states'][K]
+          >;
+        });
 
 export interface HistoryValue {
   states: Record<string, HistoryValue | undefined>;


### PR DESCRIPTION
Consider the following schema:

    type LightStateSchema = {
      states: {
        green: {},
        yellow: {},
        red: {
          states: {
            walk: {},
            wait: {},
            stop: {},
          },
        },
      },
    }

The current implementation of the ExtractStateValue type generates the
following type:

    {
      green?: {} | undefined
      yellow?: {} | undefined
      red?: "walk" | "wait" | "stop" | {
        walk?: {} | undefined
        wait?: {} | undefined
        stop?: {} | undefined
      } | undefined
    }

This does not describe the StateValue of LightStateSchema as provided
in State.value.

The new implementation generates the following type:

    "green" | "yellow" | "red" | {
      red?: "walk" | "wait" | "stop" | undefined
    }