### PR TITLE
Feature: createModel()

### DIFF
--- a/packages/core/src/model.ts
+++ b/packages/core/src/model.ts
@@ -1,0 +1,35 @@
+import { assign } from './actions';
+import { AssignAction, Assigner, EventObject, PropertyAssigner } from './types';
+import { mapValues } from './utils';
+
+export function createModel<TContext, TEvent extends EventObject>(
+  initialState: TContext
+): {
+  context: TContext;
+  withUpdaters: <
+    T extends {
+      [key: string]:
+        | Assigner<TContext, TEvent>
+        | PropertyAssigner<TContext, TEvent>;
+    }
+  >(
+    assigners: T
+  ) => {
+    context: TContext;
+    actions: {
+      [K in keyof T]: AssignAction<TContext, TEvent>;
+    };
+  };
+} {
+  return {
+    context: initialState,
+    withUpdaters: (assigners) => {
+      return {
+        context: initialState,
+        actions: mapValues(assigners, (assignment) => {
+          return assign(assignment);
+        }) as any
+      };
+    }
+  };
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -343,7 +343,7 @@ export type TransitionConfigOrTarget<
   TransitionConfigTarget<TContext, TEvent> | TransitionConfig<TContext, TEvent>
 >;
 
-type TransitionsConfigMap<TContext, TEvent extends EventObject> = {
+export type TransitionsConfigMap<TContext, TEvent extends EventObject> = {
   [K in TEvent['type']]?: TransitionConfigOrTarget<
     TContext,
     TEvent extends { type: K } ? TEvent : never

--- a/packages/core/test/model.test.ts
+++ b/packages/core/test/model.test.ts
@@ -8,7 +8,12 @@ describe('createModel', () => {
       value: string;
     };
 
-    const userModel = createModel({
+    interface UserContext {
+      name: string;
+      age: number;
+    }
+
+    const userModel = createModel<UserContext, UserEvent>({
       name: 'David',
       age: 30
     }).withUpdaters({

--- a/packages/core/test/model.test.ts
+++ b/packages/core/test/model.test.ts
@@ -1,0 +1,41 @@
+import { createMachine } from '../src';
+import { createModel } from '../src/model';
+
+describe('createModel', () => {
+  it('model.machine creates a machine that is updated', () => {
+    type UserEvent = {
+      type: 'updateName';
+      value: string;
+    };
+
+    const userModel = createModel({
+      name: 'David',
+      age: 30
+    }).withUpdaters({
+      updateName: {
+        name: (_, e: UserEvent) => e.value
+      }
+    });
+
+    const machine = createMachine<typeof userModel['context'], UserEvent>({
+      context: userModel.context,
+      initial: 'active',
+      states: {
+        active: {
+          on: {
+            updateName: {
+              actions: userModel.actions.updateName
+            }
+          }
+        }
+      }
+    });
+
+    const updatedState = machine.transition(undefined, {
+      type: 'updateName',
+      value: 'Anyone'
+    });
+
+    expect(updatedState.context.name).toEqual('Anyone');
+  });
+});


### PR DESCRIPTION
This PR adds support for an opt-in helper function called `createModel()`, which is meant to assist in creating the [datamodel (SCXML)](https://commons.apache.org/proper/commons-scxml/guide/datamodel.html) for the machine:

```js
import { createMachine } from 'xstate';
import { createModel } from 'xstate/lib/model'; // opt-in, not part of main build

const userModel = createModel({
  name: 'David',
  age: 30
}).withUpdaters({
  updateName: {
    name: (_, e) => e.value // assignments for assign()
  }
});

const machine = createMachine({
  context: userModel.context,
  initial: 'active',
  states: {
    active: {
      on: {
        updateName: {
          actions: userModel.actions.updateName
        }
      }
    }
  }
});
```