### PR TITLE
Make stop() accept an expression. Fixes #1457

### DIFF
--- a/.changeset/cyan-pants-walk.md
+++ b/.changeset/cyan-pants-walk.md
@@ -1,0 +1,10 @@
+---
+'xstate': minor
+---
+
+Expressions can now be used in the `stop()` action creator:
+
+```js
+// ...
+actions: stop((context) => context.someActor);
+```

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -1184,7 +1184,7 @@ class StateNode<
     const invokeActions = resolvedActions.filter((action) => {
       return (
         action.type === actionTypes.start &&
-        (action as ActivityActionObject<TContext, TEvent>).activity.type ===
+        (action as ActivityActionObject<TContext, TEvent>).activity?.type ===
           actionTypes.invoke
       );
     }) as Array<InvokeActionObject<TContext, TEvent>>;

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -57,6 +57,7 @@ import { isInFinalState } from './stateUtils';
 import { registry } from './registry';
 import { registerService } from './devTools';
 import * as serviceScope from './serviceScope';
+import { StopActionObject } from '.';
 
 export type StateListener<
   TContext,
@@ -880,7 +881,7 @@ export class Interpreter<
         break;
       }
       case actionTypes.stop: {
-        this.stopChild(action.activity.id);
+        this.stopChild((action as StopActionObject).activity.id);
         break;
       }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -796,7 +796,7 @@ export interface NullEvent {
 export interface ActivityActionObject<TContext, TEvent extends EventObject>
   extends ActionObject<TContext, TEvent> {
   type: ActionTypes.Start | ActionTypes.Stop;
-  activity: ActivityDefinition<TContext, TEvent>;
+  activity: ActivityDefinition<TContext, TEvent> | undefined;
   exec: ActionFunction<TContext, TEvent> | undefined;
 }
 
@@ -854,6 +854,20 @@ export interface SendActionObject<
   event: TSentEvent;
   delay?: number;
   id: string | number;
+}
+
+export interface StopAction<TContext, TEvent extends EventObject>
+  extends ActionObject<TContext, TEvent> {
+  type: ActionTypes.Stop;
+  activity:
+    | string
+    | { id: string }
+    | Expr<TContext, TEvent, string | { id: string }>;
+}
+
+export interface StopActionObject {
+  type: ActionTypes.Stop;
+  activity: { id: string };
 }
 
 export type Expr<TContext, TEvent extends EventObject, T> = (

--- a/packages/core/test/deep.test.ts
+++ b/packages/core/test/deep.test.ts
@@ -127,7 +127,6 @@ describe('deep transitions', () => {
     });
 
     it('should exit substate when machine handles event (MACHINE_EVENT)', () => {
-      // console.log(deepMachine.initialState.value);
       const actual = deepMachine
         .transition(deepMachine.initialState, 'MACHINE_EVENT')
         .actions.map((a) => `${a}`);

--- a/packages/core/test/interpreter.test.ts
+++ b/packages/core/test/interpreter.test.ts
@@ -13,7 +13,7 @@ import {
   createMachine
 } from '../src';
 import { State } from '../src/State';
-import { log, actionTypes, raise } from '../src/actions';
+import { log, actionTypes, raise, stop } from '../src/actions';
 import { isObservable } from '../src/utils';
 import { interval, from } from 'rxjs';
 import { map } from 'rxjs/operators';
@@ -1936,6 +1936,71 @@ Event: {\\"type\\":\\"SOME_EVENT\\"}"
           done();
         })
         .start();
+    });
+
+    it('stopped spawned actors should be cleaned up in parent', (done) => {
+      const childMachine = Machine({
+        initial: 'idle',
+        states: {
+          idle: {}
+        }
+      });
+
+      const parentMachine = createMachine<any>({
+        id: 'form',
+        initial: 'present',
+        context: {},
+        entry: assign({
+          machineRef: () => spawn(childMachine, 'machineChild'),
+          promiseRef: () =>
+            spawn(
+              new Promise(() => {
+                // ...
+              }),
+              'promiseChild'
+            ),
+          observableRef: () => spawn(interval(1000), 'observableChild')
+        }),
+        states: {
+          present: {
+            on: {
+              NEXT: {
+                target: 'gone',
+                actions: [
+                  stop((ctx) => ctx.machineRef),
+                  stop((ctx) => ctx.promiseRef),
+                  stop((ctx) => ctx.observableRef)
+                ]
+              }
+            }
+          },
+          gone: {
+            type: 'final'
+          }
+        }
+      });
+
+      const service = interpret(parentMachine)
+        .onDone(() => {
+          expect(service.children.get('machineChild')).toBeUndefined();
+          expect(service.children.get('promiseChild')).toBeUndefined();
+          expect(service.children.get('observableChild')).toBeUndefined();
+          done();
+        })
+        .start();
+
+      service.subscribe((state) => {
+        if (state.matches('present')) {
+          expect(state.children).toHaveProperty('machineChild');
+          expect(state.children).toHaveProperty('promiseChild');
+          expect(state.children).toHaveProperty('observableChild');
+
+          // state.children.machineChild.stop?.();
+          // state.children.promiseChild.stop?.();
+          // state.children.observableChild.stop?.();
+          service.send('NEXT');
+        }
+      });
     });
   });
 });

--- a/packages/core/test/interpreter.test.ts
+++ b/packages/core/test/interpreter.test.ts
@@ -1995,9 +1995,6 @@ Event: {\\"type\\":\\"SOME_EVENT\\"}"
           expect(state.children).toHaveProperty('promiseChild');
           expect(state.children).toHaveProperty('observableChild');
 
-          // state.children.machineChild.stop?.();
-          // state.children.promiseChild.stop?.();
-          // state.children.observableChild.stop?.();
           service.send('NEXT');
         }
       });

--- a/packages/xstate-scxml/src/index.ts
+++ b/packages/xstate-scxml/src/index.ts
@@ -55,8 +55,6 @@ function actionToSCXML(action: ActionObject<any, any>): XMLElement {
 export function transitionToSCXML(
   transition: TransitionDefinition<any, any>
 ): XMLElement {
-  // console.log(transition.cond!.predicate);
-
   const elements = transition.actions.map(actionToSCXML);
 
   return {


### PR DESCRIPTION
This PR allows expressions to be used in the `stop()` action creator:

```js
actions: stop(context => context.someActor)
```

This should be the way to stop spawned and invoked actors (as well as activities in v4, which are going away in v5 in favor of invoked actors). 

- Replaces https://github.com/davidkpiano/xstate/pull/1559
- Related: https://github.com/davidkpiano/xstate/pull/1434 (will need to be updated)