### PR TITLE
[@xstate/fsm] Add support for targetless transitions

### DIFF
--- a/.changeset/afraid-eggs-wonder.md
+++ b/.changeset/afraid-eggs-wonder.md
@@ -1,5 +1,5 @@
 ---
-'@xstate/fsm': patch
+'@xstate/fsm': minor
 ---
 
 Transitions with `undefined` targets will no longer exit and re-enter the state, which means that `exit` and `entry` actions will not be executed:

--- a/.changeset/afraid-eggs-wonder.md
+++ b/.changeset/afraid-eggs-wonder.md
@@ -1,0 +1,20 @@
+---
+'@xstate/fsm': patch
+---
+
+Transitions with `undefined` targets will no longer exit and re-enter the state, which means that `exit` and `entry` actions will not be executed:
+
+```js
+// ...
+someState: {
+  entry: [/* ... */],
+  exit: [/* ... */],
+  on: {
+    SOME_EVENT: {
+      // undefined target - will not exit/re-enter
+      actions: [/* ... */]
+    }
+  }
+}
+// ...
+```

--- a/packages/xstate-fsm/src/index.ts
+++ b/packages/xstate-fsm/src/index.ts
@@ -184,7 +184,7 @@ export function createMachine<
               ? { target: transition }
               : transition;
 
-          const isInternal = target === undefined;
+          const isTargetless = target === undefined;
 
           if (cond(context, eventObject)) {
             const nextStateConfig = fsmConfig.states[target ?? value];

--- a/packages/xstate-fsm/src/index.ts
+++ b/packages/xstate-fsm/src/index.ts
@@ -188,17 +188,14 @@ export function createMachine<
 
           if (cond(context, eventObject)) {
             const nextStateConfig = fsmConfig.states[target ?? value];
-            const allActions = ([] as any[])
-              // Only add exit and entry actions
-              .concat(
-                !isInternal ? stateConfig.exit : [],
-                actions,
-                !isInternal ? nextStateConfig.entry : []
-              )
-              .filter((a) => a)
-              .map<StateMachine.ActionObject<TContext, TEvent>>((action) =>
-                toActionObject(action, (machine as any)._options.actions)
-              );
+            const allActions = (isTargetless
+              ? toArray(actions)
+              : ([] as any[])
+                  .concat(stateConfig.exit, actions, nextStateConfig.entry)
+                  .filter((a) => a)
+            ).map<StateMachine.ActionObject<TContext, TEvent>>((action) =>
+              toActionObject(action, (machine as any)._options.actions)
+            );
 
             const [nonAssignActions, nextContext, assigned] = handleActions(
               allActions,

--- a/packages/xstate-fsm/src/index.ts
+++ b/packages/xstate-fsm/src/index.ts
@@ -150,13 +150,13 @@ export function createMachine<
     },
     transition: (
       state: string | StateMachine.State<TContext, TEvent, TState>,
-      event: string | (Record<string, any> & { type: string })
+      event: TEvent | TEvent['type']
     ): StateMachine.State<TContext, TEvent, TState> => {
       const { value, context } =
         typeof state === 'string'
           ? { value: state, context: fsmConfig.context! }
           : state;
-      const eventObject = toEventObject(event);
+      const eventObject = toEventObject<TEvent>(event);
       const stateConfig = fsmConfig.states[value];
 
       if (!IS_PRODUCTION) {
@@ -170,22 +170,31 @@ export function createMachine<
       }
 
       if (stateConfig.on) {
-        const transitions = toArray(stateConfig.on[eventObject.type]);
+        const transitions: Array<
+          StateMachine.Transition<TContext, TEvent>
+        > = toArray(stateConfig.on[eventObject.type]);
 
         for (const transition of transitions) {
           if (transition === undefined) {
             return createUnchangedState(value, context);
           }
 
-          const { target = value, actions = [], cond = () => true } =
+          const { target, actions = [], cond = () => true } =
             typeof transition === 'string'
               ? { target: transition }
               : transition;
 
+          const isInternal = target === undefined;
+
           if (cond(context, eventObject)) {
-            const nextStateConfig = fsmConfig.states[target];
+            const nextStateConfig = fsmConfig.states[target ?? value];
             const allActions = ([] as any[])
-              .concat(stateConfig.exit, actions, nextStateConfig.entry)
+              // Only add exit and entry actions
+              .concat(
+                !isInternal ? stateConfig.exit : [],
+                actions,
+                !isInternal ? nextStateConfig.entry : []
+              )
               .filter((a) => a)
               .map<StateMachine.ActionObject<TContext, TEvent>>((action) =>
                 toActionObject(action, (machine as any)._options.actions)
@@ -197,13 +206,15 @@ export function createMachine<
               eventObject
             );
 
+            const resolvedTarget = target ?? value;
+
             return {
-              value: target,
+              value: resolvedTarget,
               context: nextContext,
               actions: nonAssignActions,
               changed:
                 target !== value || nonAssignActions.length > 0 || assigned,
-              matches: createMatcher(target)
+              matches: createMatcher(resolvedTarget)
             };
           }
         }

--- a/packages/xstate-fsm/test/fsm.test.ts
+++ b/packages/xstate-fsm/test/fsm.test.ts
@@ -414,4 +414,30 @@ describe('interpreter', () => {
 
     service.send('CHANGE');
   });
+
+  it('should not re-execute exit/entry actions for transitions with undefined targets', () => {
+    const machine = createMachine({
+      initial: 'test',
+      states: {
+        test: {
+          entry: ['entry'],
+          exit: ['exit'],
+          on: {
+            EVENT: {
+              // undefined target
+              actions: ['action']
+            }
+          }
+        }
+      }
+    });
+
+    const { initialState } = machine;
+
+    expect(initialState.actions.map((a) => a.type)).toEqual(['entry']);
+
+    const nextState = machine.transition(initialState, 'EVENT');
+
+    expect(nextState.actions.map((a) => a.type)).toEqual(['action']);
+  });
 });


### PR DESCRIPTION
This PR adds support for transitions with `undefined` targets, which will not exit/re-enter the state.

```js
// ...
someState: {
  entry: [/* ... */],
  exit: [/* ... */],
  on: {
    SOME_EVENT: {
      // undefined target - will not exit/re-enter
      actions: [/* ... */]
    }
  }
}
// ...
```