### PR TITLE
move Badge away from beginning

### DIFF
--- a/docs/guides/communication.md
+++ b/docs/guides/communication.md
@@ -23,7 +23,7 @@ An invocation is defined in a state node's configuration with the `invoke` prope
   - a function that returns a "callback handler"
   - a function that returns an observable
   - a string, which refers to any of the 4 listed options defined in this machine's `options.services`
-  - <Badge text="4.12" /> an invoke source object, which contains the source string in `{ type: src }`, as well as any other metadata.
+  - an invoke source object <Badge text="4.12" />, which contains the source string in `{ type: src }`, as well as any other metadata.
 - `id` - the unique identifier for the invoked service
 - `onDone` - (optional) the [transition](./transitions.md) to be taken when:
   - the child machine reaches its [final state](./final.md), or
@@ -651,7 +651,7 @@ const userMachine = Machine({
 });
 ```
 
-<Badge text="4.12" /> The invoke `src` can also be specified as an object that describes the invoke source with its `type` and other related metadata. This can be read from the `services` option in the `meta.src` argument:
+The invoke `src` can also be specified as an object <Badge text="4.12" /> that describes the invoke source with its `type` and other related metadata. This can be read from the `services` option in the `meta.src` argument:
 
 ```js
 const machine = createMachine(


### PR DESCRIPTION
There seems to be a bug in vuepress https://github.com/vuejs/vuepress/issues/2679 stopping markdown from rendering when `Badge` is used in the beginning of paragraph:

https://xstate.js.org/docs/guides/communication.html#the-invoke-property

![image](https://user-images.githubusercontent.com/1091472/97109885-d8413600-1710-11eb-84e3-903b3464997f.png)

![image](https://user-images.githubusercontent.com/1091472/97110016-bdbb8c80-1711-11eb-8479-15bfd61916bd.png)


As it might take some time for them to fix it, I've moved the `Badge` to the middle to work around the issue at the moment. 