### PR TITLE
[@xstate/react] Add `filter` option and `useMachineSelector()` hook

### DIFF
--- a/.changeset/rude-ghosts-bathe.md
+++ b/.changeset/rude-ghosts-bathe.md
@@ -18,7 +18,7 @@ const [state, send] = useMachine(someMachine, {
 - New hook: `useMachineSelector(...)`, which enables you to apply a `selector` function to get part of (and/or transform) the machine's `state`:
 
 ```js
-const [fullName, send] = useMachine(
+const [fullName, send] = useMachineSelector(
   userMachine,
   (state) => `${state.context.firstName} ${state.context.lastName}`
 );

--- a/.changeset/rude-ghosts-bathe.md
+++ b/.changeset/rude-ghosts-bathe.md
@@ -1,0 +1,25 @@
+---
+'@xstate/react': minor
+---
+
+- New `useMachine(...)` option: `filter(state, prevState)`, which allows you to filter the states that are provided:
+
+```js
+const [state, send] = useMachine(someMachine, {
+  filter: (state, prevState) => {
+    // don't rerender if only actions changed
+    return (
+      state.value !== prevState.value || state.context !== prevState.context
+    );
+  }
+});
+```
+
+- New hook: `useMachineSelector(...)`, which enables you to apply a `selector` function to get part of (and/or transform) the machine's `state`:
+
+```js
+const [fullName, send] = useMachine(
+  userMachine,
+  (state) => `${state.context.firstName} ${state.context.lastName}`
+);
+```

--- a/packages/xstate-react/src/index.ts
+++ b/packages/xstate-react/src/index.ts
@@ -1,3 +1,4 @@
 export { useMachine, asEffect, asLayoutEffect } from './useMachine';
 export { useService } from './useService';
 export { useActor } from './useActor';
+export { useMachineSelect } from './useMachineSelect';

--- a/packages/xstate-react/src/index.ts
+++ b/packages/xstate-react/src/index.ts
@@ -1,4 +1,4 @@
 export { useMachine, asEffect, asLayoutEffect } from './useMachine';
 export { useService } from './useService';
 export { useActor } from './useActor';
-export { useMachineSelect } from './useMachineSelect';
+export { useMachineSelector as useMachineSelect } from './useMachineSelector';

--- a/packages/xstate-react/src/useMachine.ts
+++ b/packages/xstate-react/src/useMachine.ts
@@ -90,7 +90,7 @@ function executeEffect<TContext, TEvent extends EventObject>(
 
 interface UseMachineOptions<TContext, TEvent extends EventObject> {
   /**
-   * If provided, will be merged with machine's `context`.
+   * If provided, will be _merged_ with machine's `context`.
    */
   context?: Partial<TContext>;
   /**
@@ -98,6 +98,11 @@ interface UseMachineOptions<TContext, TEvent extends EventObject> {
    * start at this state instead of its `initialState`.
    */
   state?: StateConfig<TContext, TEvent>;
+
+  filter?: (
+    state: State<TContext, TEvent>,
+    prevState: State<TContext, TEvent>
+  ) => boolean;
 }
 
 export function useMachine<
@@ -140,6 +145,7 @@ export function useMachine<
     services,
     delays,
     state: rehydratedState,
+    filter,
     ...interpreterOptions
   } = options;
 
@@ -194,7 +200,11 @@ export function useMachine<
           currentState.changed === undefined &&
           Object.keys(currentState.children).length;
 
-        if (currentState.changed || initialStateChanged) {
+        if (
+          (currentState.changed || initialStateChanged) &&
+          // Only change the state if it is not filtered out
+          (!filter || filter?.(currentState, state))
+        ) {
           setState(currentState);
         }
 

--- a/packages/xstate-react/src/useMachineSelect.ts
+++ b/packages/xstate-react/src/useMachineSelect.ts
@@ -1,0 +1,33 @@
+import {
+  EventObject,
+  StateMachine,
+  Typestate,
+  Interpreter,
+  State
+} from 'xstate';
+import { MaybeLazy } from './types';
+import { useMachine, UseMachineOptions } from './useMachine';
+
+export function useMachineSelect<
+  T,
+  TContext,
+  TEvent extends EventObject,
+  TTypestate extends Typestate<TContext> = { value: any; context: TContext }
+>(
+  getMachine: MaybeLazy<StateMachine<TContext, any, TEvent, TTypestate>>,
+  selector: (state: State<TContext, TEvent, any, TTypestate>) => T,
+  options: Partial<UseMachineOptions<TContext, TEvent, TTypestate>> = {}
+): [
+  T,
+  Interpreter<TContext, any, TEvent, TTypestate>['send'],
+  Interpreter<TContext, any, TEvent, TTypestate>
+] {
+  const [state, send, service] = useMachine(getMachine, {
+    ...options,
+    filter: (currentState, prevState) => {
+      return selector(currentState) !== selector(prevState);
+    }
+  });
+
+  return [selector(state), send, service];
+}

--- a/packages/xstate-react/src/useMachineSelector.ts
+++ b/packages/xstate-react/src/useMachineSelector.ts
@@ -8,7 +8,7 @@ import {
 import { MaybeLazy } from './types';
 import { useMachine, UseMachineOptions } from './useMachine';
 
-export function useMachineSelect<
+export function useMachineSelector<
   T,
   TContext,
   TEvent extends EventObject,

--- a/packages/xstate-react/test/useMachineSelect.test.tsx
+++ b/packages/xstate-react/test/useMachineSelect.test.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react';
+import { useMachineSelect } from '../src/index';
+import { cleanup, fireEvent, render } from '@testing-library/react';
+import { createMachine, assign } from 'xstate';
+
+afterEach(cleanup);
+
+describe('useMachineSelect hook', () => {
+  it('should only capture selected parts of the state', () => {
+    let rerenders = 0;
+
+    const App = () => {
+      const [value, send] = useMachineSelect(
+        () =>
+          createMachine<{ value: number; flag: boolean }>({
+            initial: 'idle',
+            context: {
+              value: 0,
+              flag: true
+            },
+            states: {
+              idle: {
+                on: {
+                  INC: {
+                    actions: assign({
+                      value: (ctx) => ctx.value + 1
+                    })
+                  },
+                  TOGGLE: {
+                    actions: assign({
+                      flag: false as boolean
+                    })
+                  }
+                }
+              }
+            }
+          }),
+        (state) => state.context.value * 2
+      );
+
+      rerenders++;
+
+      return (
+        <>
+          <div data-testid="value">{value}</div>
+          <button data-testid="inc" onClick={() => send('INC')}></button>
+          <button data-testid="toggle" onClick={() => send('TOGGLE')}></button>
+        </>
+      );
+    };
+
+    const { getByTestId } = render(
+      <React.StrictMode>
+        <App />
+      </React.StrictMode>
+    );
+
+    const incButton = getByTestId('inc');
+    const toggleButton = getByTestId('toggle');
+    const valueEl = getByTestId('value');
+
+    expect(valueEl.textContent).toEqual('0');
+    fireEvent.click(incButton);
+    expect(valueEl.textContent).toEqual('2'); // 1 * 2 = 2
+
+    const currentRerenders = rerenders;
+    fireEvent.click(toggleButton);
+    expect(rerenders).toEqual(currentRerenders);
+  });
+});


### PR DESCRIPTION
- New `useMachine(...)` option: `filter(state, prevState)`, which allows you to filter the states that are provided:

```js
const [state, send] = useMachine(someMachine, {
  filter: (state, prevState) => {
    // don't rerender if only actions changed
    return (
      state.value !== prevState.value || state.context !== prevState.context
    );
  }
});
```

- New hook: `useMachineSelector(...)`, which enables you to apply a `selector` function to get part of (and/or transform) the machine's `state`:

```js
const [fullName, send] = useMachineSelector(
  userMachine,
  (state) => `${state.context.firstName} ${state.context.lastName}`
);
```

Closes #1491 cc. @alexreardon