### PR TITLE
Remove Gitter chat link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
 </p>
 
 [![npm version](https://badge.fury.io/js/xstate.svg)](https://badge.fury.io/js/xstate)
-[![Statecharts gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/statecharts/statecharts)
 <img src="https://opencollective.com/xstate/tiers/backer/badge.svg?label=sponsors&color=brightgreen" />
 
 <div class="blm-callout">


### PR DESCRIPTION
Using GitHub discussions is encouraged instead.