### PR TITLE
Fix history state entering after transient transitions

### DIFF
--- a/.changeset/little-bugs-begin.md
+++ b/.changeset/little-bugs-begin.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Fixed an issue with history state entering a wrong state if the most recent visit in its parent has been caused by a transient transition.

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -1312,7 +1312,6 @@ class StateNode<
     maybeNextState.changed = changed;
 
     // Preserve original history after raised events
-    maybeNextState.historyValue = nextState.historyValue;
     maybeNextState.history = history;
 
     return maybeNextState;

--- a/packages/core/test/history.test.ts
+++ b/packages/core/test/history.test.ts
@@ -1,4 +1,4 @@
-import { Machine, createMachine } from '../src/index';
+import { Machine, createMachine, interpret } from '../src/index';
 
 describe('history states', () => {
   const historyMachine = createMachine({
@@ -70,6 +70,55 @@ describe('history states', () => {
     const onState = historyMachine.transition(offState, 'H_POWER');
     const nextState = historyMachine.transition(onState, 'H_POWER');
     expect(nextState.history!.history).not.toBeDefined();
+  });
+
+  it('should go to the most recently visited state by a transient transition', () => {
+    const machine = createMachine({
+      initial: 'idle',
+      states: {
+        idle: {
+          id: 'idle',
+          initial: 'absent',
+          states: {
+            absent: {
+              on: {
+                DEPLOY: '#deploy'
+              }
+            },
+            present: {
+              on: {
+                DEPLOY: '#deploy',
+                DESTROY: '#destroy'
+              }
+            },
+            hist: {
+              type: 'history'
+            }
+          }
+        },
+        deploy: {
+          id: 'deploy',
+          on: {
+            SUCCESS: 'idle.present',
+            FAILURE: 'idle.hist'
+          }
+        },
+        destroy: {
+          id: 'destroy',
+          always: [{ target: 'idle.absent' }]
+        }
+      }
+    });
+
+    const service = interpret(machine).start();
+
+    service.send('DEPLOY');
+    service.send('SUCCESS');
+    service.send('DESTROY');
+    service.send('DEPLOY');
+    service.send('FAILURE');
+
+    expect(service.state.value).toEqual({ idle: 'absent' });
   });
 });
 

--- a/packages/xstate-graph/test/__snapshots__/graph.test.ts.snap
+++ b/packages/xstate-graph/test/__snapshots__/graph.test.ts.snap
@@ -6410,7 +6410,7 @@ Object {
             "value": "start",
           },
           "historyValue": Object {
-            "current": "start",
+            "current": "finish",
             "states": Object {
               "finish": undefined,
               "start": undefined,
@@ -6485,7 +6485,7 @@ Object {
         "value": "start",
       },
       "historyValue": Object {
-        "current": "start",
+        "current": "finish",
         "states": Object {
           "finish": undefined,
           "start": undefined,


### PR DESCRIPTION
fixes #1691 

Updating `historyValue` is done within [`exitStates`](https://www.w3.org/TR/scxml/#exitStates) procedure which is part of the [`microstep`](https://www.w3.org/TR/scxml/#microstep) procedure so this should always keep the very latest resolved values and nothing should be "preserved" from older states.