### PR TITLE
[docs] Update context.md

### DIFF
--- a/docs/guides/context.md
+++ b/docs/guides/context.md
@@ -41,7 +41,7 @@ const glassMachine = Machine(
         always: {
             target: 'full',
             cond: 'glassIsFull'
-        }
+        },
         on: {
           FILL: {
             target: 'filling',
@@ -65,7 +65,7 @@ The current context is referenced on the `State` as `state.context`:
 const nextState = glassMachine.transition(glassMachine.initialState, 'FILL');
 
 nextState.context;
-// => { count: 1 }
+// => { amount: 1 }
 ```
 
 ## Initial Context


### PR DESCRIPTION
 
 * Adds a missing comma to fix a syntax error in the first code block.
 * Changes the `nextState.context` to properly show "amount" instead of "count"