### PR TITLE
Ensure exit actions are called for finalized invoked machines. Fixes #1109

### DIFF
--- a/.changeset/chatty-wombats-worry.md
+++ b/.changeset/chatty-wombats-worry.md
@@ -2,4 +2,4 @@
 'xstate': patch
 ---
 
-Exit actions will now be properly called when an invoked machine reaches its final state. See #1109 for more details.
+Exit actions will now be properly called when an invoked machine reaches its final state. See [#1109](https://github.com/davidkpiano/xstate/issues/1109) for more details.

--- a/.changeset/chatty-wombats-worry.md
+++ b/.changeset/chatty-wombats-worry.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Exit actions will now be properly called when an invoked machine reaches its final state. See #1109 for more details.

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -275,6 +275,13 @@ export class Interpreter<
     const isDone = isInFinalState(state.configuration || [], this.machine);
 
     if (this.state.configuration && isDone) {
+      // exit interpreter procedure: https://www.w3.org/TR/scxml/#exitInterpreter
+      this.state.configuration.forEach((stateNode) => {
+        for (const action of stateNode.definition.exit) {
+          this.exec(action, state);
+        }
+      });
+
       // get final child state node
       const finalChildStateNode = state.configuration.find(
         (sn) => sn.type === 'final' && sn.parent === this.machine

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -1353,6 +1353,44 @@ describe('choose', () => {
 
     expect(service.state.context).toEqual({ answer: 42 });
   });
+
+  // https://github.com/davidkpiano/xstate/issues/1109
+  it('exit actions should be called when invoked machine reaches final state', (done) => {
+    let exitCalled = false;
+    const childMachine = Machine({
+      exit: () => {
+        exitCalled = true;
+      },
+      initial: 'a',
+      states: {
+        a: {
+          type: 'final'
+        }
+      }
+    });
+
+    const parentMachine = Machine({
+      initial: 'active',
+      states: {
+        active: {
+          invoke: {
+            src: childMachine,
+            onDone: 'finished'
+          }
+        },
+        finished: {
+          type: 'final'
+        }
+      }
+    });
+
+    interpret(parentMachine)
+      .onDone(() => {
+        expect(exitCalled).toBeTruthy();
+        done();
+      })
+      .start();
+  });
 });
 
 describe('sendParent', () => {

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -1357,6 +1357,7 @@ describe('choose', () => {
   // https://github.com/davidkpiano/xstate/issues/1109
   it('exit actions should be called when invoked machine reaches final state', (done) => {
     let exitCalled = false;
+    let childExitCalled = false;
     const childMachine = Machine({
       exit: () => {
         exitCalled = true;
@@ -1364,7 +1365,10 @@ describe('choose', () => {
       initial: 'a',
       states: {
         a: {
-          type: 'final'
+          type: 'final',
+          exit: () => {
+            childExitCalled = true;
+          }
         }
       }
     });
@@ -1387,6 +1391,7 @@ describe('choose', () => {
     interpret(parentMachine)
       .onDone(() => {
         expect(exitCalled).toBeTruthy();
+        expect(childExitCalled).toBeTruthy();
         done();
       })
       .start();


### PR DESCRIPTION
This PR fixes #1109 by executing exit actions when an invoked machine reaches its final state.