### PR TITLE
[@xstate/react] Stabilize `send` from useActor

### DIFF
--- a/.changeset/khaki-rivers-move.md
+++ b/.changeset/khaki-rivers-move.md
@@ -1,0 +1,5 @@
+---
+'@xstate/react': patch
+---
+
+The `send` function returned from the `useActor()` hook is now stable.

--- a/.changeset/khaki-rivers-move.md
+++ b/.changeset/khaki-rivers-move.md
@@ -2,4 +2,4 @@
 '@xstate/react': patch
 ---
 
-The `send` function returned from the `useActor()` hook is now stable.
+The `send` function returned from the `useService()` now can take two arguments (an event type and payload), to match the behavior of `@xstate/react` version 0.x.

--- a/.changeset/lemon-rings-kick.md
+++ b/.changeset/lemon-rings-kick.md
@@ -1,0 +1,17 @@
+---
+'@xstate/react': patch
+---
+
+The `send` value returned from the `useService()` hook will now accept a payload, which matches the signature of the `send` value returned from the `useMachine()` hook:
+
+```js
+const [state, send] = useService(someService);
+
+// ...
+
+// this is OK:
+send('ADD', { value: 3 });
+
+// which is equivalent to:
+send({ type: 'ADD', value: 3 });
+```

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -199,6 +199,34 @@ export interface ActivityDefinition<TContext, TEvent extends EventObject>
 
 export type Sender<TEvent extends EventObject> = (event: Event<TEvent>) => void;
 
+type ExcludeType<A> = { [K in Exclude<keyof A, 'type'>]: A[K] };
+
+type ExtractExtraParameters<A, T> = A extends { type: T }
+  ? ExcludeType<A>
+  : never;
+
+type ExtractSimple<A> = A extends any
+  ? {} extends ExcludeType<A>
+    ? A
+    : never
+  : never;
+
+type NeverIfEmpty<T> = {} extends T ? never : T;
+
+export interface PayloadSender<TEvent extends EventObject> {
+  /**
+   * Send an event object or just the event type, if the event has no other payload
+   */
+  (event: TEvent | ExtractSimple<TEvent>['type']): void;
+  /**
+   * Send an event type and its payload
+   */
+  <K extends TEvent['type']>(
+    eventType: K,
+    payload: NeverIfEmpty<ExtractExtraParameters<TEvent, K>>
+  ): void;
+}
+
 export type Receiver<TEvent extends EventObject> = (
   listener: (event: TEvent) => void
 ) => void;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -198,6 +198,7 @@ export interface ActivityDefinition<TContext, TEvent extends EventObject>
 }
 
 export type Sender<TEvent extends EventObject> = (event: Event<TEvent>) => void;
+
 export type Receiver<TEvent extends EventObject> = (
   listener: (event: TEvent) => void
 ) => void;

--- a/packages/xstate-react/src/types.ts
+++ b/packages/xstate-react/src/types.ts
@@ -46,31 +46,3 @@ export interface ActorRefLike<TEvent extends EventObject, TEmitted = any>
 }
 
 export type MaybeLazy<T> = T | (() => T);
-
-type ExcludeType<A> = { [K in Exclude<keyof A, 'type'>]: A[K] };
-
-type ExtractExtraParameters<A, T> = A extends { type: T }
-  ? ExcludeType<A>
-  : never;
-
-type ExtractSimple<A> = A extends any
-  ? {} extends ExcludeType<A>
-    ? A
-    : never
-  : never;
-
-type NeverIfEmpty<T> = {} extends T ? never : T;
-
-export interface PayloadSender<TEvent extends EventObject> {
-  /**
-   * Send an event object or just the event type, if the event has no other payload
-   */
-  (event: TEvent | ExtractSimple<TEvent>['type']): void;
-  /**
-   * Send an event type and its payload
-   */
-  <K extends TEvent['type']>(
-    eventType: K,
-    payload: NeverIfEmpty<ExtractExtraParameters<TEvent, K>>
-  ): void;
-}

--- a/packages/xstate-react/src/types.ts
+++ b/packages/xstate-react/src/types.ts
@@ -47,7 +47,14 @@ export interface ActorRefLike<TEvent extends EventObject, TEmitted = any>
 
 export type MaybeLazy<T> = T | (() => T);
 
