### PR TITLE
docs: Clarify scope of @xstate/test

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -29,7 +29,7 @@ JavaScript and TypeScript [finite state machines](https://en.wikipedia.org/wiki/
 - [📉 `@xstate/graph`](https://github.com/davidkpiano/xstate/tree/master/packages/xstate-graph) - Graph traversal utilities for XState
 - [⚛️ `@xstate/react`](https://github.com/davidkpiano/xstate/tree/master/packages/xstate-react) - React hooks and utilities for using XState in React applications
 - [💚 `@xstate/vue`](https://github.com/davidkpiano/xstate/tree/master/packages/xstate-vue) - Vue composition functions and utilities for using XState in Vue applications
-- [✅ `@xstate/test`](https://github.com/davidkpiano/xstate/tree/master/packages/xstate-test) - Model-based testing utilities for XState
+- [✅ `@xstate/test`](https://github.com/davidkpiano/xstate/tree/master/packages/xstate-test) - Model-Based-Testing utilities (using XState) for testing any software
 - [🔍 `@xstate/inspect`](https://github.com/davidkpiano/xstate/tree/master/packages/xstate-inspect) - Inspection utilities for XState
 
 ## Templates


### PR DESCRIPTION
as discussed in #1311 

This also aligns the package description with what is written in [github readme](https://github.com/davidkpiano/xstate/tree/master/packages/xstate-test#xstatetest) and <https://xstate.js.org/docs/packages/xstate-test/> (which looks like the first is the source for the latter).

~PS: I'm not sure about creating a changeset for this PR, just created it from the browser. If this is needed please let me know.~ From the message from changeset-bot I would assume this doesn't need a changeset.