### PR TITLE
Add test for transition meta

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1002,6 +1002,7 @@ export interface TransitionDefinition<TContext, TEvent extends EventObject>
     actions: Array<ActionObject<TContext, TEvent>>;
     cond?: Guard<TContext, TEvent>;
     eventType: TEvent['type'] | NullEvent['type'] | '*';
+    meta?: Record<string, any>;
   };
 }
 

--- a/packages/core/test/meta.test.ts
+++ b/packages/core/test/meta.test.ts
@@ -1,4 +1,4 @@
-import { Machine } from '../src/index';
+import { createMachine, Machine } from '../src/index';
 
 describe('state meta data', () => {
   const pedestrianStates = {
@@ -97,5 +97,36 @@ describe('state meta data', () => {
         walkData: 'walk data'
       }
     });
+  });
+});
+
+describe('transition meta data', () => {
+  it('should show meta data in transitions', () => {
+    const machine = createMachine({
+      initial: 'inactive',
+      states: {
+        inactive: {
+          on: {
+            EVENT: {
+              target: 'active',
+              meta: {
+                description: 'Going from inactive to active'
+              }
+            }
+          }
+        },
+        active: {}
+      }
+    });
+
+    const nextState = machine.transition(undefined, 'EVENT');
+
+    expect(nextState.transitions.map((t) => t.meta)).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "description": "Going from inactive to active",
+        },
+      ]
+    `);
   });
 });


### PR DESCRIPTION
This PR just adds a test for `transition.meta`. No behavior changed.