### PR TITLE
Improved `.matches(value)` inference for typestates containing union types as values

### DIFF
--- a/.changeset/breezy-beds-trade.md
+++ b/.changeset/breezy-beds-trade.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Improved `.matches(value)` inference for typestates containing union types as values.

--- a/packages/core/src/Actor.ts
+++ b/packages/core/src/Actor.ts
@@ -47,7 +47,7 @@ export function createNullActor(id: string): Actor {
  */
 export function createInvocableActor<TC, TE extends EventObject>(
   invokeDefinition: InvokeDefinition<TC, TE>,
-  machine: StateMachine<TC, any, TE>,
+  machine: StateMachine<TC, any, TE, any>,
   context: TC,
   _event: SCXML.Event<TE>
 ): Actor {

--- a/packages/core/src/State.ts
+++ b/packages/core/src/State.ts
@@ -291,7 +291,11 @@ export class State<
   public matches<TSV extends TTypestate['value']>(
     parentStateValue: TSV
   ): this is State<
-    (TTypestate extends { value: TSV } ? TTypestate : never)['context'],
+    (TTypestate extends any
+      ? { value: TSV; context: any } extends TTypestate
+        ? TTypestate
+        : never
+      : never)['context'],
     TEvent,
     TStateSchema,
     TTypestate

--- a/packages/core/src/State.ts
+++ b/packages/core/src/State.ts
@@ -61,7 +61,7 @@ export function isState<
 
 export function bindActionToState<TC, TE extends EventObject>(
   action: ActionObject<TC, TE>,
-  state: State<TC, TE>
+  state: State<TC, TE, any, any>
 ): ActionObject<TC, TE> {
   const { exec } = action;
   const boundAction: ActionObject<TC, TE> = {
@@ -113,7 +113,7 @@ export class State<
   /**
    * The enabled state nodes representative of the state value.
    */
-  public configuration: Array<StateNode<TContext, any, TEvent>>;
+  public configuration: Array<StateNode<TContext, any, TEvent, any>>;
   /**
    * The next events that will cause a transition from the current state.
    */
@@ -133,9 +133,9 @@ export class State<
    * @param context
    */
   public static from<TC, TE extends EventObject = EventObject>(
-    stateValue: State<TC, TE> | StateValue,
+    stateValue: State<TC, TE, any, any> | StateValue,
     context?: TC | undefined
-  ): State<TC, TE> {
+  ): State<TC, TE, any, any> {
     if (stateValue instanceof State) {
       if (stateValue.context !== context) {
         return new State<TC, TE>({

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -578,7 +578,7 @@ export function choose<TContext, TEvent extends EventObject>(
 }
 
 export function resolveActions<TContext, TEvent extends EventObject>(
-  machine: StateNode<TContext, any, TEvent>,
+  machine: StateNode<TContext, any, TEvent, any>,
   currentState: State<TContext, TEvent> | undefined,
   currentContext: TContext,
   _event: SCXML.Event<TEvent>,

--- a/packages/core/src/devTools.ts
+++ b/packages/core/src/devTools.ts
@@ -1,7 +1,7 @@
 import { Interpreter } from '.';
 import { IS_PRODUCTION } from './environment';
+import { AnyInterpreter } from './types';
 
-type AnyInterpreter = Interpreter<any, any, any>;
 type ServiceListener = (service: AnyInterpreter) => void;
 
 export interface XStateDevInterface {

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -27,7 +27,8 @@ import {
   Observer,
   Spawnable,
   Typestate,
-  AnyEventObject
+  AnyEventObject,
+  AnyInterpreter
 } from './types';
 import { State, bindActionToState, isState } from './State';
 import * as actionTypes from './actionTypes';
@@ -685,7 +686,7 @@ export class Interpreter<
 
     if ('machine' in target) {
       // Send SCXML events to machines
-      (target as Interpreter<any, any, any>).send({
+      (target as AnyInterpreter).send({
         ...event,
         name:
           event.name === actionTypes.error ? `${error(this.id)}` : event.name,

--- a/packages/core/src/serviceScope.ts
+++ b/packages/core/src/serviceScope.ts
@@ -1,13 +1,13 @@
-import { Interpreter } from './interpreter';
+import { AnyInterpreter } from './types';
 
 /**
  * Maintains a stack of the current service in scope.
  * This is used to provide the correct service to spawn().
  */
 
-const serviceStack = [] as Array<Interpreter<any, any, any> | undefined>;
+const serviceStack = [] as Array<AnyInterpreter | undefined>;
 
-export const provide = <T, TService extends Interpreter<any, any, any>>(
+export const provide = <T, TService extends AnyInterpreter>(
   service: TService | undefined,
   fn: (service: TService | undefined) => T
 ) => {
@@ -17,6 +17,6 @@ export const provide = <T, TService extends Interpreter<any, any, any>>(
   return result;
 };
 
-export const consume = <T, TService extends Interpreter<any, any, any>>(
+export const consume = <T, TService extends AnyInterpreter>(
   fn: (service: TService) => T
 ) => fn(serviceStack[serviceStack.length - 1] as TService);

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -10,7 +10,7 @@ type AdjList<TC, TE extends EventObject> = Map<
   Array<StateNode<TC, any, TE>>
 >;
 
-export const isLeafNode = (stateNode: StateNode<any, any, any>) =>
+export const isLeafNode = (stateNode: StateNode<any, any, any, any>) =>
   stateNode.type === 'atomic' || stateNode.type === 'final';
 
 export function getChildren<TC, TE extends EventObject>(
@@ -20,8 +20,8 @@ export function getChildren<TC, TE extends EventObject>(
 }
 
 export function getAllStateNodes<TC, TE extends EventObject>(
-  stateNode: StateNode<TC, any, TE>
-): Array<StateNode<TC, any, TE>> {
+  stateNode: StateNode<TC, any, TE, any>
+): Array<StateNode<TC, any, TE, any>> {
   const stateNodes = [stateNode];
 
   if (isLeafNode(stateNode)) {
@@ -34,9 +34,9 @@ export function getAllStateNodes<TC, TE extends EventObject>(
 }
 
 export function getConfiguration<TC, TE extends EventObject>(
-  prevStateNodes: Iterable<StateNode<TC, any, TE>>,
-  stateNodes: Iterable<StateNode<TC, any, TE>>
-): Iterable<StateNode<TC, any, TE>> {
+  prevStateNodes: Iterable<StateNode<TC, any, TE, any>>,
+  stateNodes: Iterable<StateNode<TC, any, TE, any>>
+): Iterable<StateNode<TC, any, TE, any>> {
   const prevConfiguration = new Set(prevStateNodes);
   const prevAdjList = getAdjList(prevConfiguration);
 
@@ -149,7 +149,7 @@ export function getAdjList<TC, TE extends EventObject>(
 }
 
 export function getValue<TC, TE extends EventObject>(
-  rootNode: StateNode<TC, any, TE>,
+  rootNode: StateNode<TC, any, TE, any>,
   configuration: Configuration<TC, TE>
 ): StateValue {
   const config = getConfiguration([rootNode], configuration);
@@ -176,8 +176,8 @@ export function nextEvents<TC, TE extends EventObject>(
 }
 
 export function isInFinalState<TC, TE extends EventObject>(
-  configuration: Array<StateNode<TC, any, TE>>,
-  stateNode: StateNode<TC, any, TE>
+  configuration: Array<StateNode<TC, any, TE, any>>,
+  stateNode: StateNode<TC, any, TE, any>
 ): boolean {
   if (stateNode.type === 'compound') {
     return getChildren(stateNode).some(

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -659,7 +659,7 @@ export interface MachineOptions<TContext, TEvent extends EventObject> {
   /**
    * @private
    */
-  _parent?: StateNode<TContext, any, TEvent>;
+  _parent?: StateNode<TContext, any, TEvent, any>;
   /**
    * @private
    */
@@ -742,13 +742,13 @@ export interface ActivityMap {
 // tslint:disable-next-line:class-name
 export interface StateTransition<TContext, TEvent extends EventObject> {
   transitions: Array<TransitionDefinition<TContext, TEvent>>;
-  configuration: Array<StateNode<TContext, any, TEvent>>;
-  entrySet: Array<StateNode<TContext, any, TEvent>>;
-  exitSet: Array<StateNode<TContext, any, TEvent>>;
+  configuration: Array<StateNode<TContext, any, TEvent, any>>;
+  entrySet: Array<StateNode<TContext, any, TEvent, any>>;
+  exitSet: Array<StateNode<TContext, any, TEvent, any>>;
   /**
    * The source state that preceded the transition.
    */
-  source: State<TContext> | undefined;
+  source: State<TContext, any, any, any> | undefined;
   actions: Array<ActionObject<TContext, TEvent>>;
 }
 
@@ -1090,7 +1090,7 @@ export interface SCXMLEventMeta<TEvent extends EventObject> {
 }
 
 export interface StateMeta<TContext, TEvent extends EventObject> {
-  state: State<TContext, TEvent>;
+  state: State<TContext, TEvent, any, any>;
   _event: SCXML.Event<TEvent>;
 }
 
@@ -1138,7 +1138,7 @@ export interface InterpreterOptions {
   execute: boolean;
   clock: Clock;
   logger: (...args: any[]) => void;
-  parent?: Interpreter<any, any, any>;
+  parent?: AnyInterpreter;
   /**
    * If `true`, defers processing of sent events until the service
    * is initialized (`.start()`). Otherwise, an error will be thrown
@@ -1274,3 +1274,5 @@ export type ActorRefFrom<
       state: State<TContext, TEvent, any, TTypestate>;
     }
   : never;
+
+export type AnyInterpreter = Interpreter<any, any, any, any>;

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -641,7 +641,7 @@ export function reportUnhandledExceptionOnInvocation(
 }
 
 export function evaluateGuard<TContext, TEvent extends EventObject>(
-  machine: StateNode<TContext, any, TEvent>,
+  machine: StateNode<TContext, any, TEvent, any>,
   guard: Guard<TContext, TEvent>,
   context: TContext,
   _event: SCXML.Event<TEvent>,


### PR DESCRIPTION
reported on Discord: https://discord.com/channels/795785288994652170/799416943324823592/801198150894223411
