### PR TITLE
Update Ember.js recipe

### DIFF
--- a/docs/recipes/ember.md
+++ b/docs/recipes/ember.md
@@ -1,17 +1,9 @@
 # Usage with Ember
 
-Ember follows a similar pattern to [Vue](./vue.md):
+The most straightforward way of using XState with Ember.js is through the [ember-statecharts](https://ember-statecharts.com)-addon.
+You can also write a custom integration layer yourself if you want to.
 
-- The machine can be defined externally;
-- The service is placed as a property of the component;
-- State changes are observed via `interpreter.onTransition(state => ...)`, where you set some data property to the next `state`;
-- The machine's context can be referenced as an external data store by the app. Context changes are also observed via `interpreter.onTransition(state => ...)`, where you set another data property to the updated context;
-- The interpreter is started (`interpreter.start()`) when the component is created `constructor()`;
-- Events are sent to the interpreter via `interpreter.send(event)`.
-
-::: tip
-This example is based on Ember Octane features (Ember 3.13+)
-:::
+The machine used should always be decoupled from implementation details; e.g., it should never know that it is in Ember.js (or React, or Vue, etc.):
 
 ```js
 import { Machine } from 'xstate';
@@ -33,6 +25,58 @@ export const toggleMachine = Machine({
   }
 });
 ```
+
+## ember-statecharts
+
+Using [ember-statecharts](https://ember-statecharts.com) makes it easy to use
+XState in your Ember.js codebase.
+
+The addon provides the `useMachine`-API that you can use to interpret and use
+XState machines:
+
+```js
+import Component from '@glimmmer/component';
+import { action } from '@ember/object';
+
+import { useMachine, matchesState } from 'ember-statecharts';
+
+// @use (https://github.com/emberjs/rfcs/pull/567) is still WIP - polyfill it
+import { use } from 'ember-usable';
+
+import toggleMachine from './path/to/toggleMachine';
+
+export default class ToggleComponent extends Component {
+  @use this.statechart = useMachine(toggleMachine);
+
+  @matchesState('active')
+  isActive;
+
+  @matchesState('inactive')
+  isInactive;
+
+  @action
+  toggle() {
+    this.statechart.send('TOGGLE');
+  }
+}
+```
+
+## Custom integration
+
+To integrate XState into your Ember.js codebase without using an addon you can
+follow a similar pattern to [Vue](./vue.md):
+
+- The machine can be defined externally;
+- The service is placed as a property of the component;
+- State changes are observed via `interpreter.onTransition(state => ...)`, where you set some data property to the next `state`;
+- The machine's context can be referenced as an external data store by the app. Context changes are also observed via `interpreter.onTransition(state => ...)`, where you set another data property to the updated context;
+- The interpreter is started (`interpreter.start()`) when the component is created `constructor()`;
+- Events are sent to the interpreter via `interpreter.send(event)`.
+
+::: tip
+This example is based on Ember Octane features (Ember 3.13+)
+:::
+
 
 ```handlebars
 <button type="button" {{on "click" (fn this.transition "TOGGLE")}}>


### PR DESCRIPTION
This updates the Ember.js recipe to mention [ember-statecharts](https://ember-statecharts.com). The addon has existed for multiple years now and sees quite a lot of usage in the Ember.js ecosystem when looking at the stats from [emberobserver](https://emberobserver.com/addons/ember-statecharts) - it's in the 10% most downloaded Ember.js addons.

Using the addon also makes it much easier to use XState with Ember.js in general and writing your own integration layer will just be more work than installing the addon - especially if you want to come up with a nice api.

ember-statecharts mostly follows what xstate/react and xstate/vue are doing - i.e. it provides a `useMachine`-api that will create an interpreter for you that you can then use directly in your application code.