### PR TITLE
Add delays to options documentation

### DIFF
--- a/docs/guides/machines.md
+++ b/docs/guides/machines.md
@@ -48,7 +48,7 @@ The machine config is the same as the [state node config](./statenodes.md), with
 
 ## Options
 
-Implementations for [actions](./actions.md), [activities](./activities.md), [guards](./guards.md), and [services](./communication.md) can be referenced in the machine config as a string, and then specified as an object in the 2nd argument to `Machine()`:
+Implementations for [actions](./actions.md), [activities](./activities.md), [delays](./delays.md), [guards](./guards.md), and [services](./communication.md) can be referenced in the machine config as a string, and then specified as an object in the 2nd argument to `Machine()`:
 
 ```js
 const lightMachine = Machine(
@@ -72,6 +72,9 @@ const lightMachine = Machine(
     activities: {
       /* ... */
     },
+    delays: {
+      /* ... */
+    },
     guards: {
       /* ... */
     },
@@ -82,10 +85,11 @@ const lightMachine = Machine(
 );
 ```
 
-This object has 4 optional properties:
+This object has 5 optional properties:
 
 - `actions` - the mapping of action names to their implementation
 - `activities` - the mapping of activity names to their implementation
+- `delays` - the mapping of delay names to their implementation
 - `guards` - the mapping of transition guard (`cond`) names to their implementation
 - `services` - the mapping of invoked service (`src`) names to their implementation
 


### PR DESCRIPTION
It looks like `delays` was missing from the options docs.
- add link to delays docs
- add delays to example option code
- update total to 5
- add delays description

\*Inserted in alphabetical order position.

Please let me know if I made any mistakes. Just trying to help document this great tool :)