### PR TITLE
Ensure spawned actors are present in state.children. Fixes #795

### DIFF
--- a/.changeset/funny-spiders-push.md
+++ b/.changeset/funny-spiders-push.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+The `state.children` property now properly shows all spawned and invoked actors. See #795 for more details.

--- a/.changeset/funny-spiders-push.md
+++ b/.changeset/funny-spiders-push.md
@@ -2,4 +2,4 @@
 'xstate': patch
 ---
 
-The `state.children` property now properly shows all spawned and invoked actors. See #795 for more details.
+The `state.children` property now properly shows all spawned and invoked actors. See [#795](https://github.com/davidkpiano/xstate/issues/795) for more details.

--- a/packages/core/test/interpreter.test.ts
+++ b/packages/core/test/interpreter.test.ts
@@ -1909,5 +1909,33 @@ Event: {\\"type\\":\\"SOME_EVENT\\"}"
 
       service.start();
     });
+
+    it('state.children should reference spawned actors', (done) => {
+      const childMachine = Machine({
+        initial: 'idle',
+        states: {
+          idle: {}
+        }
+      });
+
+      const formMachine = createMachine<any>({
+        id: 'form',
+        initial: 'idle',
+        context: {},
+        entry: assign({
+          firstNameRef: () => spawn(childMachine, 'child')
+        }),
+        states: {
+          idle: {}
+        }
+      });
+
+      interpret(formMachine)
+        .onTransition((state) => {
+          expect(state.children).toHaveProperty('child');
+          done();
+        })
+        .start();
+    });
   });
 });

--- a/packages/xstate-react/src/useMachine.ts
+++ b/packages/xstate-react/src/useMachine.ts
@@ -157,23 +157,25 @@ export function useMachine<
       services,
       delays
     };
-    const resolvedMachine = machine.withConfig(machineConfig, {
+    const machineWithConfig = machine.withConfig(machineConfig, {
       ...machine.context,
       ...context
     } as TContext);
 
     return [
-      resolvedMachine,
-      interpret(resolvedMachine, { deferEvents: true, ...interpreterOptions })
+      machineWithConfig,
+      interpret(machineWithConfig, { deferEvents: true, ...interpreterOptions })
     ];
   });
 
-  const [state, setState] = useState(() => {
-    // Always read the initial state to properly initialize the machine
-    // https://github.com/davidkpiano/xstate/issues/1334
-    const { initialState } = resolvedMachine;
-    return rehydratedState ? State.create(rehydratedState) : initialState;
-  });
+  const [state, setState] = useState<State<TContext, TEvent, any, TTypestate>>(
+    () => {
+      // Always read the initial state to properly initialize the machine
+      // https://github.com/davidkpiano/xstate/issues/1334
+      const { initialState } = resolvedMachine;
+      return rehydratedState ? State.create(rehydratedState) : initialState;
+    }
+  );
 
   const effectActionsRef = useRef<
     Array<[ReactActionObject<TContext, TEvent>, State<TContext, TEvent>]>


### PR DESCRIPTION
This PR ensures that all actors (spawned/invoked) are represented in `state.children`.