### PR TITLE
`machine.resolveState(state)` calls should resolve to the correct value of `.done` property now

### DIFF
--- a/.changeset/quick-pets-collect.md
+++ b/.changeset/quick-pets-collect.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+`machine.resolveState(state)` calls should resolve to the correct value of `.done` property now.

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -692,7 +692,8 @@ class StateNode<
     return new State({
       ...state,
       value: this.resolve(state.value),
-      configuration
+      configuration,
+      done: isInFinalState(configuration, this)
     });
   }
 

--- a/packages/core/test/machine.test.ts
+++ b/packages/core/test/machine.test.ts
@@ -1,4 +1,4 @@
-import { Machine, interpret } from '../src/index';
+import { Machine, interpret, createMachine } from '../src/index';
 import { State } from '../src/State';
 
 const pedestrianStates = {
@@ -281,6 +281,25 @@ describe('machine', () => {
       const resolvedState = resolveMachine.resolveState(tempState);
 
       expect(resolvedState.nextEvents.sort()).toEqual(['TO_BAR', 'TO_TWO']);
+    });
+
+    it('should resolve .done', () => {
+      const machine = createMachine({
+        initial: 'foo',
+        states: {
+          foo: {
+            on: { NEXT: 'bar' }
+          },
+          bar: {
+            type: 'final'
+          }
+        }
+      });
+      const tempState = State.from<any>('bar');
+
+      const resolvedState = machine.resolveState(tempState);
+
+      expect(resolvedState.done).toBe(true);
     });
   });
 


### PR DESCRIPTION
fixes https://github.com/davidkpiano/xstate/issues/1814