+type OnlyIfExact<A, B, C> = A extends B ? (B extends A ? C : never) : never;
 export interface PayloadSender<TEvent extends EventObject> {
-  (event: TEvent | TEvent['type']): void;
-  (event: TEvent['type'], payload: Omit<TEvent, 'type'>): void;
+  (event: TEvent): void;
+  <K extends TEvent['type']>(
+    event: K & OnlyIfExact<{ type: K }, Extract<TEvent, { type: K }>, K>
+  ): void;
+  <K extends TEvent['type']>(
+    event: K,
+    payload: Omit<Extract<TEvent, { type: K }>, 'type'>
+  ): void;
 }

--- a/packages/xstate-react/src/types.ts
+++ b/packages/xstate-react/src/types.ts
@@ -46,3 +46,8 @@ export interface ActorRefLike<TEvent extends EventObject, TEmitted = any>
 }
 
 export type MaybeLazy<T> = T | (() => T);
+
+export interface PayloadSender<TEvent extends EventObject> {
+  (event: TEvent | TEvent['type']): void;
+  (event: TEvent['type'], payload: Omit<TEvent, 'type'>): void;
+}

--- a/packages/xstate-react/src/types.ts
+++ b/packages/xstate-react/src/types.ts
@@ -46,3 +46,33 @@ export interface ActorRefLike<TEvent extends EventObject, TEmitted = any>
 }
 
 export type MaybeLazy<T> = T | (() => T);
+
+// TODO: remove these types (up to PayloadSender) when
+// @xstate/react depends on xstate v5.0 (use PayloadSender from core instead)
+type ExcludeType<A> = { [K in Exclude<keyof A, 'type'>]: A[K] };
+
+type ExtractExtraParameters<A, T> = A extends { type: T }
+  ? ExcludeType<A>
+  : never;
+
+type ExtractSimple<A> = A extends any
+  ? {} extends ExcludeType<A>
+    ? A
+    : never
+  : never;
+
+type NeverIfEmpty<T> = {} extends T ? never : T;
+
+export interface PayloadSender<TEvent extends EventObject> {
+  /**
+   * Send an event object or just the event type, if the event has no other payload
+   */
+  (event: TEvent | ExtractSimple<TEvent>['type']): void;
+  /**
+   * Send an event type and its payload
+   */
+  <K extends TEvent['type']>(
+    eventType: K,
+    payload: NeverIfEmpty<ExtractExtraParameters<TEvent, K>>
+  ): void;
+}

--- a/packages/xstate-react/src/useActor.ts
+++ b/packages/xstate-react/src/useActor.ts
@@ -1,4 +1,5 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useRef } from 'react';
+import useIsomorphicLayoutEffect from 'use-isomorphic-layout-effect';
 import { Sender, ActorRefLike } from './types';
 import { EventObject, Actor } from 'xstate';
 import useConstant from './useConstant';
@@ -24,7 +25,7 @@ export function useActor<TEvent extends EventObject, TEmitted = any>(
     }
   });
 
-  useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     actorRefRef.current = actorRef;
     setCurrent(getSnapshot(actorRef));
     const subscription = actorRef.subscribe(setCurrent);

--- a/packages/xstate-react/src/useActor.ts
+++ b/packages/xstate-react/src/useActor.ts
@@ -1,31 +1,31 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Sender, ActorRefLike } from './types';
 import { EventObject, Actor } from 'xstate';
