### PR TITLE
Preserve global context with `clock` methods (`setTimeout`/`clearTimeout`)

### DIFF
--- a/.changeset/tall-apes-tickle.md
+++ b/.changeset/tall-apes-tickle.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+The `clock` methods (`setTimeout`, `clearTimeout`) are now properly bound to the `global` scope internally (fixes #1703)

--- a/.changeset/tall-apes-tickle.md
+++ b/.changeset/tall-apes-tickle.md
@@ -2,4 +2,4 @@
 'xstate': patch
 ---
 
-The `clock` methods (`setTimeout`, `clearTimeout`) are now properly bound to the `global` scope internally (fixes #1703)
+The default `clock` methods (`setTimeout` and `clearTimeout`) are now invoked properly with the global context preserved for those invocations which matter for some JS environments. More details can be found in the corresponding issue: [#1703](https://github.com/davidkpiano/xstate/issues/1703).

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -124,10 +124,10 @@ export class Interpreter<
     deferEvents: true,
     clock: {
       setTimeout: (fn, ms) => {
-        return global.setTimeout.call(null, fn, ms);
+        return global.setTimeout.call(global, fn, ms);
       },
       clearTimeout: (id) => {
-        return global.clearTimeout.call(null, id);
+        return global.clearTimeout.call(global, id);
       }
     },
     logger: global.console.log.bind(console),

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -124,7 +124,7 @@ export class Interpreter<
     deferEvents: true,
     clock: {
       setTimeout: (fn, ms) => {
-        return global.setTimeout.call(global, fn, ms);
+        return setTimeout(fn, ms);
       },
       clearTimeout: (id) => {
         return global.clearTimeout.call(global, id);

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -127,7 +127,7 @@ export class Interpreter<
         return setTimeout(fn, ms);
       },
       clearTimeout: (id) => {
-        return global.clearTimeout.call(global, id);
+        return clearTimeout(id);
       }
     },
     logger: global.console.log.bind(console),


### PR DESCRIPTION
Fixes #1703