### PR TITLE
Change import in Getting Started

### DIFF
--- a/docs/guides/start.md
+++ b/docs/guides/start.md
@@ -6,24 +6,24 @@ Suppose we want to model a [Promise](https://developer.mozilla.org/en-US/docs/We
 npm install xstate --save
 ```
 
-Then, in your project, import `Machine`, which is a factory function that creates a state machine or statechart:
+Then, in your project, import `createMachine`, which is a factory function that creates a state machine or statechart:
 
 ```js
-import { Machine } from 'xstate';
+import { createMachine } from 'xstate';
 
-const promiseMachine = Machine(/* ... */);
+const promiseMachine = createMachine(/* ... */);
 ```
 
-We'll pass the [machine configuration](./machines.md#configuration) inside of `Machine(...)`. Since this is a [hierarchical machine](./hierarchical.md), we need to provide the:
+We'll pass the [machine configuration](./machines.md#configuration) inside of `createMachine(...)`. Since this is a [hierarchical machine](./hierarchical.md), we need to provide the:
 
 - `id` - to identify the machine and set the base string for its child state node IDs
 - `initial` - to specify the initial state node this machine should be in
 - `states` - to define each of the child states:
 
 ```js
-import { Machine } from 'xstate';
+import { createMachine } from 'xstate';
 
-const promiseMachine = Machine({
+const promiseMachine = createMachine({
   id: 'promise',
   initial: 'pending',
   states: {
@@ -37,9 +37,9 @@ const promiseMachine = Machine({
 Then, we need to add [transitions](./transitions.md) to the state nodes and mark the `resolved` and `rejected` state nodes as [final state nodes](./final.md) since the promise machine terminates running once it reaches those states:
 
 ```js
-import { Machine } from 'xstate';
+import { createMachine } from 'xstate';
 
-const promiseMachine = Machine({
+const promiseMachine = createMachine({
   id: 'promise',
   initial: 'pending',
   states: {
@@ -62,9 +62,9 @@ const promiseMachine = Machine({
 To [interpret](./interpretation.md) the machine and make it run, we need to add an interpreter. This creates a service:
 
 ```js
-import { Machine, interpret } from 'xstate';
+import { createMachine, interpret } from 'xstate';
 
-const promiseMachine = Machine({
+const promiseMachine = createMachine({
   /* ... */
 });
 
@@ -80,6 +80,9 @@ promiseService.send('RESOLVE');
 // => 'resolved'
 ```
 
-You can also copy/paste the `Machine(...)` code and [visualize it on XState Viz](https://xstate.js.org/viz):
+You can also visualize the code by changing `createMachine` to `Machine` and copy-pasting it into [the XState Viz](https://xstate.js.org/viz):
+
+::: tip Why do I have to change `createMachine` to `Machine`? The Xstate Viz uses an older version of Xstate. We're going to update it soon; for now just know that `createMachine` is the way to go, but you'll have to swap it out for `Machine` to use some of the tooling.
+:::
 
 <iframe src="https://xstate.js.org/viz/?gist=9e4476d6312ac1bb29938d6c5e7f8f84&embed=1"></iframe>


### PR DESCRIPTION
This PR changes the import in the Getting Started guide to `createMachine` (it's `Machine` right now) and adds a note about the fact that the Xstate Viz only works with `Machine`.

For me, one of Xstate's learning curves is that there's a few ways to do things, and sometimes you're not sure if what you're doing's better or worse, or if it makes no difference. In this case I'm pretty sure `createMachine` is the new way of doing things, and I'd rather newcomers know that upfront, then warn them about the Xstate Viz.

I know you wanted more beginner-friendly tutorials, but I picked this as my first PR just to get started 'cause it seemed pretty easy. @davidkpiano thoughts? Thanks!