### PR TITLE
 add "exports" top level field to package.json

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,6 +17,10 @@
     "es/**/*.js",
     "es/**/*.d.ts"
   ],
+  "exports": {
+    "require": "./lib/index.js",
+    "import": "./es/index.js"
+  },
   "keywords": [
     "statechart",
     "state machine",

--- a/packages/xstate-fsm/package.json
+++ b/packages/xstate-fsm/package.json
@@ -29,6 +29,10 @@
     "es/**/*.js",
     "es/**/*.d.ts"
   ],
+  "exports": {
+    "require": "./dist/xstate.fsm.js",
+    "import": "./es/index.js"
+  },
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/davidkpiano/xstate.git"

--- a/packages/xstate-graph/package.json
+++ b/packages/xstate-graph/package.json
@@ -23,6 +23,10 @@
     "es/**/*.js",
     "es/**/*.d.ts"
   ],
+  "exports": {
+    "require": "./lib/index.js",
+    "import": "./es/index.js"
+  },
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/davidkpiano/xstate.git"

--- a/packages/xstate-inspect/package.json
+++ b/packages/xstate-inspect/package.json
@@ -24,6 +24,10 @@
     "es/**/*.js",
     "es/**/*.d.ts"
   ],
+  "exports": {
+    "require": "./lib/index.js",
+    "import": "./es/index.js"
+  },
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/davidkpiano/xstate.git"

--- a/packages/xstate-react/package.json
+++ b/packages/xstate-react/package.json
@@ -30,6 +30,10 @@
     "es/**/*.js",
     "es/**/*.d.ts"
   ],
+  "exports": {
+    "require": "./lib/index.js",
+    "import": "./es/index.js"
+  },
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/davidkpiano/xstate.git"

--- a/packages/xstate-test/package.json
+++ b/packages/xstate-test/package.json
@@ -30,6 +30,10 @@
     "es/**/*.js",
     "es/**/*.d.ts"
   ],
+  "exports": {
+    "require": "./lib/index.js",
+    "import": "./es/index.js"
+  },
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/davidkpiano/xstate.git"

--- a/packages/xstate-viz/package.json
+++ b/packages/xstate-viz/package.json
@@ -10,6 +10,10 @@
   "files": [
     "dist"
   ],
+  "exports": {
+    "require": "./dist/index.js",
+    "import": "./dist/viz.esm.js"
+  },
   "scripts": {
     "clean": "echo \"No clean script\"",
     "start": "tsdx watch",


### PR DESCRIPTION
## why

> Export Maps help package authors accomplish two things: transition from Common.js (CJS)  to ESM & make a package's internal files private.
>
> Historically, it has been impossible for some packages to reliably support multiple module systems (UMD, CJS, ESM) and multiple environments (Web, Node.js, Deno). Past efforts to standardize have relied solely on community buy-in, with little official support from Node.js or npm. Export Maps aim to solve this problem as the official Node.js standard to define package entrypoints per-environment.

source: https://docs.skypack.dev/package-authors/package-checks#export-map


see also:
https://docs.skypack.dev/package-authors/package-checks#esm
https://nodejs.org/api/packages.html#packages_subpath_exports

Might help w/ #1625