### PR TITLE
Update event name reference in docs

### DIFF
--- a/docs/guides/communication.md
+++ b/docs/guides/communication.md
@@ -128,7 +128,7 @@ The resolved data is placed into a `'done.invoke.<id>'` event, under the `data` 
 
 ### Promise Rejection
 
-If a Promise rejects, the `onError` transition will be taken with a `{ type: 'error.execution' }` event. The error data is available on the event's `data` property:
+If a Promise rejects, the `onError` transition will be taken with a `{ type: 'error.platform' }` event. The error data is available on the event's `data` property:
 
 ```js
 const search = (context, event) => new Promise((resolve, reject) => {
@@ -162,7 +162,7 @@ const searchMachine = Machine({
           actions: assign({
             errorMessage: (context, event) => {
               // event is:
-              // { type: 'error.execution', data: 'No query specified' }
+              // { type: 'error.platform', data: 'No query specified' }
               return event.data;
             }
           })
@@ -896,7 +896,7 @@ The `invoke` property is synonymous to the SCXML `<invoke>` element:
 <state id="loading">
   <invoke id="someID" src="someSource" autoforward />
   <transition event="done.invoke.someID" target="success" />
-  <transition event="error.execution" cond="_event.src === 'someID'" target="failure" />
+  <transition event="error.platform" cond="_event.src === 'someID'" target="failure" />
 </state>
 ```
 


### PR DESCRIPTION
Updates the documentation related to promise rejection to align with changes from https://github.com/davidkpiano/xstate/pull/461.