### PR TITLE
[v5] Add support for partial wildcards (prefix matching)

### DIFF
--- a/.changeset/thin-ads-obey.md
+++ b/.changeset/thin-ads-obey.md
@@ -1,0 +1,28 @@
+---
+'xstate': major
+---
+
+Prefix wildcard event descriptors are now supported. These are event descriptors ending with `".*"` which will match all events that start with the prefix (the partial event type before `".*"`):
+
+```js
+// ...
+on: {
+  'mouse.click': {/* ... */},
+  // Matches events such as:
+  // "pointer.move"
+  // "pointer.move.out"
+  // "pointer"
+  'pointer.*': {/* ... */}
+}
+// ...
+```
+
+Note: wildcards are only valid as the entire event type (`"*"`) or at the end of an event type, preceded by a period (`".*"`):
+
+- ✅ `"*"`
+- ✅ `"event.*"`
+- ✅ `"event.something.*"`
+- ❌ ~`"event.*.something"`~
+- ❌ ~`"event*"`~
+- ❌ ~`"event*.some*thing"`~
+- ❌ ~`"*.something"`~

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -384,7 +384,11 @@ export class StateNode<
 
     const candidates: Array<TransitionDefinition<TContext, TEvent>> =
       this.__cache.candidates[eventName] ||
-      (this.__cache.candidates[eventName] = getCandidates(this, eventName));
+      (this.__cache.candidates[eventName] = getCandidates(
+        this,
+        eventName,
+        this.machine.config.scxml // Whether token matching should be used
+      ));
 
     for (const candidate of candidates) {
       const { guard } = candidate;

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -226,9 +226,16 @@ export function resolveSend<
       : action.delay;
   }
 
-  const resolvedTarget = isFunction(action.to)
+  let resolvedTarget = isFunction(action.to)
     ? action.to(ctx, _event.data, meta)
     : action.to;
