### PR TITLE
pass context as first argument to immerAssign

### DIFF
--- a/packages/xstate-immer/src/index.ts
+++ b/packages/xstate-immer/src/index.ts
@@ -8,7 +8,8 @@ import {
 import { produce, Draft } from 'immer';
 
 export type ImmerAssigner<TContext, TEvent extends EventObject> = (
-  context: Draft<TContext>,
+  context: TContext,
+  draft: Draft<TContext>,
   event: TEvent,
   meta: AssignMeta<TContext, TEvent>
 ) => void;
@@ -22,7 +23,10 @@ function immerAssign<TContext, TEvent extends EventObject = EventObject>(
   recipe: ImmerAssigner<TContext, TEvent>
 ): AssignAction<TContext, TEvent> {
   return xstateAssign((context, event, meta) => {
-    return produce(context, (draft) => void recipe(draft, event, meta));
+    return produce(
+      context,
+      (draft) => void recipe(context, draft, event, meta)
+    );
   });
 }
 


### PR DESCRIPTION
With `produce` from immer `baseState` ( as called in the [docs](https://immerjs.github.io/immer/docs/produce)) is the scope. 

When using `immerAssign` within a `MachineConfig` the current context isn't in scope, which is why I think context should be passed as a first argument to the `immerAssigner`.