### PR TITLE
docs(xstate-test): add note about nested states

### DIFF
--- a/packages/xstate-test/README.md
+++ b/packages/xstate-test/README.md
@@ -222,4 +222,4 @@ Executes each step in `testPath.segments` by:
 
 And finally, verifying that the SUT is in the target `testPath.state`.
 
-NOTE: If your model has nested states, the `meta.test` method for each parent state is also executed when veryifing the SUT is in the target `testPath.state`
+NOTE: If your model has nested states, the `meta.test` method for each parent state of that nested state is also executed when verifying that the SUT is in that nested state.

--- a/packages/xstate-test/README.md
+++ b/packages/xstate-test/README.md
@@ -221,3 +221,5 @@ Executes each step in `testPath.segments` by:
 2. Executing the event for `segment.event`
 
 And finally, verifying that the SUT is in the target `testPath.state`.
+
+NOTE: If your model has nested states, the `meta.test` method for each parent state is also executed when veryifing the SUT is in the target `testPath.state`


### PR DESCRIPTION
This tripped me up before and caused me to spend a few hours debugging @xstate/test and my tests to determine why it seemed like tests were being run for the wrong state.

Turns out that @xstate/test executes not just the `meta.test` for the current state, but also all the parent states of the current state. Seems like a good thing to note in the docs as it's not immediately obvious (but makes sense now in retrospect).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/davidkpiano/xstate/1535)
<!-- Reviewable:end -->
