### PR TITLE
Use on transition hook

### DIFF
--- a/.changeset/two-chefs-mix.md
+++ b/.changeset/two-chefs-mix.md
@@ -1,0 +1,5 @@
+---
+'@xstate/react': minor
+---
+
+Add `useOnTransition` hook

--- a/packages/xstate-react/src/index.ts
+++ b/packages/xstate-react/src/index.ts
@@ -1,3 +1,4 @@
 export { useMachine, asEffect, asLayoutEffect } from './useMachine';
 export { useService } from './useService';
 export { useActor } from './useActor';
+export { useOnTransition } from './useOnTransition';

--- a/packages/xstate-react/src/useOnTransition.ts
+++ b/packages/xstate-react/src/useOnTransition.ts
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+import { EventObject, Typestate } from 'xstate';
+import { Interpreter, StateListener } from 'xstate/lib/interpreter';
+
+interface UseOnTransitionOptions {
+  ignoreInitEvent: boolean;
+}
+export function useOnTransition<
+  TContext,
+  TEvent extends EventObject,
+  TTypestate extends Typestate<TContext> = { value: any; context: TContext }
+>(
+  listener: StateListener<TContext, TEvent, any, TTypestate>,
+  service: Interpreter<TContext, any, TEvent, TTypestate>,
+  options?: UseOnTransitionOptions
+) {
+  useEffect(() => {
+    service.onTransition((state, event) => {
+      if (options?.ignoreInitEvent && event.type === 'xstate.init') {
+        return;
+      }
+      listener(state, event);
+    });
+  }, [service]);
+}

--- a/packages/xstate-react/test/useOnTransition.test.tsx
+++ b/packages/xstate-react/test/useOnTransition.test.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react';
+import { render, fireEvent, cleanup } from '@testing-library/react';
+import { Machine } from 'xstate';
+import { useMachine, useOnTransition } from '../src';
+
+describe('useOnTransition hook', () => {
+  const machine = Machine({
+    id: 'useOnTransition',
+    initial: 'a',
+    states: {
+      a: {
+        on: {
+          b: 'b'
+        }
+      },
+      b: {
+        on: {
+          a: 'a'
+        }
+      }
+    }
+  });
+  interface TestProps {
+    onTransition: () => void;
+    ignoreInit?: boolean;
+  }
+  const Test = ({ onTransition, ignoreInit }: TestProps) => {
+    const [state, send, service] = useMachine(machine, {
+      actions: {
+        onTransition
+      }
+    });
+
+    useOnTransition(onTransition, service, { ignoreInitEvent: !!ignoreInit });
+
+    if (state.matches('a')) {
+      return <button onClick={() => send('b')}>go to b</button>;
+    }
+    if (state.matches('b')) {
+      return <button onClick={() => send('a')}>go to a</button>;
+    }
+
+    return <> </>;
+  };
+
+  beforeEach(cleanup);
+
+  it('calls the function on each state transition and on init', () => {
+    const mockOnTransition = jest.fn();
+    const { getByText } = render(<Test onTransition={mockOnTransition} />);
+
+    fireEvent.click(getByText(/go to b/i));
+    fireEvent.click(getByText(/go to a/i));
+    fireEvent.click(getByText(/go to b/i));
+    fireEvent.click(getByText(/go to a/i));
+
+    expect(mockOnTransition).toHaveBeenCalledTimes(5);
+  });
+
+  it('calls the function on each state transition, but not on init', () => {
+    const mockOnTransition = jest.fn();
+    const { getByText } = render(
+      <Test onTransition={mockOnTransition} ignoreInit={true} />
+    );
+
+    fireEvent.click(getByText(/go to b/i));
+    fireEvent.click(getByText(/go to a/i));
+    fireEvent.click(getByText(/go to b/i));
+    fireEvent.click(getByText(/go to a/i));
+
+    expect(mockOnTransition).toHaveBeenCalledTimes(4);
+  });
+});


### PR DESCRIPTION
This PR adds a hook that allows you to pass a function to be run on each state transition.

example usage:

```jsx
const MyComponent = () => {
  const [state, send, service] = useMachine(someMachine);
  useOnTransition((state, event) => {
    console.log({state, event});
  }, service, { ignoreInitEvent: true });

  return (
    <div>
      {/* ... */}
    </div>
  );
}

```