+import useConstant from './useConstant';
 
 export function useActor<TEvent extends EventObject, TEmitted = any>(
   actorRef: ActorRefLike<TEvent, TEmitted> | Actor,
   getSnapshot: (actor: typeof actorRef) => TEmitted = (a) =>
     'state' in a ? a.state : (undefined as any)
 ): [TEmitted, Sender<TEvent>] {
-  // const actor = useMemo(() => resolveActor(actorLike), [actorLike]);
+  const actorRefRef = useRef(actorRef);
   const deferredEventsRef = useRef<TEvent[]>([]);
   const [current, setCurrent] = useState(() => getSnapshot(actorRef));
 
-  const send: Sender<TEvent> = useCallback(
-    (event) => {
-      // If the previous actor is a deferred actor,
-      // queue the events so that they can be replayed
-      // on the non-deferred actor.
-      if ('deferred' in actorRef && actorRef.deferred) {
-        deferredEventsRef.current.push(event);
-      } else {
-        actorRef.send(event);
-      }
-    },
-    [actorRef]
-  );
+  const send: Sender<TEvent> = useConstant(() => (event) => {
+    const currentActorRef = actorRefRef.current;
+    // If the previous actor is a deferred actor,
+    // queue the events so that they can be replayed
+    // on the non-deferred actor.
+    if ('deferred' in currentActorRef && currentActorRef.deferred) {
+      deferredEventsRef.current.push(event);
+    } else {
+      currentActorRef.send(event);
+    }
+  });
 
   useEffect(() => {
+    actorRefRef.current = actorRef;
     setCurrent(getSnapshot(actorRef));
     const subscription = actorRef.subscribe(setCurrent);
 

--- a/packages/xstate-react/src/useService.ts
+++ b/packages/xstate-react/src/useService.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useMemo, useRef } from 'react';
 import {
   EventObject,
   State,
@@ -6,6 +6,7 @@ import {
   Typestate,
   PayloadSender
 } from 'xstate';
+import useIsomorphicLayoutEffect from 'use-isomorphic-layout-effect';
 import { useActor } from './useActor';
 import { ActorRef } from './types';
 import useConstant from './useConstant';
@@ -45,7 +46,7 @@ export function useService<
   // Using a ref ensures that the constant `sender` always sends the event
   // to the latest (possibly changed) `service.send` method.
   const senderRef = useRef(service.send);
-  useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     senderRef.current = service.send;
   }, [service.send]);
   const sender = useConstant(

--- a/packages/xstate-react/src/useService.ts
+++ b/packages/xstate-react/src/useService.ts
@@ -1,13 +1,7 @@
 import { useMemo } from 'react';
-import {
-  EventObject,
-  State,
-  Interpreter,
-  Typestate,
-  PayloadSender
-} from 'xstate';
+import { EventObject, State, Interpreter, Typestate } from 'xstate';
 import { useActor } from './useActor';
-import { ActorRef } from './types';
+import { ActorRef, PayloadSender } from './types';
 
 export function fromService<TContext, TEvent extends EventObject>(
   service: Interpreter<TContext, any, TEvent>

--- a/packages/xstate-react/src/useService.ts
+++ b/packages/xstate-react/src/useService.ts
@@ -1,7 +1,13 @@
 import { useEffect, useMemo, useRef } from 'react';
-import { EventObject, State, Interpreter, Typestate } from 'xstate';
+import {
+  EventObject,
+  State,
+  Interpreter,
+  Typestate,
+  PayloadSender
+} from 'xstate';
 import { useActor } from './useActor';
-import { ActorRef, PayloadSender } from './types';
+import { ActorRef } from './types';
 import useConstant from './useConstant';
 
 export function fromService<TContext, TEvent extends EventObject>(

--- a/packages/xstate-react/test/useActor.test.tsx
+++ b/packages/xstate-react/test/useActor.test.tsx
@@ -278,4 +278,64 @@ describe('useActor', () => {
     fireEvent.click(button);
     expect(div.textContent).toEqual('100');
   });
+
+  it('send() should be stable', (done) => {
+    jest.useFakeTimers();
+    const fakeSubscribe = () => {
+      return {
+        unsubscribe: () => {
+          /* ... */
+        }
+      };
+    };
+    const noop = () => {
+      /* ... */
+    };
+    const firstActor: ActorRefLike<any> = {
+      send: noop,
+      subscribe: fakeSubscribe
+    };
+    const lastActor: ActorRefLike<any> = {
+      send: () => {
+        done();
+      },
+      subscribe: fakeSubscribe
+    };
+
+    const Test = () => {
+      const [actor, setActor] = useState(firstActor);
+      const [, send] = useActor(actor);
+
+      React.useEffect(() => {
+        setTimeout(() => {
+          // The `send` here is closed-in
+          send('anything');
+        }, 10);
+      }, []); // Intentionally omit `send` from dependency array
+
+      return (
+        <>
+          <button
+            data-testid="button"
+            onClick={() => setActor(lastActor)}
+          ></button>
+        </>
+      );
+    };
+
+    const { getByTestId } = render(<Test />);
+
+    // At this point, `send` refers to the first (noop) actor
+
+    const button = getByTestId('button');
+    fireEvent.click(button);
+
+    // At this point, `send` refers to the last actor
+
+    jest.advanceTimersByTime(20);
+
+    // The effect will call the closed-in `send`, which originally
+    // was the reference to the first actor. Now that `send` is stable,
+    // it will always refer to the latest actor.
+  });
 });

--- a/packages/xstate-react/test/useMachine.test.tsx
+++ b/packages/xstate-react/test/useMachine.test.tsx
@@ -18,6 +18,7 @@ import {
 } from '@testing-library/react';
 import { useState } from 'react';
 import { asEffect, asLayoutEffect } from '../src/useMachine';
+import { DoneEventObject } from 'xstate/src';
 
 afterEach(cleanup);
 
@@ -25,7 +26,10 @@ describe('useMachine hook', () => {
   const context = {
     data: undefined
   };
-  const fetchMachine = Machine<typeof context>({
+  const fetchMachine = Machine<
+    typeof context,
+    { type: 'FETCH' } | DoneEventObject
+  >({
     id: 'fetch',
     initial: 'idle',
     context,
@@ -220,7 +224,7 @@ describe('useMachine hook', () => {
   });
 
   it('actions should not have stale data', async (done) => {
-    const toggleMachine = Machine({
+    const toggleMachine = Machine<any, { type: 'TOGGLE' }>({
       initial: 'inactive',
       states: {
         inactive: {
@@ -344,7 +348,7 @@ describe('useMachine hook', () => {
   it('should capture all actions', (done) => {
     let count = 0;
 
-    const machine = createMachine({
+    const machine = createMachine<any, { type: 'EVENT' }>({
       initial: 'active',
       states: {
         active: {
@@ -569,7 +573,7 @@ describe('useMachine (strict mode)', () => {
   });
 
   it('child component should be able to send an event to a parent immediately in an effect', (done) => {
-    const machine = createMachine({
+    const machine = createMachine<any, { type: 'FINISH' }>({
       initial: 'active',
       states: {
         active: {
@@ -653,7 +657,7 @@ describe('useMachine (strict mode)', () => {
   it('delayed transitions should work when initializing from a rehydrated state', () => {
     jest.useFakeTimers();
     try {
-      const testMachine = Machine({
+      const testMachine = Machine<any, { type: 'START' }>({
         id: 'app',
         initial: 'idle',
         states: {

--- a/packages/xstate-react/test/useService.test.tsx
+++ b/packages/xstate-react/test/useService.test.tsx
@@ -158,7 +158,7 @@ describe('useService hook', () => {
 
   it('should render the final state', () => {
     const service = interpret(
-      Machine({
+      Machine<any, { type: 'NEXT' }>({
         initial: 'first',
         states: {
           first: {
@@ -175,7 +175,7 @@ describe('useService hook', () => {
       })
     ).start();
 
-    service.send({ type: 'NEXT' });
+    service.send('NEXT');
 
     const Test = () => {
       const [state] = useService(service);

--- a/packages/xstate-react/test/useService.test.tsx
+++ b/packages/xstate-react/test/useService.test.tsx
@@ -1,13 +1,16 @@
 import { useState } from 'react';
 import * as React from 'react';
 import { useService, useMachine } from '../src';
-import { Machine, assign, interpret, Interpreter } from 'xstate';
+import { Machine, assign, interpret, Interpreter, createMachine } from 'xstate';
 import { render, cleanup, fireEvent, act } from '@testing-library/react';
 
 afterEach(cleanup);
 
 describe('useService hook', () => {
-  const counterMachine = Machine<{ count: number }>(
+  const counterMachine = Machine<
+    { count: number },
+    { type: 'INC' } | { type: 'SOMETHING' }
+  >(
     {
       id: 'counter',
       initial: 'active',
@@ -23,7 +26,9 @@ describe('useService hook', () => {
     },
     {
       actions: {
-        doSomething: () => {}
+        doSomething: () => {
+          /* do nothing */
+        }
       }
     }
   );
@@ -180,5 +185,51 @@ describe('useService hook', () => {
     const { container } = render(<Test />);
 
     expect(container.textContent).toBe('last');
+  });
+
+  it('service should accept the 2-argument variant', () => {
+    const service = interpret(
+      createMachine<any, { type: 'EVENT'; value: number }>({
+        initial: 'first',
+        states: {
+          first: {
+            on: {
+              EVENT: {
+                target: 'second',
+                cond: (_, e) => e.value === 42
+              }
+            }
+          },
+          second: {}
+        }
+      })
+    ).start();
+
+    const Test = () => {
+      const [state, send] = useService(service);
+
+      return (
+        <>
+          <div data-testid="value">{state.value}</div>
+          <button
+            data-testid="button"
+            onClick={() => send('EVENT', { value: 42 })}
+          ></button>
+        </>
+      );
+    };
+
+    const { getByTestId } = render(
+      <React.StrictMode>
+        <Test />
+      </React.StrictMode>
+    );
+
+    const button = getByTestId('button');
+    const value = getByTestId('value');
+
+    fireEvent.click(button);
+
+    expect(value.textContent).toBe('second');
   });
 });


### PR DESCRIPTION
This PR makes `send` from the `useActor(...)` hook stable.

Reference: https://spectrum.chat/statecharts/general/xstate-react-1-0-0-breaking-changes~5ce72da1-871f-4ea4-9f70-40680bf02027