### PR TITLE
autoForward for machines only (see issue: #1112)

### DIFF
--- a/docs/guides/communication.md
+++ b/docs/guides/communication.md
@@ -31,7 +31,7 @@ An invocation is defined in a state node's configuration with the `invoke` prope
   - the invoked observable completes
 - `onError` - (optional) the transition to be taken when the invoked service encounters an execution error.
 - `autoForward` - (optional) `true` if all events sent to this machine should also be sent (or _forwarded_) to the invoked child (`false` by default)
-  - ⚠️ Avoid setting `autoForward` to `true`, as blindly forwarding all events may lead to unexpected behavior and/or infinite loops. Always prefer to explicitly send events, and/or use the `forward(...)` action creator to directly forward an event to an invoked child.
+  - ⚠️ Avoid setting `autoForward` to `true`, as blindly forwarding all events may lead to unexpected behavior and/or infinite loops. Always prefer to explicitly send events, and/or use the `forward(...)` action creator to directly forward an event to an invoked child. (works currently for machines only! ⚠️)
 - `data` - (optional, used only when invoking machines) an object that maps properties of the child machine's [context](./context.md) to a function that returns the corresponding value from the parent machine's `context`.
 
 ::: warning
@@ -764,7 +764,7 @@ const machine = Machine({
           // - an observable
         },
         id: 'some-id',
-        // (optional) forward machine events to invoked service
+        // (optional) forward machine events to invoked service (currently for machines only!)
         autoForward: true,
         // (optional) the transition when the invoked promise/observable/machine is done
         onDone: { target: /* ... */ },
@@ -883,7 +883,7 @@ The `invoke` property is synonymous to the SCXML `<invoke>` element:
     invoke: {
       src: 'someSource',
       id: 'someID',
-      autoForward: true,
+      autoForward: true, // currently for machines only!  
       onDone: 'success',
       onError: 'failure'
     }


### PR DESCRIPTION
I spend a couple of hours trying to get autoForwarding to work on a callback.
It works with forwardTo, though when just quickly trying to prototype a behavior, autoForward comes in handy.

So I thought I am doing something wrong, and keept trying, until I found issue #1112, where it is clearly stated by @davidkpiano that indeed, at the moment it works only for machines. 

So I thought it might be helpful to state it in the docs.
It might save some time of other developers.

Best
Evangelos