### PR TITLE
[v5] Rename machine.withConfig(...) to machine.provide(...)

### DIFF
--- a/.changeset/eighty-chefs-return.md
+++ b/.changeset/eighty-chefs-return.md
@@ -1,0 +1,5 @@
+---
+'xstate': major
+---
+
+Renamed `machine.withConfig(...)` to `machine.withOptions(...)`. https://github.com/davidkpiano/xstate/projects/1#card-40598347

--- a/.changeset/eighty-chefs-return.md
+++ b/.changeset/eighty-chefs-return.md
@@ -2,4 +2,4 @@
 'xstate': major
 ---
 
-Renamed `machine.withConfig(...)` to `machine.withOptions(...)`. https://github.com/davidkpiano/xstate/projects/1#card-40598347
+Renamed `machine.withConfig(...)` to `machine.provide(...)`.

--- a/.changeset/rotten-rivers-wonder.md
+++ b/.changeset/rotten-rivers-wonder.md
@@ -18,7 +18,7 @@ const machine = createMachine(
   },
   {
 -   activities: {
-+   behaviors: {
++   actors: {
 -     someActivity: ((context, event) => {
 +     someActivity: invokeActivity((context, event) => {
         // ... some continuous activity
@@ -32,7 +32,7 @@ const machine = createMachine(
 );
 ```
 
-**Breaking:** The `services` option passed as the second argument to `createMachine(config, options)` is renamed to `behaviors`. Each value in `behaviors`should be a function that takes in `context` and `event` and returns a [behavior](TODO: link). The provided invoke creators are:
+**Breaking:** The `services` option passed as the second argument to `createMachine(config, options)` is renamed to `actors`. Each value in `actors`should be a function that takes in `context` and `event` and returns a [behavior](TODO: link) for an actor. The provided invoke creators are:
 
 - `invokeActivity`
 - `invokePromise`
@@ -53,7 +53,7 @@ const machine = createMachine(
   },
   {
 -   services: {
-+   behaviors: {
++   actors: {
 -     fetchFromAPI: ((context, event) => {
 +     fetchFromAPI: invokePromise((context, event) => {
         // ... (return a promise)
@@ -86,7 +86,7 @@ const machine = createMachine({
 
 ```
 
-**Breaking:** The `src` of an `invoke` config is now either a string that references the machine's `options.behaviors`, or a `BehaviorCreator`, which is a function that takes in `context` and `event` and returns a `Behavior`:
+**Breaking:** The `src` of an `invoke` config is now either a string that references the machine's `options.actors`, or a `BehaviorCreator`, which is a function that takes in `context` and `event` and returns a `Behavior`:
 
 ```diff
 import { createMachine } from 'xstate';

--- a/docs/packages/xstate-react/index.md
+++ b/docs/packages/xstate-react/index.md
@@ -323,7 +323,7 @@ const Fetcher = ({ onResolve }) => {
     actions: {
       notifySuccess: (ctx) => onResolve(ctx.data)
     },
-    behaviors: {
+    actors: {
       fetchData: invokePromise((_, event) =>
         fetch(`some/api/${event.query}`).then((res) => res.json())
       )

--- a/docs/packages/xstate-vue/index.md
+++ b/docs/packages/xstate-vue/index.md
@@ -77,7 +77,7 @@ A [Vue composition function](https://vue-composition-api-rfc.netlify.com/) that 
 **Arguments**
 
 - `machine` - An [XState machine](https://xstate.js.org/docs/guides/machines.html).
-- `options` (optional) - [Interpreter options](https://xstate.js.org/docs/guides/interpretation.html#options) OR one of the following Machine Config options: `guards`, `actions`, `activities`, `behaviors`, `delays`, `immediate`, `context`, or `state`.
+- `options` (optional) - [Interpreter options](https://xstate.js.org/docs/guides/interpretation.html#options) OR one of the following Machine Config options: `guards`, `actions`, `actors`, `delays`, `immediate`, `context`, or `state`.
 
 **Returns** `{ state, send, service}`:
 

--- a/packages/core/src/Machine.ts
+++ b/packages/core/src/Machine.ts
@@ -1,5 +1,5 @@
 import {
-  MachineOptions,
+  MachineImplementations,
   DefaultContext,
   MachineConfig,
   StateSchema,
@@ -14,7 +14,7 @@ export function Machine<
   TEvent extends EventObject = AnyEventObject
 >(
   config: MachineConfig<TContext, TEvent, any>,
-  options?: Partial<MachineOptions<TContext, TEvent>>
+  options?: Partial<MachineImplementations<TContext, TEvent>>
 ): MachineNode<TContext, TEvent>;
 export function Machine<
   TContext = DefaultContext,
@@ -22,7 +22,7 @@ export function Machine<
   TStateSchema extends StateSchema = any
 >(
   config: MachineConfig<TContext, TEvent, TStateSchema>,
-  options?: Partial<MachineOptions<TContext, TEvent>>
+  options?: Partial<MachineImplementations<TContext, TEvent>>
 ): MachineNode<TContext, TEvent, TStateSchema>;
 export function Machine<
   TContext = DefaultContext,
@@ -30,7 +30,7 @@ export function Machine<
   TStateSchema extends StateSchema = any
 >(
   config: MachineConfig<TContext, TEvent, TStateSchema>,
-  options?: Partial<MachineOptions<TContext, TEvent>>
+  options?: Partial<MachineImplementations<TContext, TEvent>>
 ): MachineNode<TContext, TEvent, TStateSchema> {
   return new MachineNode<TContext, TEvent, TStateSchema, any>(config, options);
 }
@@ -41,7 +41,7 @@ export function createMachine<
   TTypestate extends Typestate<TContext> = { value: any; context: TContext }
 >(
   config: MachineConfig<TContext, TEvent, any>,
-  options?: Partial<MachineOptions<TContext, TEvent>>
+  options?: Partial<MachineImplementations<TContext, TEvent>>
 ): MachineNode<TContext, TEvent, any, TTypestate> {
   return new MachineNode<TContext, TEvent, TTypestate>(config, options);
 }

--- a/packages/core/src/Machine.ts
+++ b/packages/core/src/Machine.ts
@@ -13,26 +13,29 @@ export function Machine<
   TContext = any,
   TEvent extends EventObject = AnyEventObject
 >(
-  config: MachineConfig<TContext, TEvent, any>,
-  options?: Partial<MachineImplementations<TContext, TEvent>>
+  definition: MachineConfig<TContext, TEvent, any>,
+  implementations?: Partial<MachineImplementations<TContext, TEvent>>
 ): MachineNode<TContext, TEvent>;
 export function Machine<
   TContext = DefaultContext,
   TEvent extends EventObject = AnyEventObject,
   TStateSchema extends StateSchema = any
 >(
-  config: MachineConfig<TContext, TEvent, TStateSchema>,
-  options?: Partial<MachineImplementations<TContext, TEvent>>
+  definition: MachineConfig<TContext, TEvent, TStateSchema>,
+  implementations?: Partial<MachineImplementations<TContext, TEvent>>
 ): MachineNode<TContext, TEvent, TStateSchema>;
 export function Machine<
   TContext = DefaultContext,
   TEvent extends EventObject = AnyEventObject,
   TStateSchema extends StateSchema = any
 >(
-  config: MachineConfig<TContext, TEvent, TStateSchema>,
-  options?: Partial<MachineImplementations<TContext, TEvent>>
+  definition: MachineConfig<TContext, TEvent, TStateSchema>,
+  implementations?: Partial<MachineImplementations<TContext, TEvent>>
 ): MachineNode<TContext, TEvent, TStateSchema> {
-  return new MachineNode<TContext, TEvent, TStateSchema, any>(config, options);
+  return new MachineNode<TContext, TEvent, TStateSchema, any>(
+    definition,
+    implementations
+  );
 }
 
 export function createMachine<
@@ -40,8 +43,11 @@ export function createMachine<
   TEvent extends EventObject = AnyEventObject,
   TTypestate extends Typestate<TContext> = { value: any; context: TContext }
 >(
-  config: MachineConfig<TContext, TEvent, any>,
-  options?: Partial<MachineImplementations<TContext, TEvent>>
+  definition: MachineConfig<TContext, TEvent, any>,
+  implementations?: Partial<MachineImplementations<TContext, TEvent>>
 ): MachineNode<TContext, TEvent, any, TTypestate> {
-  return new MachineNode<TContext, TEvent, TTypestate>(config, options);
+  return new MachineNode<TContext, TEvent, TTypestate>(
+    definition,
+    implementations
+  );
 }

--- a/packages/core/src/MachineNode.ts
+++ b/packages/core/src/MachineNode.ts
@@ -41,7 +41,7 @@ const createDefaultOptions = <TContext>(
 ): MachineOptions<TContext, any> => ({
   actions: {},
   guards: {},
-  behaviors: {},
+  actors: {},
   delays: {},
   context
 });
@@ -142,22 +142,21 @@ export class MachineNode<
   }
 
   /**
-   * Clones this state machine with custom options and context.
+   * Clones this state machine with custom options.
    *
-   * @param options Options (actions, guards, behaviors, delays) to recursively merge with the existing options.
-   * @param context Custom context (will override predefined context)
+   * @param options Options (actions, guards, actors, delays, context) to recursively merge with the existing options.
    *
-   * @returns A new `MachineNode` instance with the custom options and context
+   * @returns A new `MachineNode` instance with the custom options
    */
-  public withConfig(
+  public withOptions(
     options: Partial<MachineOptions<TContext, TEvent>>
   ): MachineNode<TContext, TEvent, TStateSchema> {
-    const { actions, guards, behaviors, delays } = this.options;
+    const { actions, guards, actors, delays } = this.options;
 
     return new MachineNode(this.config, {
       actions: { ...actions, ...options.actions },
       guards: { ...guards, ...options.guards },
-      behaviors: { ...behaviors, ...options.behaviors },
+      actors: { ...actors, ...options.actors },
       delays: { ...delays, ...options.delays },
       context: resolveContext(this.context, options.context)
     });
@@ -173,7 +172,7 @@ export class MachineNode<
   public withContext(
     context: Partial<TContext>
   ): MachineNode<TContext, TEvent, TStateSchema> {
-    return this.withConfig({
+    return this.withOptions({
       context: resolveContext(this.context, context)
     });
   }

--- a/packages/core/src/MachineNode.ts
+++ b/packages/core/src/MachineNode.ts
@@ -142,7 +142,8 @@ export class MachineNode<
   }
 
   /**
-   * Clones this state machine with the provided implementations.
+   * Clones this state machine with the provided implementations
+   * and merges the `context` (if provided).
    *
    * @param implementations Options (`actions`, `guards`, `actors`, `delays`, `context`)
    *  to recursively merge with the existing options.

--- a/packages/core/src/MachineNode.ts
+++ b/packages/core/src/MachineNode.ts
@@ -2,7 +2,7 @@ import { toArray, isBuiltInEvent, toSCXMLEvent } from './utils';
 import {
   Event,
   StateValue,
-  MachineOptions,
+  MachineImplementations,
   EventObject,
   StateSchema,
   MachineConfig,
@@ -38,7 +38,7 @@ export const WILDCARD = '*';
 
 const createDefaultOptions = <TContext>(
   context: TContext
-): MachineOptions<TContext, any> => ({
+): MachineImplementations<TContext, any> => ({
   actions: {},
   guards: {},
   actors: {},
@@ -80,7 +80,7 @@ export class MachineNode<
    */
   public delimiter: string;
 
-  public options: MachineOptions<TContext, TEvent>;
+  public options: MachineImplementations<TContext, TEvent>;
 
   public __xstatenode: true = true;
 
@@ -89,7 +89,7 @@ export class MachineNode<
      * The raw config used to create the machine.
      */
     public config: MachineConfig<TContext, TEvent, TStateSchema>,
-    options?: Partial<MachineOptions<TContext, TEvent>>
+    options?: Partial<MachineImplementations<TContext, TEvent>>
   ) {
     super(config, {
       _key: config.id || '(machine)'
@@ -142,23 +142,24 @@ export class MachineNode<
   }
 
   /**
-   * Clones this state machine with custom options.
+   * Clones this state machine with the provided implementations.
    *
-   * @param options Options (actions, guards, actors, delays, context) to recursively merge with the existing options.
+   * @param implementations Options (`actions`, `guards`, `actors`, `delays`, `context`)
+   *  to recursively merge with the existing options.
    *
-   * @returns A new `MachineNode` instance with the custom options
+   * @returns A new `MachineNode` instance with the provided implementations.
    */
-  public withOptions(
-    options: Partial<MachineOptions<TContext, TEvent>>
+  public provide(
+    implementations: Partial<MachineImplementations<TContext, TEvent>>
   ): MachineNode<TContext, TEvent, TStateSchema> {
     const { actions, guards, actors, delays } = this.options;
 
     return new MachineNode(this.config, {
-      actions: { ...actions, ...options.actions },
-      guards: { ...guards, ...options.guards },
-      actors: { ...actors, ...options.actors },
-      delays: { ...delays, ...options.delays },
-      context: resolveContext(this.context, options.context)
+      actions: { ...actions, ...implementations.actions },
+      guards: { ...guards, ...implementations.guards },
+      actors: { ...actors, ...implementations.actors },
+      delays: { ...delays, ...implementations.delays },
+      context: resolveContext(this.context, implementations.context)
     });
   }
 
@@ -172,7 +173,7 @@ export class MachineNode<
   public withContext(
     context: Partial<TContext>
   ): MachineNode<TContext, TEvent, TStateSchema> {
-    return this.withOptions({
+    return this.provide({
       context: resolveContext(this.context, context)
     });
   }

--- a/packages/core/src/State.ts
+++ b/packages/core/src/State.ts
@@ -95,7 +95,7 @@ export class State<
    */
   public transitions: Array<TransitionDefinition<TContext, TEvent>>;
   /**
-   * An object mapping actor IDs to spawned actors/invoked behaviors.
+   * An object mapping actor names to spawned/invoked actors.
    */
   public children: Record<string, SpawnedActorRef<any>>;
   /**

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -287,11 +287,11 @@ export class StateNode<
         );
 
         if (
-          !this.machine.options.behaviors[resolvedSrc.type] &&
+          !this.machine.options.actors[resolvedSrc.type] &&
           isFunction(invokeConfig.src)
         ) {
-          this.machine.options.behaviors = {
-            ...this.machine.options.behaviors,
+          this.machine.options.actors = {
+            ...this.machine.options.actors,
             [resolvedSrc.type]: invokeConfig.src
           };
         }

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -12,7 +12,7 @@ import {
   InterpreterOptions,
   DoneEvent,
   Subscription,
-  MachineOptions,
+  MachineImplementations,
   ActionFunctionMap,
   SCXML,
   Observer,
@@ -190,7 +190,7 @@ export class Interpreter<
    */
   public execute(
     state: State<TContext, TEvent, TStateSchema, TTypestate>,
-    actionsConfig?: MachineOptions<TContext, TEvent>['actions']
+    actionsConfig?: MachineImplementations<TContext, TEvent>['actions']
   ): void {
     for (const action of state.actions) {
       this.exec(action, state, actionsConfig);

--- a/packages/core/src/invoke.ts
+++ b/packages/core/src/invoke.ts
@@ -129,7 +129,7 @@ export function createActorRefFromInvokeAction<
     actorRef = src as SpawnedActorRef<any>;
   } else {
     const behaviorCreator: BehaviorCreator<TContext, TEvent> | undefined =
-      machine.options.behaviors[src.type];
+      machine.options.actors[src.type];
 
     if (!behaviorCreator) {
       if (!IS_PRODUCTION) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -639,7 +639,7 @@ export type DelayConfig<TContext, TEvent extends EventObject> =
 export interface MachineOptions<TContext, TEvent extends EventObject> {
   guards: Record<string, GuardPredicate<TContext, TEvent>>;
   actions: ActionFunctionMap<TContext, TEvent>;
-  behaviors: Record<string, BehaviorCreator<TContext, TEvent>>;
+  actors: Record<string, BehaviorCreator<TContext, TEvent>>;
   delays: DelayFunctionMap<TContext, TEvent>;
   context: Partial<TContext>;
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -636,7 +636,7 @@ export type DelayConfig<TContext, TEvent extends EventObject> =
   | number
   | DelayExpr<TContext, TEvent>;
 
-export interface MachineOptions<TContext, TEvent extends EventObject> {
+export interface MachineImplementations<TContext, TEvent extends EventObject> {
   guards: Record<string, GuardPredicate<TContext, TEvent>>;
   actions: ActionFunctionMap<TContext, TEvent>;
   actors: Record<string, BehaviorCreator<TContext, TEvent>>;

--- a/packages/core/test/activities.test.ts
+++ b/packages/core/test/activities.test.ts
@@ -53,7 +53,7 @@ describe('activities with guarded transitions', () => {
         }
       },
       {
-        behaviors: {
+        actors: {
           B_ACTIVITY: invokeActivity(() => {
             done();
           })
@@ -87,8 +87,8 @@ describe('remembering activities', () => {
 
   it('should remember the activities even after an event', (done) => {
     const service = interpret(
-      machine.withConfig({
-        behaviors: {
+      machine.withOptions({
+        actors: {
           B_ACTIVITY: invokeActivity(() => {
             done();
           })
@@ -104,8 +104,8 @@ describe('remembering activities', () => {
 describe('activities', () => {
   it('identifies initial activities', (done) => {
     const service = interpret(
-      lightMachine.withConfig({
-        behaviors: {
+      lightMachine.withOptions({
+        actors: {
           fadeInGreen: invokeActivity(() => {
             done();
           })
@@ -117,8 +117,8 @@ describe('activities', () => {
   });
   it('identifies start activities', (done) => {
     const service = interpret(
-      lightMachine.withConfig({
-        behaviors: {
+      lightMachine.withOptions({
+        actors: {
           activateCrosswalkLight: invokeActivity(() => {
             done();
           })
@@ -133,8 +133,8 @@ describe('activities', () => {
 
   it('identifies start activities for child states and active activities', (done) => {
     const service = interpret(
-      lightMachine.withConfig({
-        behaviors: {
+      lightMachine.withOptions({
+        actors: {
           blinkCrosswalkLight: invokeActivity(() => {
             done();
           })
@@ -150,8 +150,8 @@ describe('activities', () => {
 
   it('identifies stop activities for child states', (done) => {
     const service = interpret(
-      lightMachine.withConfig({
-        behaviors: {
+      lightMachine.withOptions({
+        actors: {
           blinkCrosswalkLight: invokeActivity(() => {
             return () => {
               done();
@@ -172,8 +172,8 @@ describe('activities', () => {
     let stopActivateCrosswalkLightcalled = false;
 
     const service = interpret(
-      lightMachine.withConfig({
-        behaviors: {
+      lightMachine.withOptions({
+        actors: {
           fadeInGreen: invokeActivity(() => {
             if (stopActivateCrosswalkLightcalled) {
               done();
@@ -276,8 +276,8 @@ describe('transient activities', () => {
 
   it('should have started initial activities', (done) => {
     const service = interpret(
-      machine.withConfig({
-        behaviors: {
+      machine.withOptions({
+        actors: {
           A: invokeActivity(() => {
             done();
           })
@@ -290,8 +290,8 @@ describe('transient activities', () => {
 
   it('should have started deep initial activities', (done) => {
     const service = interpret(
-      machine.withConfig({
-        behaviors: {
+      machine.withOptions({
+        actors: {
           A1: invokeActivity(() => {
             done();
           })
@@ -303,8 +303,8 @@ describe('transient activities', () => {
 
   it('should have kept existing activities', (done) => {
     const service = interpret(
-      machine.withConfig({
-        behaviors: {
+      machine.withOptions({
+        actors: {
           A: invokeActivity(() => {
             done();
           })
@@ -317,8 +317,8 @@ describe('transient activities', () => {
 
   it('should have kept same activities', (done) => {
     const service = interpret(
-      machine.withConfig({
-        behaviors: {
+      machine.withOptions({
+        actors: {
           C1: invokeActivity(() => {
             done();
           })
@@ -331,8 +331,8 @@ describe('transient activities', () => {
 
   it('should have kept same activities after self transition', (done) => {
     const service = interpret(
-      machine.withConfig({
-        behaviors: {
+      machine.withOptions({
+        actors: {
           C1: invokeActivity(() => {
             done();
           })
@@ -345,8 +345,8 @@ describe('transient activities', () => {
 
   it('should have stopped after automatic transitions', (done) => {
     const service = interpret(
-      machine.withConfig({
-        behaviors: {
+      machine.withOptions({
+        actors: {
           B2: invokeActivity(() => {
             done();
           })

--- a/packages/core/test/activities.test.ts
+++ b/packages/core/test/activities.test.ts
@@ -87,7 +87,7 @@ describe('remembering activities', () => {
 
   it('should remember the activities even after an event', (done) => {
     const service = interpret(
-      machine.withOptions({
+      machine.provide({
         actors: {
           B_ACTIVITY: invokeActivity(() => {
             done();
@@ -104,7 +104,7 @@ describe('remembering activities', () => {
 describe('activities', () => {
   it('identifies initial activities', (done) => {
     const service = interpret(
-      lightMachine.withOptions({
+      lightMachine.provide({
         actors: {
           fadeInGreen: invokeActivity(() => {
             done();
@@ -117,7 +117,7 @@ describe('activities', () => {
   });
   it('identifies start activities', (done) => {
     const service = interpret(
-      lightMachine.withOptions({
+      lightMachine.provide({
         actors: {
           activateCrosswalkLight: invokeActivity(() => {
             done();
@@ -133,7 +133,7 @@ describe('activities', () => {
 
   it('identifies start activities for child states and active activities', (done) => {
     const service = interpret(
-      lightMachine.withOptions({
+      lightMachine.provide({
         actors: {
           blinkCrosswalkLight: invokeActivity(() => {
             done();
@@ -150,7 +150,7 @@ describe('activities', () => {
 
   it('identifies stop activities for child states', (done) => {
     const service = interpret(
-      lightMachine.withOptions({
+      lightMachine.provide({
         actors: {
           blinkCrosswalkLight: invokeActivity(() => {
             return () => {
@@ -172,7 +172,7 @@ describe('activities', () => {
     let stopActivateCrosswalkLightcalled = false;
 
     const service = interpret(
-      lightMachine.withOptions({
+      lightMachine.provide({
         actors: {
           fadeInGreen: invokeActivity(() => {
             if (stopActivateCrosswalkLightcalled) {
@@ -276,7 +276,7 @@ describe('transient activities', () => {
 
   it('should have started initial activities', (done) => {
     const service = interpret(
-      machine.withOptions({
+      machine.provide({
         actors: {
           A: invokeActivity(() => {
             done();
@@ -290,7 +290,7 @@ describe('transient activities', () => {
 
   it('should have started deep initial activities', (done) => {
     const service = interpret(
-      machine.withOptions({
+      machine.provide({
         actors: {
           A1: invokeActivity(() => {
             done();
@@ -303,7 +303,7 @@ describe('transient activities', () => {
 
   it('should have kept existing activities', (done) => {
     const service = interpret(
-      machine.withOptions({
+      machine.provide({
         actors: {
           A: invokeActivity(() => {
             done();
@@ -317,7 +317,7 @@ describe('transient activities', () => {
 
   it('should have kept same activities', (done) => {
     const service = interpret(
-      machine.withOptions({
+      machine.provide({
         actors: {
           C1: invokeActivity(() => {
             done();
@@ -331,7 +331,7 @@ describe('transient activities', () => {
 
   it('should have kept same activities after self transition', (done) => {
     const service = interpret(
-      machine.withOptions({
+      machine.provide({
         actors: {
           C1: invokeActivity(() => {
             done();
@@ -345,7 +345,7 @@ describe('transient activities', () => {
 
   it('should have stopped after automatic transitions', (done) => {
     const service = interpret(
-      machine.withOptions({
+      machine.provide({
         actors: {
           B2: invokeActivity(() => {
             done();

--- a/packages/core/test/interpreter.test.ts
+++ b/packages/core/test/interpreter.test.ts
@@ -518,7 +518,7 @@ describe('interpreter', () => {
         }
       },
       {
-        behaviors: {
+        actors: {
           myActivity: invokeActivity(() => {
             activityState = 'on';
             return () => (activityState = 'off');
@@ -565,7 +565,7 @@ describe('interpreter', () => {
           }
         },
         {
-          behaviors: {
+          actors: {
             myActivity: invokeActivity(() => {
               stopActivityState = 'on';
               return () => (stopActivityState = 'off');
@@ -606,7 +606,7 @@ describe('interpreter', () => {
           }
         },
         {
-          behaviors: {
+          actors: {
             blink: invokeActivity(() => {
               activityActive = true;
 
@@ -1096,7 +1096,7 @@ describe('interpreter', () => {
       const evenCounts: number[] = [];
       const oddCounts: number[] = [];
       const countService = interpret(
-        countMachine.withConfig({
+        countMachine.withOptions({
           actions: {
             evenAction: (ctx) => {
               evenCounts.push(ctx.count);
@@ -1643,7 +1643,7 @@ describe('interpreter', () => {
           }
         },
         {
-          behaviors: {
+          actors: {
             testService: invokeActivity(() => {
               // nothing
             })

--- a/packages/core/test/interpreter.test.ts
+++ b/packages/core/test/interpreter.test.ts
@@ -1096,7 +1096,7 @@ describe('interpreter', () => {
       const evenCounts: number[] = [];
       const oddCounts: number[] = [];
       const countService = interpret(
-        countMachine.withOptions({
+        countMachine.provide({
           actions: {
             evenAction: (ctx) => {
               evenCounts.push(ctx.count);

--- a/packages/core/test/invoke.test.ts
+++ b/packages/core/test/invoke.test.ts
@@ -615,7 +615,7 @@ describe('invoke', () => {
     );
 
     interpret(
-      someParentMachine.withOptions({
+      someParentMachine.provide({
         actors: {
           child: invokeMachine(
             Machine({

--- a/packages/core/test/invoke.test.ts
+++ b/packages/core/test/invoke.test.ts
@@ -181,7 +181,7 @@ describe('invoke', () => {
         }
       },
       {
-        behaviors: {
+        actors: {
           child: invokeMachine(childMachine)
         }
       }
@@ -248,7 +248,7 @@ describe('invoke', () => {
         }
       },
       {
-        behaviors: {
+        actors: {
           child: invokeMachine(childMachine)
         }
       }
@@ -608,15 +608,15 @@ describe('invoke', () => {
         }
       },
       {
-        behaviors: {
+        actors: {
           child: invokeMachine(childMachine)
         }
       }
     );
 
     interpret(
-      someParentMachine.withConfig({
-        behaviors: {
+      someParentMachine.withOptions({
+        actors: {
           child: invokeMachine(
             Machine({
               id: 'child',
@@ -1061,7 +1061,7 @@ describe('invoke', () => {
             }
           },
           {
-            behaviors: {
+            actors: {
               somePromise: invokePromise(() =>
                 createPromise((resolve) => resolve())
               )
@@ -1131,7 +1131,7 @@ describe('invoke', () => {
             }
           },
           {
-            behaviors: {
+            actors: {
               somePromise: invokePromise(() =>
                 createPromise((resolve) => resolve({ count: 1 }))
               )
@@ -1211,7 +1211,7 @@ describe('invoke', () => {
             }
           },
           {
-            behaviors: {
+            actors: {
               somePromise: invokePromise(() =>
                 createPromise((resolve) => resolve({ count: 1 }))
               )
@@ -1257,7 +1257,7 @@ describe('invoke', () => {
             }
           },
           {
-            behaviors: {
+            actors: {
               somePromise: invokePromise((ctx, e: BeginEvent) => {
                 return createPromise((resolve, reject) => {
                   ctx.foo && e.payload ? resolve() : reject();
@@ -1323,7 +1323,7 @@ describe('invoke', () => {
           }
         },
         {
-          behaviors: {
+          actors: {
             someCallback: invokeCallback(
               (ctx, e: BeginEvent) => (cb: (ev: CallbackEvent) => void) => {
                 if (ctx.foo && e.payload) {
@@ -1380,7 +1380,7 @@ describe('invoke', () => {
           }
         },
         {
-          behaviors: {
+          actors: {
             someCallback: invokeCallback(() => (cb) => {
               cb('CALLBACK');
             })
@@ -1421,7 +1421,7 @@ describe('invoke', () => {
           }
         },
         {
-          behaviors: {
+          actors: {
             someCallback: invokeCallback(() => (cb) => {
               cb('CALLBACK');
             })
@@ -1469,7 +1469,7 @@ describe('invoke', () => {
           }
         },
         {
-          behaviors: {
+          actors: {
             someCallback: invokeCallback(() => (cb) => {
               cb('CALLBACK');
             })
@@ -2387,7 +2387,7 @@ describe('invoke', () => {
         }
       },
       {
-        behaviors: {
+        actors: {
           search: invokePromise(async (_, __, meta) => {
             expect(meta.src.endpoint).toEqual('example.com');
 
@@ -2428,7 +2428,7 @@ describe('services option', () => {
         }
       },
       {
-        behaviors: {
+        actors: {
           stringService: invokePromise((ctx, _, { data }) => {
             expect(ctx).toEqual({ count: 42 });
 

--- a/packages/core/test/machine.test.ts
+++ b/packages/core/test/machine.test.ts
@@ -156,7 +156,7 @@ describe('machine', () => {
 
   describe('machine.withConfig', () => {
     it('should override guards and actions', () => {
-      const differentMachine = configMachine.withOptions({
+      const differentMachine = configMachine.provide({
         actions: {
           entryAction: () => {
             throw new Error('new entry');
@@ -177,7 +177,7 @@ describe('machine', () => {
     });
 
     it('should not override context if not defined', () => {
-      const differentMachine = configMachine.withOptions({});
+      const differentMachine = configMachine.provide({});
 
       expect(differentMachine.initialState.context).toEqual(
         configMachine.context

--- a/packages/core/test/machine.test.ts
+++ b/packages/core/test/machine.test.ts
@@ -156,7 +156,7 @@ describe('machine', () => {
 
   describe('machine.withConfig', () => {
     it('should override guards and actions', () => {
-      const differentMachine = configMachine.withConfig({
+      const differentMachine = configMachine.withOptions({
         actions: {
           entryAction: () => {
             throw new Error('new entry');
@@ -177,7 +177,7 @@ describe('machine', () => {
     });
 
     it('should not override context if not defined', () => {
-      const differentMachine = configMachine.withConfig({});
+      const differentMachine = configMachine.withOptions({});
 
       expect(differentMachine.initialState.context).toEqual(
         configMachine.context

--- a/packages/xstate-react/src/useMachine.ts
+++ b/packages/xstate-react/src/useMachine.ts
@@ -157,7 +157,7 @@ export function useMachine<
       services,
       delays
     };
-    const machineWithOptions = machine.withConfig(machineConfig).withContext({
+    const machineWithOptions = machine.withOptions(machineConfig).withContext({
       ...machine.context,
       ...context
     } as TContext);
@@ -258,7 +258,7 @@ export function useMachine<
   }, [actions]);
 
   useEffect(() => {
-    Object.assign(service.machine.options.behaviors, services);
+    Object.assign(service.machine.options.actors, services);
   }, [services]);
 
   // this is somewhat weird - this should always be flushed within useLayoutEffect

--- a/packages/xstate-react/src/useMachine.ts
+++ b/packages/xstate-react/src/useMachine.ts
@@ -157,7 +157,7 @@ export function useMachine<
       services,
       delays
     };
-    const machineWithOptions = machine.withOptions(machineConfig).withContext({
+    const machineWithOptions = machine.provide(machineConfig).withContext({
       ...machine.context,
       ...context
     } as TContext);

--- a/packages/xstate-react/src/useMachine.ts
+++ b/packages/xstate-react/src/useMachine.ts
@@ -7,7 +7,7 @@ import {
   State,
   Interpreter,
   InterpreterOptions,
-  MachineOptions,
+  MachineImplementations,
   StateConfig,
   Typestate,
   ActionObject,
@@ -108,7 +108,7 @@ export function useMachine<
   getMachine: MaybeLazy<MachineNode<TContext, TEvent, any, TTypestate>>,
   options: Partial<InterpreterOptions> &
     Partial<UseMachineOptions<TContext, TEvent>> &
-    Partial<MachineOptions<TContext, TEvent>> = {}
+    Partial<MachineImplementations<TContext, TEvent>> = {}
 ): [
   State<TContext, TEvent, any, TTypestate>,
   InterpreterOf<typeof machine>['send'],

--- a/packages/xstate-vue/src/index.ts
+++ b/packages/xstate-vue/src/index.ts
@@ -56,7 +56,7 @@ export function useMachine<
     delays
   };
 
-  const createdMachine = machine.withOptions({
+  const createdMachine = machine.provide({
     ...machineConfig,
     context
   });

--- a/packages/xstate-vue/src/index.ts
+++ b/packages/xstate-vue/src/index.ts
@@ -6,7 +6,7 @@ import {
   State,
   Interpreter,
   InterpreterOptions,
-  MachineOptions,
+  MachineImplementations,
   StateConfig,
   Typestate,
   InterpreterOf
@@ -32,7 +32,7 @@ export function useMachine<
   machine: MachineNode<TContext, TEvent, any, TTypestate>,
   options: Partial<InterpreterOptions> &
     Partial<UseMachineOptions<TContext, TEvent>> &
-    Partial<MachineOptions<TContext, TEvent>> = {}
+    Partial<MachineImplementations<TContext, TEvent>> = {}
 ): {
   state: Ref<State<TContext, TEvent, any, TTypestate>>;
   send: InterpreterOf<typeof machine>['send'];

--- a/packages/xstate-vue/src/index.ts
+++ b/packages/xstate-vue/src/index.ts
@@ -42,8 +42,7 @@ export function useMachine<
     context,
     guards,
     actions,
-    activities,
-    behaviors,
+    actors,
     delays,
     state: rehydratedState,
     ...interpreterOptions
@@ -53,12 +52,11 @@ export function useMachine<
     context,
     guards,
     actions,
-    activities,
-    behaviors,
+    actors,
     delays
   };
 
-  const createdMachine = machine.withConfig({
+  const createdMachine = machine.withOptions({
     ...machineConfig,
     context
   });

--- a/packages/xstate-vue/test/UseMachine.vue
+++ b/packages/xstate-vue/test/UseMachine.vue
@@ -57,7 +57,7 @@ export default {
       new Promise((res) => setTimeout(() => res('some data'), 50));
 
     const { state, send, service } = useMachine(fetchMachine, {
-      behaviors: {
+      actors: {
         fetchData: invokePromise(onFetch)
       },
       state: persistedState


### PR DESCRIPTION
Reference: https://github.com/davidkpiano/xstate/projects/1#card-40598347

This PR also renames `options.behaviors` to `options.actors`, as previously discussed.