+  resolvedTarget =
+    isString(resolvedTarget) &&
+    resolvedTarget !== SpecialTargets.Parent &&
+    resolvedTarget !== SpecialTargets.Internal &&
+    resolvedTarget.startsWith('#_')
+      ? resolvedTarget.slice(2)
+      : resolvedTarget;
 
   return {
     ...action,

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -471,11 +471,14 @@ export function done(id: string, data?: any): DoneEventObject {
  * An invoked service is terminated when it has reached a top-level final state node,
  * but not when it is canceled.
  *
- * @param id The final state node ID
+ * @param invokeId The invoked service ID
  * @param data The data to pass into the event
  */
-export function doneInvoke(id: string, data?: any): DoneEvent {
-  const type = `${ActionTypes.DoneInvoke}.${id}`;
+export function doneInvoke(
+  invokeId: string,
+  data?: any
+): SCXML.Event<DoneEvent> {
+  const type = `${ActionTypes.DoneInvoke}.${invokeId}`;
   const eventObject = {
     type,
     data
@@ -483,7 +486,7 @@ export function doneInvoke(id: string, data?: any): DoneEvent {
 
   eventObject.toString = () => type;
 
-  return eventObject as DoneEvent;
+  return toSCXMLEvent(eventObject as DoneEvent, { invokeid: invokeId });
 }
 
 export function error(id: string, data?: any): ErrorPlatformEvent & string {

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -343,7 +343,7 @@ export const resolveLog = <TContext, TEvent extends EventObject>(
  * @param sendId The `id` of the `send(...)` action to cancel.
  */
 export const cancel = <TContext, TEvent extends EventObject>(
-  sendId: string | number | ExprWithMeta<TContext, TEvent, string | number>
+  sendId: string | ExprWithMeta<TContext, TEvent, string>
 ): CancelAction<TContext, TEvent> => {
   return {
     type: actionTypes.cancel,

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -474,10 +474,7 @@ export function done(id: string, data?: any): DoneEventObject {
  * @param invokeId The invoked service ID
  * @param data The data to pass into the event
  */
-export function doneInvoke(
-  invokeId: string,
-  data?: any
-): SCXML.Event<DoneEvent> {
+export function doneInvoke(invokeId: string, data?: any): DoneEvent {
   const type = `${ActionTypes.DoneInvoke}.${invokeId}`;
   const eventObject = {
     type,
@@ -486,7 +483,7 @@ export function doneInvoke(
 
   eventObject.toString = () => type;
 
-  return toSCXMLEvent(eventObject as DoneEvent, { invokeid: invokeId });
+  return eventObject as DoneEvent;
 }
 
 export function error(id: string, data?: any): ErrorPlatformEvent & string {

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -554,14 +554,14 @@ export class Interpreter<
 
   private sendTo(
     event: SCXML.Event<AnyEventObject>,
-    to: string | number | ActorRef<any>
+    to: string | ActorRef<any>
   ) {
     const isParent = this.parent && to === SpecialTargets.Parent;
     const target = isParent
       ? this.parent
       : isActorRef(to)
       ? to
-      : this.children.get(to);
+      : this.children.get(to.startsWith('#_') ? to.slice(2) : to);
 
     if (!target) {
       if (!isParent) {

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -563,7 +563,7 @@ export class Interpreter<
       ? this.parent
       : isActorRef(to)
       ? to
-      : this.children.get(to.startsWith('#_') ? to.slice(2) : to);
+      : this.children.get(to);
 
     if (!target) {
       if (!isParent) {

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -229,7 +229,9 @@ export class Interpreter<
           : undefined;
 
       for (const listener of this.doneListeners) {
-        listener(doneInvoke(this.id, doneData));
+        listener(
+          toSCXMLEvent(doneInvoke(this.id, doneData), { invokeid: this.id })
+        );
       }
       this.stop();
     }

--- a/packages/core/src/scxml.ts
+++ b/packages/core/src/scxml.ts
@@ -318,6 +318,12 @@ function toConfig(
         target: target ? `#${target}` : undefined
       };
     }
+    // case 'final': {
+    //   return {
+    //     ...nodeJson.attributes,
+    //     type: 'final'
+    //   };
+    // }
     default:
       break;
   }
@@ -474,7 +480,7 @@ function toConfig(
     };
   }
 
-  return { id };
+  return { id, ...(nodeJson.name === 'final' ? { type: 'final' } : undefined) };
 }
 
 export interface ScxmlToMachineOptions {

--- a/packages/core/src/scxml.ts
+++ b/packages/core/src/scxml.ts
@@ -318,12 +318,6 @@ function toConfig(
         target: target ? `#${target}` : undefined
       };
     }
-    // case 'final': {
-    //   return {
-    //     ...nodeJson.attributes,
-    //     type: 'final'
-    //   };
-    // }
     default:
       break;
   }

--- a/packages/core/src/scxml.ts
+++ b/packages/core/src/scxml.ts
@@ -485,18 +485,7 @@ function scxmlToMachine(
   scxmlJson: XMLElement,
   options: ScxmlToMachineOptions
 ): MachineNode {
-  if (!scxmlJson.elements) {
-    // If there is no SCXML element, this should call 'done.invoke' immediately.
-    // TODO: there's probably a better way to do this
-    return Machine({
-      initial: 'final',
-      states: {
-        final: { type: 'final' }
-      }
-    });
-  }
-
-  const machineElement = scxmlJson.elements.find(
+  const machineElement = scxmlJson.elements!.find(
     (element) => element.name === 'scxml'
   ) as XMLElement;
 

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -272,10 +272,14 @@ export function getCandidates<TEvent extends EventObject>(
       return true;
     }
 
+    // transient transitions can't match non-transient events
+    if (transient) {
+        return false;
+    }
     // Then, check if transition is a wildcard transition,
-    // which matches all non-transient events
+    // which matches any non-transient events
     if (transition.eventType === WILDCARD) {
-      return !transient;
+      return true;
     }
 
     if (!matchTokens && !transition.eventType.endsWith('.*')) {

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -278,7 +278,7 @@ export function getCandidates<TEvent extends EventObject>(
       return !transient;
     }
 
-    if (!matchTokens) {
+    if (!matchTokens && !transition.eventType.endsWith('.*')) {
       return false;
     }
 

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -301,8 +301,6 @@ export function getCandidates<TEvent extends EventObject>(
       if (partialEventToken !== eventToken) {
         return false;
       }
-
-      continue;
     }
 
     return true;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -656,6 +656,10 @@ export interface MachineConfig<
    * The machine's own version.
    */
   version?: string;
+  /**
+   * If `true`, will use SCXML semantics, such as event token matching.
+   */
+  scxml?: boolean;
 }
 
 export interface HistoryStateNode<TContext> extends StateNode<TContext> {
@@ -812,7 +816,7 @@ export interface SendActionObject<
   TEvent extends EventObject,
   TSentEvent extends EventObject = AnyEventObject
 > extends SendAction<TContext, TEvent, TSentEvent> {
-  to: string | number | ActorRef<TSentEvent> | undefined;
+  to: string | ActorRef<TSentEvent> | undefined;
   _event: SCXML.Event<TSentEvent>;
   event: TSentEvent;
   delay?: number;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -799,11 +799,7 @@ export interface SendAction<
   to:
     | string
     | ActorRef<any>
-    | ExprWithMeta<
-        TContext,
-        TEvent,
-        string | number | ActorRef<any> | undefined
-      >
+    | ExprWithMeta<TContext, TEvent, string | ActorRef<any> | undefined>
     | undefined;
   event: TSentEvent | SendExpr<TContext, TEvent, TSentEvent>;
   delay?: number | string | DelayExpr<TContext, TEvent>;
@@ -849,22 +845,18 @@ export interface SendActionOptions<TContext, TEvent extends EventObject> {
   delay?: number | string | DelayExpr<TContext, TEvent>;
   to?:
     | string
-    | ExprWithMeta<
-        TContext,
-        TEvent,
-        string | number | ActorRef<any> | undefined
-      >
+    | ExprWithMeta<TContext, TEvent, string | ActorRef<any> | undefined>
     | undefined;
 }
 
 export interface CancelAction<TContext, TEvent extends EventObject>
   extends ActionObject<TContext, TEvent> {
-  sendId: string | number | ExprWithMeta<TContext, TEvent, string | number>;
+  sendId: string | ExprWithMeta<TContext, TEvent, string>;
 }
 
 export interface CancelActionObject<TContext, TEvent extends EventObject>
   extends CancelAction<TContext, TEvent> {
-  sendId: string | number;
+  sendId: string;
 }
 
 export type Assigner<TContext, TEvent extends EventObject> = (

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -798,7 +798,6 @@ export interface SendAction<
 > extends ActionObject<TContext, TEvent> {
   to:
     | string
-    | number
     | ActorRef<any>
     | ExprWithMeta<
         TContext,

--- a/packages/core/test/eventDescriptors.test.ts
+++ b/packages/core/test/eventDescriptors.test.ts
@@ -212,5 +212,9 @@ describe('event descriptors', () => {
     expect(
       SCXMLMachine.transition(undefined, 'event.whatever').matches('success')
     ).toBeTruthy();
+    
+    expect(
+      SCXMLMachine.transition(undefined, 'eventually').matches('start')
+    ).toBeTruthy();
   });
 });

--- a/packages/core/test/eventDescriptors.test.ts
+++ b/packages/core/test/eventDescriptors.test.ts
@@ -212,9 +212,35 @@ describe('event descriptors', () => {
     expect(
       SCXMLMachine.transition(undefined, 'event.whatever').matches('success')
     ).toBeTruthy();
-    
+
     expect(
       SCXMLMachine.transition(undefined, 'eventually').matches('start')
     ).toBeTruthy();
+  });
+
+  it('should not match infix wildcards', () => {
+    const machine = Machine({
+      initial: 'start',
+      states: {
+        start: {
+          on: {
+            'event.*.bar.*': 'success',
+            '*.event.*': 'success'
+          }
+        },
+        success: {
+          type: 'final'
+        }
+      }
+    });
+
+    expect(
+      machine
+        .transition(undefined, 'event.foo.bar.first.second')
+        .matches('success')
+    ).toBeFalsy();
+    expect(
+      machine.transition(undefined, 'whatever.event').matches('success')
+    ).toBeFalsy();
   });
 });

--- a/packages/core/test/eventDescriptors.test.ts
+++ b/packages/core/test/eventDescriptors.test.ts
@@ -243,4 +243,28 @@ describe('event descriptors', () => {
       machine.transition(undefined, 'whatever.event').matches('success')
     ).toBeFalsy();
   });
+
+  it('should not match wildcards as part of tokens', () => {
+    const machine = Machine({
+      initial: 'start',
+      states: {
+        start: {
+          on: {
+            'event*.bar.*': 'success',
+            '*event.*': 'success'
+          }
+        },
+        success: {
+          type: 'final'
+        }
+      }
+    });
+
+    expect(
+      machine.transition(undefined, 'eventually.bar.baz').matches('success')
+    ).toBeFalsy();
+    expect(
+      machine.transition(undefined, 'prevent.whatever').matches('success')
+    ).toBeFalsy();
+  });
 });

--- a/packages/core/test/eventDescriptors.test.ts
+++ b/packages/core/test/eventDescriptors.test.ts
@@ -60,4 +60,157 @@ describe('event descriptors', () => {
     service.send('NEXT');
     expect(service.state.value).toBe('pass');
   });
+
+  it('should NOT support non-tokenized wildcards', () => {
+    const machine = Machine({
+      initial: 'start',
+      states: {
+        start: {
+          on: {
+            'event*': 'success'
+          }
+        },
+        success: {
+          type: 'final'
+        }
+      }
+    });
+
+    expect(
+      machine.transition(undefined, 'event').matches('success')
+    ).toBeFalsy();
+    expect(
+      machine.transition(undefined, 'eventually').matches('success')
+    ).toBeFalsy();
+  });
+
+  it('should support prefix matching with wildcards (+0)', () => {
+    const machine = Machine({
+      initial: 'start',
+      states: {
+        start: {
+          on: {
+            'event.*': 'success'
+          }
+        },
+        success: {
+          type: 'final'
+        }
+      }
+    });
+
+    expect(
+      machine.transition(undefined, 'event').matches('success')
+    ).toBeTruthy();
+    expect(
+      machine.transition(undefined, 'eventually').matches('success')
+    ).toBeFalsy();
+  });
+
+  it('should support prefix matching with wildcards (+1)', () => {
+    const machine = Machine({
+      initial: 'start',
+      states: {
+        start: {
+          on: {
+            'event.*': 'success'
+          }
+        },
+        success: {
+          type: 'final'
+        }
+      }
+    });
+
+    expect(
+      machine.transition(undefined, 'event.whatever').matches('success')
+    ).toBeTruthy();
+    expect(
+      machine.transition(undefined, 'eventually').matches('success')
+    ).toBeFalsy();
+    expect(
+      machine.transition(undefined, 'eventually.event').matches('success')
+    ).toBeFalsy();
+  });
+
+  it('should support prefix matching with wildcards (+n)', () => {
+    const machine = Machine({
+      initial: 'start',
+      states: {
+        start: {
+          on: {
+            'event.*': 'success'
+          }
+        },
+        success: {
+          type: 'final'
+        }
+      }
+    });
+
+    expect(
+      machine.transition(undefined, 'event.first.second').matches('success')
+    ).toBeTruthy();
+  });
+
+  it('should support prefix matching with wildcards (+n, multi-prefix)', () => {
+    const machine = Machine({
+      initial: 'start',
+      states: {
+        start: {
+          on: {
+            'event.foo.bar.*': 'success'
+          }
+        },
+        success: {
+          type: 'final'
+        }
+      }
+    });
+
+    expect(
+      machine
+        .transition(undefined, 'event.foo.bar.first.second')
+        .matches('success')
+    ).toBeTruthy();
+  });
+
+  it('should only allow non-wildcard prefix matching for SCXML machines', () => {
+    const nonSCXMLMachine = Machine({
+      initial: 'start',
+      states: {
+        start: {
+          on: {
+            event: 'success'
+          }
+        },
+        success: {
+          type: 'final'
+        }
+      }
+    });
+
+    const SCXMLMachine = Machine({
+      scxml: true,
+      initial: 'start',
+      states: {
+        start: {
+          on: {
+            event: 'success'
+          }
+        },
+        success: {
+          type: 'final'
+        }
+      }
+    });
+
+    expect(
+      nonSCXMLMachine.transition(undefined, 'event.whatever').matches('start')
+    ).toBeTruthy();
+
+    expect(
+      SCXMLMachine.transition(undefined, 'event.whatever').matches('success')
+    ).toBeTruthy();
+  });
 });

--- a/packages/core/test/interpreter.test.ts
+++ b/packages/core/test/interpreter.test.ts
@@ -1742,7 +1742,6 @@ describe('interpreter', () => {
 
       const service = interpret(parentMachine)
         .onTransition((state) => {
-          console.log(state.value, state._event);
           if (state.matches('active')) {
             const childActor = state.children.childActor;
 

--- a/packages/core/test/interpreter.test.ts
+++ b/packages/core/test/interpreter.test.ts
@@ -1742,6 +1742,7 @@ describe('interpreter', () => {
 
       const service = interpret(parentMachine)
         .onTransition((state) => {
+          console.log(state.value, state._event);
           if (state.matches('active')) {
             const childActor = state.children.childActor;
 

--- a/packages/core/test/scxml.test.ts
+++ b/packages/core/test/scxml.test.ts
@@ -175,7 +175,7 @@ const testGroups = {
     // 'test226.txml', // <invoke src="...">
     'test228.txml',
     'test229.txml',
-    'test230.txml',
+    // 'test230.txml', // Manual test (TODO: check)
     'test232.txml',
     // 'test233.txml', // <finalize> not implemented yet
     // 'test234.txml', // <finalize> not implemented yet
@@ -307,7 +307,7 @@ const testGroups = {
     // 'test527.txml', // conversion of <donedata> not implemented yet
     // 'test528.txml', // conversion of <donedata> not implemented yet + error.execution when evaluating donedata
     // 'test529.txml', // conversion of <donedata> not implemented yet
-    'test530.txml',
+    // 'test530.txml', // https://github.com/davidkpiano/xstate/pull/1811#discussion_r551897693
     // 'test531.txml', // Basic HTTP Event I/O processor not implemented
     // 'test532.txml', // Basic HTTP Event I/O processor not implemented
     'test533.txml',

--- a/packages/core/test/scxml.test.ts
+++ b/packages/core/test/scxml.test.ts
@@ -230,7 +230,7 @@ const testGroups = {
     'test335.txml',
     'test336.txml',
     'test337.txml',
-    'test338.txml',
+    // 'test338.txml', // <invoke idlocation="..."> + _event.invokeid available on <send> events received from the invoked child
     'test339.txml',
     'test342.txml',
     // 'test343.txml', // error.execution when evaluating donedata

--- a/packages/core/test/scxml.test.ts
+++ b/packages/core/test/scxml.test.ts
@@ -255,7 +255,7 @@ const testGroups = {
     'test396.txml',
     'test399.txml',
     'test401.txml',
-    'test402.txml',
+    // 'test402.txml', // TODO: investigate more, it expects error.execution when evaluating assign, check if assigning to a deep location is even allowed, check if assigning to an initialized datamodel is allowed, improve how datamodel is exposed to constructed functions
     'test403a.txml',
     'test403b.txml',
     'test403c.txml',

--- a/packages/core/test/scxml.test.ts
+++ b/packages/core/test/scxml.test.ts
@@ -176,11 +176,11 @@ const testGroups = {
     'test228.txml',
     'test229.txml',
     'test230.txml',
-    'test232.txml',
+    // 'test232.txml', // TODO: not sure
     // 'test233.txml', // <finalize> not implemented yet
     // 'test234.txml', // <finalize> not implemented yet
     'test235.txml',
-    'test236.txml',
+    // 'test236.txml', // TODO: not sure
     'test237.txml',
     // 'test239.txml', // <invoke src="...">
     // 'test240.txml', // conversion of namelist not implemented yet
@@ -230,7 +230,7 @@ const testGroups = {
     'test335.txml',
     'test336.txml',
     'test337.txml',
-    // 'test338.txml', // _event.invokeid not implemented yet
+    'test338.txml',
     'test339.txml',
     'test342.txml',
     // 'test343.txml', // error.execution when evaluating donedata
@@ -427,8 +427,6 @@ async function runTestToCompletion(
 describe('scxml', () => {
   const onlyTests: string[] = [
     // e.g., 'test399.txml'
-    // 'test232.txml'
-    'test236.txml'
   ];
   const testGroupKeys = Object.keys(testGroups);
 

--- a/packages/core/test/scxml.test.ts
+++ b/packages/core/test/scxml.test.ts
@@ -180,7 +180,7 @@ const testGroups = {
     // 'test233.txml', // <finalize> not implemented yet
     // 'test234.txml', // <finalize> not implemented yet
     'test235.txml',
-    // 'test236.txml', // TODO: not sure
+    // 'test236.txml', // reaching a final state should execute all onexit handlers
     'test237.txml',
     // 'test239.txml', // <invoke src="...">
     // 'test240.txml', // conversion of namelist not implemented yet

--- a/packages/core/test/scxml.test.ts
+++ b/packages/core/test/scxml.test.ts
@@ -176,7 +176,7 @@ const testGroups = {
     'test228.txml',
     'test229.txml',
     'test230.txml',
-    // 'test232.txml', // TODO: not sure
+    'test232.txml',
     // 'test233.txml', // <finalize> not implemented yet
     // 'test234.txml', // <finalize> not implemented yet
     'test235.txml',

--- a/packages/core/test/scxml.test.ts
+++ b/packages/core/test/scxml.test.ts
@@ -148,7 +148,7 @@ const testGroups = {
     'test175.txml',
     'test176.txml',
     // 'test179.txml', // conversion of <content> in <send> not implemented yet
-    // 'test183.txml', idlocation not implemented yet
+    // 'test183.txml', // idlocation not implemented yet
     'test185.txml',
     'test186.txml',
     'test187.txml',

--- a/packages/core/test/scxml.test.ts
+++ b/packages/core/test/scxml.test.ts
@@ -155,7 +155,7 @@ const testGroups = {
     'test189.txml',
     'test190.txml', // note: _sessionid is undefined for expressions
     'test191.txml',
-    // 'test192.txml', // done.invoke inexact event descriptor
+    'test192.txml',
     'test193.txml',
     'test194.txml',
     // 'test198.txml', // origintype not implemented yet
@@ -168,30 +168,30 @@ const testGroups = {
     // 'test210.txml', // sendidexpr not supported yet
     // 'test215.txml', // <invoke typeexpr="...">
     // 'test216.txml', // <invoke srcexpr="...">
-    // 'test220.txml', // done.invoke used as inexact event descriptor
+    'test220.txml',
     // 'test223.txml', // idlocation not implemented yet
-    // 'test224.txml', // done.invoke used as inexact event descriptor
+    // 'test224.txml', // <invoke idlocation="...">
     // 'test225.txml', // unique invokeids generated at invoke time
     // 'test226.txml', // <invoke src="...">
-    // 'test228.txml', // done.invoke used as inexact event descriptor + _event.invokeid not implemented yet
+    'test228.txml',
     'test229.txml',
-    // 'test230.txml', // done.invoke used as inexact event descriptor + SCXML _event properties not implemented yet
-    // 'test232.txml', // done.invoke used as inexact event descriptor
+    'test230.txml',
+    'test232.txml',
     // 'test233.txml', // <finalize> not implemented yet
     // 'test234.txml', // <finalize> not implemented yet
     'test235.txml',
-    // 'test236.txml', // done.invoke used as inexact event descriptor
-    // 'test237.txml', // done.invoke used as inexact event descriptor
-    // 'test239.txml', // done.invoke used as inexact event descriptor
+    'test236.txml',
+    'test237.txml',
+    // 'test239.txml', // <invoke src="...">
     // 'test240.txml', // conversion of namelist not implemented yet
     // 'test241.txml', // conversion of namelist not implemented yet
     // 'test242.txml', // <invoke src="...">
     // 'test243.txml', // conversion of <param> in <scxml> not implemented yet
     // 'test244.txml', // conversion of namelist not implemented yet
     // 'test245.txml', // conversion of namelist not implemented yet
-    // 'test247.txml', // done.invoke used as inexact event descriptor
+    'test247.txml',
     // 'test250.txml', // this is a manual test - we could test it by snapshoting logged valued
-    // 'test252.txml', // done.invoke used as inexact event descriptor
+    'test252.txml',
     // 'test253.txml', // _event.origintype not implemented yet
     // 'test276.txml', // <invoke src="...">
     // 'test277.txml', // illegal expression in datamodel creates unbound variable
@@ -236,7 +236,7 @@ const testGroups = {
     // 'test343.txml', // error.execution when evaluating donedata
     // 'test344.txml', // error in cond expression being treated as false and raises error.execution
     // 'test346.txml', // system variables can't be modified, we don't keep them in datamodel, so it might be hard to run this test
-    // 'test347.txml', // done.invoke used as inexact event descriptor
+    'test347.txml',
     'test348.txml',
     'test349.txml',
     // 'test350.txml', // _sessionid not yet available for expressions
@@ -253,9 +253,9 @@ const testGroups = {
     'test387.txml',
     'test388.txml',
     'test396.txml',
-    // 'test399.txml', // inexact prefix event matching not implemented
-    // 'test401.txml', // inexact "error" event (should be "error.execution")
-    // 'test402.txml', // error.execution when evaluating assign + inexact prefix event matching not implemented
+    'test399.txml',
+    'test401.txml',
+    'test402.txml',
     'test403a.txml',
     'test403b.txml',
     'test403c.txml',
@@ -307,7 +307,7 @@ const testGroups = {
     // 'test527.txml', // conversion of <donedata> not implemented yet
     // 'test528.txml', // conversion of <donedata> not implemented yet + error.execution when evaluating donedata
     // 'test529.txml', // conversion of <donedata> not implemented yet
-    // 'test530.txml', // done.invoke used as inexact event descriptor
+    'test530.txml',
     // 'test531.txml', // Basic HTTP Event I/O processor not implemented
     // 'test532.txml', // Basic HTTP Event I/O processor not implemented
     'test533.txml',
@@ -358,14 +358,15 @@ async function runW3TestToCompletion(machine: MachineNode): Promise<void> {
         nextState = state;
       })
       .onDone(() => {
-        if (nextState.value === 'pass') {
+        // Add 'final' for test230.txml which does not have a 'pass' state
+        if (['final', 'pass'].includes(nextState.value as string)) {
           resolve();
         } else {
           reject(
             new Error(
               `Reached "fail" state with event ${JSON.stringify(
                 nextState.event
-              )}`
+              )} from state ${JSON.stringify(nextState.history?.value)}`
             )
           );
         }
@@ -390,12 +391,16 @@ async function runTestToCompletion(
     clock: new SimulatedClock()
   })
     .onTransition((state) => {
+      // console.log(state._event, state.value);
+
       nextState = state;
     })
     .onDone(() => {
       if (nextState.value === 'fail') {
         throw new Error(
-          `Reached "fail" state with event ${JSON.stringify(nextState.event)}`
+          `Reached "fail" state with event ${JSON.stringify(
+            nextState.event
+          )} from state ${JSON.stringify(nextState.history?.value)}`
         );
       }
       done = true;
@@ -420,14 +425,23 @@ async function runTestToCompletion(
 }
 
 describe('scxml', () => {
+  const onlyTests: string[] = [
+    // e.g., 'test399.txml'
+    // 'test232.txml'
+    'test236.txml'
+  ];
   const testGroupKeys = Object.keys(testGroups);
-  // const testGroupKeys = ['w3c-ecma'];
 
   testGroupKeys.forEach((testGroupName) => {
     const testNames = testGroups[testGroupName];
-    // const testNames = ['test372.txml'];
 
     testNames.forEach((testName) => {
+      const execTest = onlyTests.length
+        ? onlyTests.includes(testName)
+          ? it.only
+          : it.skip
+        : it;
+
       const scxmlSource =
         overrides[testGroupName] &&
         overrides[testGroupName].indexOf(testName) !== -1
@@ -447,7 +461,7 @@ describe('scxml', () => {
         )
       ) as SCIONTest;
 
-      it(`${testGroupName}/${testName}`, async () => {
+      execTest(`${testGroupName}/${testName}`, async () => {
         const machine = toMachine(scxmlDefinition, {
           delimiter: '$'
         });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1508,15 +1508,6 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@jest/types@^24.9.0":
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-24.9.0.tgz#63cb26cb7500d069e5a389441a7c6ab5e909fc59"
-  integrity sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==
-  dependencies:
-    "@types/istanbul-lib-coverage" "^2.0.0"
-    "@types/istanbul-reports" "^1.1.1"
-    "@types/yargs" "^13.0.0"
-
 "@manypkg/cli@^0.16.1":
   version "0.16.2"
   resolved "https://registry.yarnpkg.com/@manypkg/cli/-/cli-0.16.2.tgz#e949583d83fd051d0cb732d24657967b1f81c591"
@@ -2123,10 +2114,10 @@
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-6.2.2.tgz#5c27df09ca39e3c9beb4fae6b95f4d71426df0a9"
   integrity sha512-RxAwYt4rGwK5GyoRwuP0jT6ZHAVTdz2EqgsHmX0PYNjGsko+OeT4WFXXTs/lM3teJUJodM+SNtAL5/pXIJ61IQ==
 
-"@types/stack-utils@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
-  integrity sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==
+"@types/stack-utils@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
+  integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
 
 "@types/stack-utils@^2.0.0":
   version "2.0.0"
@@ -3250,7 +3241,6 @@ babel-preset-current-node-syntax@^0.1.2:
     "@babel/plugin-syntax-object-rest-spread" "^7.8.3"
     "@babel/plugin-syntax-optional-catch-binding" "^7.8.3"
     "@babel/plugin-syntax-optional-chaining" "^7.8.3"
-    "@babel/plugin-syntax-top-level-await" "^7.8.3"
 
 babel-preset-current-node-syntax@^1.0.0:
   version "1.0.1"
@@ -4177,11 +4167,6 @@ commander@2.17.x:
   integrity sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==
 
 commander@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
-  integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
-
-commander@^5.0.0, commander@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
   integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
@@ -6417,13 +6402,6 @@ for-own@^1.0.0:
   dependencies:
     for-in "^1.0.1"
 
-for-own@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/for-own/-/for-own-1.0.0.tgz#c63332f415cedc4b04dbfe70cf836494c53cb44b"
-  integrity sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=
-  dependencies:
-    for-in "^1.0.1"
-
 foreach@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
@@ -6768,17 +6746,6 @@ global-modules@^1.0.0:
     global-prefix "^1.0.1"
     is-windows "^1.0.1"
     resolve-dir "^1.0.0"
-
-global-prefix@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/global-prefix/-/global-prefix-1.0.2.tgz#dbf743c6c14992593c655568cb66ed32c0122ebe"
-  integrity sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=
-  dependencies:
-    expand-tilde "^2.0.2"
-    homedir-polyfill "^1.0.1"
-    ini "^1.3.4"
-    is-windows "^1.0.1"
-    which "^1.2.14"
 
 global-prefix@^1.0.1:
   version "1.0.2"
@@ -8375,6 +8342,11 @@ jest-get-type@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-24.9.0.tgz#1684a0c8a50f2e4901b6644ae861f579eed2ef0e"
   integrity sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==
+
+jest-get-type@^25.2.6:
+  version "25.2.6"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-25.2.6.tgz#0b0a32fab8908b44d508be81681487dbabb8d877"
+  integrity sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==
 
 jest-get-type@^26.3.0:
   version "26.3.0"
@@ -9983,15 +9955,6 @@ minimist-options@^3.0.1:
   dependencies:
     arrify "^1.0.1"
     is-plain-obj "^1.1.0"
-
-minimist-options@^4.0.2:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/minimist-options/-/minimist-options-4.1.0.tgz#c0655713c53a8a2ebd77ffa247d342c40f010619"
-  integrity sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==
-  dependencies:
-    arrify "^1.0.1"
-    is-plain-obj "^1.1.0"
-    kind-of "^6.0.3"
 
 minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
@@ -12010,7 +11973,7 @@ react-dom@^16.12.0:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
-react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
+react-is@^16.12.0, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -12356,14 +12319,6 @@ resolve-dir@^1.0.0, resolve-dir@^1.0.1:
     expand-tilde "^2.0.0"
     global-modules "^1.0.0"
 
-resolve-dir@^1.0.0, resolve-dir@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/resolve-dir/-/resolve-dir-1.0.1.tgz#79a40644c362be82f26effe739c9bb5382046f43"
-  integrity sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=
-  dependencies:
-    expand-tilde "^2.0.0"
-    global-modules "^1.0.0"
-
 resolve-from@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-2.0.0.tgz#9480ab20e94ffa1d9e80a804c7ea147611966b57"
@@ -12697,20 +12652,6 @@ send@0.17.1:
     on-finished "~2.3.0"
     range-parser "~1.2.1"
     statuses "~1.5.0"
-
-serialize-javascript@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-3.1.0.tgz#8bf3a9170712664ef2561b44b691eafe399214ea"
-  integrity sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==
-  dependencies:
-    randombytes "^2.1.0"
-
-serialize-javascript@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-4.0.0.tgz#b525e1238489a5ecfc42afacc3fe99e666f4b1aa"
-  integrity sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==
-  dependencies:
-    randombytes "^2.1.0"
 
 serialize-javascript@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
This PR adds support for prefix matching with wildcards (and without wildcards for SCXML machines only):

```js
const machine = createMachine({
  // ...
  on: {
    // This transition accepts event types like:
    // "mouse", "mouse.click", "mouse.move.out", etc.
    // but not events like "mouseclick"
    'mouse.*': {/* ... */}
  }
});
```

https://github.com/davidkpiano/xstate/projects/1#card-52117183