### PR TITLE
[@xstate/graph] Add ability to resolve events from state

### DIFF
--- a/.changeset/poor-bugs-reflect.md
+++ b/.changeset/poor-bugs-reflect.md
@@ -1,0 +1,47 @@
+---
+'@xstate/graph': minor
+---
+
+Options passed into graph functions (e.g., `getShortestPaths(machine, options)`) can now resolve `.events` based on the `state`:
+
+```js
+const countMachine = createMachine({
+  initial: 'active',
+  context: {
+    count: 0
+  },
+  states: {
+    active: {
+      on: {
+        ADD: {
+          actions: assign({
+            count: (context, event) => {
+              return context.count + event.value;
+            }
+          })
+        }
+      }
+    }
+  }
+});
+
+const shortestPaths = getShortestPaths(countMachine, {
+  events: {
+    ADD: (state) => {
+      // contrived example: if `context.count` is >= 10, increment by 10
+      return state.context.count >= 10
+        ? [{ type: 'ADD', value: 10 }]
+        : [{ type: 'ADD', value: 1 }];
+    }
+  }
+});
+
+// The keys to the shortest paths will look like:
+// "active" | { count: 0 }
+// "active" | { count: 1 }
+// "active" | { count: 2 }
+// ...
+// "active" | { count: 10 }
+// "active" | { count: 20 }
+// "active" | { count: 30 }
+```

--- a/packages/xstate-graph/src/graph.ts
+++ b/packages/xstate-graph/src/graph.ts
@@ -176,7 +176,6 @@ export function getShortestPaths<
   options?: ValueAdjMapOptions<TContext, TEvent>
 ): StatePathsMap<TContext, TEvent> {
   if (!machine.states) {
-    // return EMPTY_MAP;
     return EMPTY_MAP;
   }
   const optionsWithDefaults = getValueAdjMapOptions(options);

--- a/packages/xstate-graph/src/types.ts
+++ b/packages/xstate-graph/src/types.ts
@@ -109,9 +109,18 @@ export type Segments<TContext, TEvent extends EventObject> = Array<
   Segment<TContext, TEvent>
 >;
 
+export type ExtractEvent<
+  TEvent extends EventObject,
+  TType extends TEvent['type']
+> = TEvent extends { type: TType } ? TEvent : never;
+
 export interface ValueAdjMapOptions<TContext, TEvent extends EventObject> {
-  events: { [K in TEvent['type']]?: Array<TEvent & { type: K }> };
-  filter: (state: State<TContext, any>) => boolean;
-  stateSerializer: (state: State<TContext, any>) => string;
-  eventSerializer: (event: TEvent) => string;
+  events?: {
+    [K in TEvent['type']]?:
+      | Array<ExtractEvent<TEvent, K>>
+      | ((state: State<TContext, TEvent>) => Array<ExtractEvent<TEvent, K>>);
+  };
+  filter?: (state: State<TContext, any>) => boolean;
+  stateSerializer?: (state: State<TContext, any>) => string;
+  eventSerializer?: (event: TEvent) => string;
 }

--- a/packages/xstate-graph/test/graph.test.ts
+++ b/packages/xstate-graph/test/graph.test.ts
@@ -347,6 +347,39 @@ describe('@xstate/graph', () => {
 
       expect(adj).toHaveProperty('"full" | {"count":5}');
     });
+
+    it('should get events via function', () => {
+      const machine = createMachine<
+        { count: number },
+        { type: 'EVENT'; value: number }
+      >({
+        initial: 'first',
+        context: {
+          count: 0
+        },
+        states: {
+          first: {
+            on: {
+              EVENT: {
+                target: 'second',
+                actions: assign({
+                  count: (_, event) => event.value
+                })
+              }
+            }
+          },
+          second: {}
+        }
+      });
+
+      const adj = getAdjacencyMap(machine, {
+        events: {
+          EVENT: (state) => [{ type: 'EVENT', value: state.context.count + 10 }]
+        }
+      });
+
+      expect(adj).toHaveProperty('"second" | {"count":10}');
+    });
   });
 
   describe('toDirectedGraph', () => {


### PR DESCRIPTION

Options passed into graph functions (e.g., `getShortestPaths(machine, options)`) can now resolve `.events` based on the `state`:

```js
const countMachine = createMachine({
  initial: 'active',
  context: {
    count: 0
  },
  states: {
    active: {
      on: {
        ADD: {
          actions: assign({
            count: (context, event) => {
              return context.count + event.value;
            }
          })
        }
      }
    }
  }
});

const shortestPaths = getShortestPaths(countMachine, {
  events: {
    ADD: (state) => {
      // contrived example: if `context.count` is >= 10, increment by 10
      return state.context.count >= 10
        ? [{ type: 'ADD', value: 10 }]
        : [{ type: 'ADD', value: 1 }];
    }
  }
});

// The keys to the shortest paths will look like:
// "active" | { count: 0 }
// "active" | { count: 1 }
// "active" | { count: 2 }
// ...
// "active" | { count: 10 }
// "active" | { count: 20 }
// "active" | { count: 30 }
```
