### PR TITLE
Use `lightMachine` instead of `machine` in testing example

### DIFF
--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -16,7 +16,7 @@ import { lightMachine } from '../path/to/lightMachine';
 it('should reach "yellow" given "green" when the "TIMER" event occurs', () => {
   const expectedValue = 'yellow'; // the expected state value
 
-  const actualState = machine.transition('green', 'TIMER');
+  const actualState = lightMachine.transition('green', 'TIMER');
 
   expect(actualState.matches(expectedValue)).toBeTruthy();
 });


### PR DESCRIPTION
Fixes an issue in the guides where `machine` was used in a test, instead of the imported `lightMachine`.

Issue: https://github.com/davidkpiano/xstate/issues/1724