### PR TITLE
move Community to Github-Discussions

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -20,7 +20,7 @@ module.exports = {
       { text: 'API', link: 'https://xstate.js.org/api' },
       { text: 'Visualizer', link: 'https://xstate.js.org/viz' },
       { text: 'Chat', link: 'https://gitter.im/statecharts/statecharts' },
-      { text: 'Community', link: 'https://spectrum.chat/statecharts' }
+      { text: 'Community', link: 'https://github.com/davidkpiano/xstate/discussions' }
     ],
     sidebar: [
       {


### PR DESCRIPTION
I think you mentioned you wanted to move Xstate specific non-bug-report conversations to [here](https://github.com/davidkpiano/xstate/discussions)?

Besides, Spectrum is flaky lately.