### PR TITLE
@xstate/fsm: Add internal transition

### DIFF
--- a/.changeset/brave-lies-retire.md
+++ b/.changeset/brave-lies-retire.md
@@ -1,0 +1,5 @@
+---
+'@xstate/fsm': minor
+---
+
+Adds internal transitions via `internal` attribute

--- a/docs/packages/xstate-fsm/index.md
+++ b/docs/packages/xstate-fsm/index.md
@@ -151,6 +151,7 @@ Object syntax:
 - `target?` (string) - the state name to transition to.
 - `actions?` (Action | Action[]) - the [action(s)](#action-config) to execute when this transition is taken.
 - `cond?` (Guard) - the condition (predicate function) to test. If it returns `true`, the transition will be taken.
+- `internal?` (boolean) - if `true` marks transition as internal. Defaults to `false`. An internal transition is one that does not exit its state node.
 
 ### Machine options
 

--- a/packages/xstate-fsm/src/index.ts
+++ b/packages/xstate-fsm/src/index.ts
@@ -177,7 +177,12 @@ export function createMachine<
             return createUnchangedState(value, context);
           }
 
-          const { target = value, actions = [], cond = () => true } =
+          const {
+            target = value,
+            actions = [],
+            cond = () => true,
+            internal = false
+          } =
             typeof transition === 'string'
               ? { target: transition }
               : transition;
@@ -185,7 +190,11 @@ export function createMachine<
           if (cond(context, eventObject)) {
             const nextStateConfig = fsmConfig.states[target];
             const allActions = ([] as any[])
-              .concat(stateConfig.exit, actions, nextStateConfig.entry)
+              .concat(
+                internal ? [] : stateConfig.exit,
+                actions,
+                internal ? [] : nextStateConfig.entry
+              )
               .filter((a) => a)
               .map<StateMachine.ActionObject<TContext, TEvent>>((action) =>
                 toActionObject(action, (machine as any)._options.actions)

--- a/packages/xstate-fsm/test/fsm.test.ts
+++ b/packages/xstate-fsm/test/fsm.test.ts
@@ -223,6 +223,7 @@ describe('@xstate/fsm', () => {
               actions: assign({ didAction: true })
             },
             INTERNAL: {
+              target: 'initial',
               actions: assign({ didAction: true }),
               internal: true
             }
@@ -230,6 +231,7 @@ describe('@xstate/fsm', () => {
         }
       }
     };
+
     it('should dispatch entry, exit and actions if internal not set', () => {
       const next = createMachine<
         InternalContext,
@@ -240,6 +242,7 @@ describe('@xstate/fsm', () => {
       expect(next.context.didExit).toBeTruthy();
       expect(next.context.didAction).toBeTruthy();
     });
+
     it('should dispatch actions only if internal is true', () => {
       const next = createMachine<
         InternalContext,


### PR DESCRIPTION
Adds internal state transitions to @xstate/fsm via `internal` attribute

Excludes internal transition definition via `{target: undefined}` or omitting `target` to avoid a backward breaking change. Currently fsm produces an external transition if undefined target