### PR TITLE
[@xstate/inspect] Add changeset for stringify fix

### DIFF
--- a/.changeset/purple-papayas-begin.md
+++ b/.changeset/purple-papayas-begin.md
@@ -1,0 +1,5 @@
+---
+'@xstate/inspect': minor
+---
+
+The `@xstate/inspect` tool now uses [`fast-safe-stringify`](https://www.npmjs.com/package/fast-safe-stringify) for internal JSON stringification of machines, states, and events when regular `JSON.stringify()` fails (e.g., due to circular structures).

--- a/packages/xstate-inspect/test/inspect.test.ts
+++ b/packages/xstate-inspect/test/inspect.test.ts
@@ -2,7 +2,7 @@ import { createMachine, interpret } from 'xstate';
 import { createDevTools, inspect } from '../src';
 
 describe('@xstate/inspect', () => {
-  it('should handle circular structures', (done) => {
+  it('should handle circular structures in context', (done) => {
     const circularStructure = {
       get cycle() {
         return circularStructure;
@@ -29,6 +29,51 @@ describe('@xstate/inspect', () => {
     });
 
     const service = interpret(machine).start();
+
+    // The devTools will notify the listeners:
+    // 1. the built-in service listener
+    // 2. the test listener that calls done() above
+    // with the service. The built-in service listener is responsible for
+    // stringifying the service's machine definition (which contains a circular structure)
+    // and will throw an error if circular structures are not handled.
+    expect(() => devTools.register(service)).not.toThrow();
+  });
+
+  it('should handle circular structures in events', (done) => {
+    const circularStructure = {
+      get cycle() {
+        return circularStructure;
+      }
+    };
+
+    const machine = createMachine({
+      initial: 'active',
+      states: {
+        active: {}
+      }
+    });
+
+    const devTools = createDevTools();
+
+    devTools.onRegister((inspectedService) => {
+      inspectedService.onTransition((state) => {
+        if (state.event.type === 'CIRCULAR') {
+          done();
+        }
+      });
+    });
+
+    inspect({
+      iframe: false,
+      devTools
+    });
+
+    const service = interpret(machine).start();
+
+    service.send({
+      type: 'CIRCULAR',
+      value: circularStructure
+    });
 
     // The devTools will notify the listeners:
     // 1. the built-in service listener

--- a/packages/xstate-inspect/test/inspect.test.ts
+++ b/packages/xstate-inspect/test/inspect.test.ts
@@ -75,12 +75,6 @@ describe('@xstate/inspect', () => {
       value: circularStructure
     });
 
-    // The devTools will notify the listeners:
-    // 1. the built-in service listener
-    // 2. the test listener that calls done() above
-    // with the service. The built-in service listener is responsible for
-    // stringifying the service's machine definition (which contains a circular structure)
-    // and will throw an error if circular structures are not handled.
     expect(() => devTools.register(service)).not.toThrow();
   });
 });


### PR DESCRIPTION
This PR adds a changeset for adding `fast-safe-stringify`, as well as an additional test for events with circular structures.

The changeset was omitted in https://github.com/davidkpiano/xstate/pull/1699 (oops), so I'm using this PR to trigger a release.