### PR TITLE
chore: use tsdx to build @xstate/react

### DIFF
--- a/packages/xstate-react/package.json
+++ b/packages/xstate-react/package.json
@@ -16,6 +16,7 @@
   "homepage": "https://github.com/davidkpiano/xstate/tree/master/packages/xstate-react#readme",
   "license": "MIT",
   "main": "lib/index.js",
+  "module": "es/index.js",
   "types": "lib/index.d.ts",
   "sideEffects": false,
   "directories": {
@@ -24,7 +25,9 @@
   },
   "files": [
     "lib/**/*.js",
-    "lib/**/*.d.ts"
+    "lib/**/*.d.ts",
+    "es/**/*.js",
+    "es/**/*.d.ts"
   ],
   "repository": {
     "type": "git",
@@ -32,7 +35,7 @@
   },
   "scripts": {
     "clean": "rm -rf dist lib tsconfig.tsbuildinfo",
-    "build": "tsc",
+    "build": "tsc && tsc --outDir es --module es2015",
     "test": "jest",
     "prepublish": "npm run build && npm run test"
   },


### PR DESCRIPTION
My original motivation for this pull request was to get `@xstate/react` to play nicely with Snowpack by just adding an ESM build for this particular package.

While doing so, however, I found that there is a wide range of different build setups for all the packages in this repository and was wondering if it might make sense to unify that setup in one sweeping change instead.

As `tsdx` is already used in one package and I personally also use this for my own libraries I went with that but am also open for other options.

Would you be open to accepting a pull request that reconfigures the entire repository more broadly to use tsdx throughout instead of typescript project reference builds. I'd also suggest to move the dependencies to each package individually as well as the jest runtime and then use lerna to invoke all these runtimes (build, test, lint, etc.) on a per-package basis. There are also mixtures of yarn and npm sprinkled here and there - Not sure which one you'd prefer but even with the latest improvements to npm my experience with monorepos is in favor of yarn).

Let me know if you think this would be out of scope for now or if I should proceed. For my own personal use, this pull request alone gets the job done.

@davidkpiano Btw. I don't know if you remember but we met at the first Agent Conf in Austria as speakers (I co-presented with Nik Graf) and went skiing together afterwards. We both ended up on the newbie squad and rolled down the mountain more than anything else :-D