### PR TITLE
[@xstate/inspect] Handle circular references gracefully in inspector.

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  projects: ['<rootDir>/packages/!(xstate-dev|xstate-inspect)'],
+  projects: ['<rootDir>/packages/!(xstate-dev)'],
   watchPlugins: [
     'jest-watch-typeahead/filename',
     'jest-watch-typeahead/testname'

--- a/packages/core/src/devTools.ts
+++ b/packages/core/src/devTools.ts
@@ -2,18 +2,26 @@ import { Interpreter } from '.';
 import { IS_PRODUCTION } from './environment';
 
 type AnyInterpreter = Interpreter<any, any, any>;
-interface DevInterface {
-  services: Set<AnyInterpreter>;
-  register(service: AnyInterpreter): void;
-  onRegister(listener: ServicesListener): void;
+type ServiceListener = (service: AnyInterpreter) => void;
+
+export interface XStateDevInterface {
+  register: (service: Interpreter<any>) => void;
+  unregister: (service: Interpreter<any>) => void;
+  onRegister: (
+    listener: ServiceListener
+  ) => {
+    unsubscribe: () => void;
+  };
+  services: Set<Interpreter<any>>;
 }
 
-type ServicesListener = (service: Set<AnyInterpreter>) => void;
+declare global {
+  var __xstate__: XStateDevInterface;
+}
 
-function getDevTools(): DevInterface | undefined {
-  const w = window as Window & { __xstate__?: DevInterface };
-  if (!!w.__xstate__) {
-    return w.__xstate__;
+function getDevTools(): XStateDevInterface | undefined {
+  if (!!window.__xstate__) {
+    return window.__xstate__;
   }
 
   return undefined;

--- a/packages/core/src/devTools.ts
+++ b/packages/core/src/devTools.ts
@@ -15,13 +15,9 @@ export interface XStateDevInterface {
   services: Set<Interpreter<any>>;
 }
 
-declare global {
-  var __xstate__: XStateDevInterface;
-}
-
 function getDevTools(): XStateDevInterface | undefined {
-  if (!!window.__xstate__) {
-    return window.__xstate__;
+  if (!!(window as any).__xstate__) {
+    return (window as any).__xstate__;
   }
 
   return undefined;

--- a/packages/xstate-inspect/package.json
+++ b/packages/xstate-inspect/package.json
@@ -48,5 +48,7 @@
   "peerDependencies": {
     "ws": "^7.3.1"
   },
-  "dependencies": {}
+  "dependencies": {
+    "fast-safe-stringify": "^2.0.7"
+  }
 }

--- a/packages/xstate-inspect/src/index.ts
+++ b/packages/xstate-inspect/src/index.ts
@@ -87,7 +87,7 @@ export const createInspectMachine = (
               const { event } = e;
               const scxmlEventObject = JSON.parse(event) as SCXML.Event<any>;
               const service = serviceMap.get(scxmlEventObject.origin!);
-              service?.send(JSON.parse(event));
+              service?.send(scxmlEventObject);
             }
           },
           unload: {

--- a/packages/xstate-inspect/src/index.ts
+++ b/packages/xstate-inspect/src/index.ts
@@ -7,7 +7,9 @@ import {
   EventObject,
   EventData
 } from 'xstate';
+import { XStateDevInterface } from 'xstate/lib/devTools';
 import { toSCXMLEvent, toEventObject } from 'xstate/lib/utils';
+import safeStringify from 'fast-safe-stringify';
 
 export type ServiceListener = (service: Interpreter<any>) => void;
 
@@ -16,30 +18,16 @@ type MaybeLazy<T> = T | (() => T);
 export interface InspectorOptions {
   url: string;
   iframe: MaybeLazy<HTMLIFrameElement | null | false>;
-}
-
-declare global {
-  interface Window {
-    __xstate__: {
-      register: (service: Interpreter<any>) => void;
-      unregister: (service: Interpreter<any>) => void;
-      onRegister: (
-        listener: ServiceListener
-      ) => {
-        unsubscribe: () => void;
-      };
-      services: Set<Interpreter<any>>;
-    };
-  }
+  devTools: MaybeLazy<XStateDevInterface>;
 }
 
 const serviceMap = new Map<string, Interpreter<any>>();
 
-export function createDevTools() {
+export function createDevTools(): XStateDevInterface {
   const services = new Set<Interpreter<any>>();
   const serviceListeners = new Set<ServiceListener>();
 
-  window.__xstate__ = {
+  return {
     services,
     register: (service) => {
       services.add(service);
@@ -68,80 +56,109 @@ export function createDevTools() {
   };
 }
 
-export const inspectMachine = createMachine<{
-  client?: any;
-}>({
-  initial: 'pendingConnection',
-  context: {
-    client: undefined
-  },
-  states: {
-    pendingConnection: {},
-    connected: {
-      on: {
-        'service.state': {
-          actions: (ctx, e) => ctx.client!.send(e)
-        },
-        'service.event': {
-          actions: (ctx, e) => ctx.client!.send(e)
-        },
-        'service.register': {
-          actions: (ctx, e) => ctx.client!.send(e)
-        },
-        'service.stop': {
-          actions: (ctx, e) => ctx.client!.send(e)
-        },
-        'xstate.event': {
-          actions: (_, e) => {
-            const { event } = e;
-            const scxmlEventObject = JSON.parse(event) as SCXML.Event<any>;
-            const service = serviceMap.get(scxmlEventObject.origin!);
-            service?.send(JSON.parse(event));
+export const createInspectMachine = (
+  devTools: XStateDevInterface = globalThis.__xstate__
+) =>
+  createMachine<{
+    client?: any;
+  }>({
+    initial: 'pendingConnection',
+    context: {
+      client: undefined
+    },
+    states: {
+      pendingConnection: {},
+      connected: {
+        on: {
+          'service.state': {
+            actions: (ctx, e) => ctx.client!.send(e)
+          },
+          'service.event': {
+            actions: (ctx, e) => ctx.client!.send(e)
+          },
+          'service.register': {
+            actions: (ctx, e) => ctx.client!.send(e)
+          },
+          'service.stop': {
+            actions: (ctx, e) => ctx.client!.send(e)
+          },
+          'xstate.event': {
+            actions: (_, e) => {
+              const { event } = e;
+              const scxmlEventObject = JSON.parse(event) as SCXML.Event<any>;
+              const service = serviceMap.get(scxmlEventObject.origin!);
+              service?.send(JSON.parse(event));
+            }
+          },
+          unload: {
+            actions: (ctx) => {
+              ctx.client!.send({ type: 'xstate.disconnect' });
+            }
+          },
+          disconnect: 'disconnected'
+        }
+      },
+      disconnected: {
+        type: 'final'
+      }
+    },
+    on: {
+      'xstate.inspecting': {
+        target: '.connected',
+        actions: [
+          assign({ client: (_, e) => e.client }),
+          (ctx) => {
+            devTools.services.forEach((service) => {
+              ctx.client.send({
+                type: 'service.register',
+                machine: stringify(service.machine),
+                state: stringify(service.state || service.initialState),
+                sessionId: service.sessionId
+              });
+            });
           }
-        },
-        unload: {
-          actions: (ctx) => {
-            ctx.client!.send({ type: 'xstate.disconnect' });
-          }
-        },
-        disconnect: 'pendingConnection'
+        ]
       }
     }
-  },
-  on: {
-    'xstate.inspecting': {
-      target: '.connected',
-      actions: [
-        assign({ client: (_, e) => e.client }),
-        (ctx) => {
-          globalThis.__xstate__.services.forEach((service) => {
-            ctx.client.send({
-              type: 'service.register',
-              machine: JSON.stringify(service.machine),
-              state: JSON.stringify(service.state || service.initialState),
-              sessionId: service.sessionId
-            });
-          });
-        }
-      ]
-    }
-  }
-});
+  });
 
 const defaultInspectorOptions: InspectorOptions = {
   url: 'https://statecharts.io/inspect',
-  iframe: () => document.querySelector<HTMLIFrameElement>('iframe[data-xstate]')
+  iframe: () =>
+    document.querySelector<HTMLIFrameElement>('iframe[data-xstate]'),
+  devTools: () => {
+    const devTools = createDevTools();
+    globalThis.__xstate__ = devTools;
+    return devTools;
+  }
 };
+
+function getLazy<T>(value: MaybeLazy<T>): T {
+  return typeof value === 'function' ? (value as () => T)() : value;
+}
+
+function stringify(value: any): string {
+  try {
+    return JSON.stringify(value);
+  } catch (e) {
+    return safeStringify(value);
+  }
+}
 
 export function inspect(
   options?: Partial<InspectorOptions>
 ): {
+  send: (event: EventObject) => void;
+  /**
+   * Disconnects the inspector.
+   */
   disconnect: () => void;
 } {
-  createDevTools();
+  const { iframe, url, devTools } = { ...defaultInspectorOptions, ...options };
+  const resolvedDevTools = getLazy(devTools);
+  const resolvedIframe = getLazy(iframe);
 
-  const { iframe, url } = { ...defaultInspectorOptions, ...options };
-  const resolvedIframe = typeof iframe === 'function' ? iframe() : iframe;
+  const inspectMachine = createInspectMachine(resolvedDevTools);
 
   let targetWindow: Window | null | undefined;
 
@@ -152,7 +169,9 @@ export function inspect(
       'No suitable <iframe> found to embed the inspector. Please pass an <iframe> element to `inspect(iframe)` or create an <iframe data-xstate></iframe> element.'
     );
 
-    return { disconnect: () => void 0 };
+    inspectService.send('disconnect');
+
+    return { send: () => void 0, disconnect: () => void 0 };
   }
 
   let client: any;
@@ -192,11 +211,11 @@ export function inspect(
     targetWindow = window.open(url, 'xstateinspector');
   }
 
-  globalThis.__xstate__.onRegister((service) => {
+  resolvedDevTools.onRegister((service) => {
     inspectService.send({
       type: 'service.register',
-      machine: JSON.stringify(service.machine),
-      state: JSON.stringify(service.state || service.initialState),
+      machine: stringify(service.machine),
+      state: stringify(service.state || service.initialState),
       sessionId: service.sessionId,
       id: service.id,
       parent: service.parent?.sessionId
@@ -204,7 +223,7 @@ export function inspect(
 
     inspectService.send({
       type: 'service.event',
-      event: JSON.stringify((service.state || service.initialState)._event),
+      event: stringify((service.state || service.initialState)._event),
       sessionId: service.sessionId
     });
 
@@ -219,7 +238,7 @@ export function inspect(
     ) {
       inspectService.send({
         type: 'service.event',
-        event: JSON.stringify(
+        event: stringify(
           toSCXMLEvent(toEventObject(event as EventObject, payload))
         ),
         sessionId: service.sessionId
@@ -231,7 +250,7 @@ export function inspect(
     service.subscribe((state) => {
       inspectService.send({
         type: 'service.state',
-        state: JSON.stringify(state),
+        state: stringify(state),
         sessionId: service.sessionId
       });
     });
@@ -253,6 +272,9 @@ export function inspect(
   }
 
   return {
+    send: (event) => {
+      inspectService.send(event);
+    },
     disconnect: () => {
       inspectService.send('disconnect');
       window.removeEventListener('message', messageHandler);

--- a/packages/xstate-inspect/test/inspect.test.ts
+++ b/packages/xstate-inspect/test/inspect.test.ts
@@ -36,6 +36,6 @@ describe('@xstate/inspect', () => {
     // with the service. The built-in service listener is responsible for
     // stringifying the service's machine definition (which contains a circular structure)
     // and will throw an error if circular structures are not handled.
-    devTools.register(service);
+    expect(() => devTools.register(service)).not.toThrow();
   });
 });

--- a/packages/xstate-inspect/test/inspect.test.ts
+++ b/packages/xstate-inspect/test/inspect.test.ts
@@ -1,0 +1,41 @@
+import { createMachine, interpret } from 'xstate';
+import { createDevTools, inspect } from '../src';
+
+describe('@xstate/inspect', () => {
+  it('should handle circular structures', (done) => {
+    const circularStructure = {
+      get cycle() {
+        return circularStructure;
+      }
+    };
+
+    const machine = createMachine({
+      initial: 'active',
+      context: circularStructure,
+      states: {
+        active: {}
+      }
+    });
+
+    const devTools = createDevTools();
+
+    devTools.onRegister(() => {
+      done();
+    });
+
+    inspect({
+      iframe: false,
+      devTools
+    });
+
+    const service = interpret(machine).start();
+
+    // The devTools will notify the listeners:
+    // 1. the built-in service listener
+    // 2. the test listener that calls done() above
+    // with the service. The built-in service listener is responsible for
+    // stringifying the service's machine definition (which contains a circular structure)
+    // and will throw an error if circular structures are not handled.
+    devTools.register(service);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -6798,6 +6798,11 @@ fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
+fast-safe-stringify@^2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz#124aa885899261f68aedb42a7c080de9da608743"
+  integrity sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==
+
 fastparse@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.2.tgz#91728c5a5942eced8531283c79441ee4122c35a9"


### PR DESCRIPTION
This PR fixes stringifying circular reference in `@xstate/inspect` by using [fast-safe-stringify](https://www.npmjs.com/package/fast-safe-stringify) when normal `JSON.stringify(...)` throws.

Currently, this will result in the string `"[Circular]"` in the inspect UI, which is much better than completely failing (previous behavior):

<img width="719" alt="CleanShot 2020-12-06 at 17 52 45@2x" src="https://user-images.githubusercontent.com/1093738/101295695-48050f00-37ed-11eb-9273-8c573c98793f.png">

Fixes #1497