### PR TITLE
Move links to GH/Discussions & Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Read [📽 the slides](http://slides.com/davidkhourshid/finite-state-machines) (
 - [The World of Statecharts](https://statecharts.github.io/) by Erik Mogensen
 - [Pure UI](https://rauchg.com/2015/pure-ui) by Guillermo Rauch
 - [Pure UI Control](https://medium.com/@asolove/pure-ui-control-ac8d1be97a8d) by Adam Solove
-- [Spectrum - Statecharts Community](https://spectrum.chat/statecharts)
+- [Spectrum - Statecharts Community](https://spectrum.chat/statecharts) (For XState specific questions, please use the [GitHub Discussions](https://github.com/davidkpiano/xstate/discussions))
 
 ## Finite State Machines
 

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -19,7 +19,7 @@ module.exports = {
     nav: [
       { text: 'API', link: 'https://xstate.js.org/api' },
       { text: 'Visualizer', link: 'https://xstate.js.org/viz' },
-      { text: 'Chat', link: 'https://gitter.im/statecharts/statecharts' },
+      { text: 'Discord', link: 'https://discord.gg/xtWgFTgvNV' },
       {
         text: 'Community',
         link: 'https://github.com/davidkpiano/xstate/discussions'

--- a/docs/README.md
+++ b/docs/README.md
@@ -157,7 +157,7 @@ Read [📽 the slides](http://slides.com/davidkhourshid/finite-state-machines) (
 - [The World of Statecharts](https://statecharts.github.io/) by Erik Mogensen
 - [Pure UI](https://rauchg.com/2015/pure-ui) by Guillermo Rauch
 - [Pure UI Control](https://medium.com/@asolove/pure-ui-control-ac8d1be97a8d) by Adam Solove
-- [Spectrum - Statecharts Community](https://spectrum.chat/statecharts)
+- [Spectrum - Statecharts Community](https://spectrum.chat/statecharts) (For XState specific questions, please use the [GitHub Discussions](https://github.com/davidkpiano/xstate/discussions))
 
 ## Finite State Machines
 

--- a/docs/about/goals.md
+++ b/docs/about/goals.md
@@ -25,6 +25,6 @@ If you're deciding if you should use XState, [John Yanarella](https://github.com
 >
 > The front-end development world is the wild west, and it could stand to learn from what other engineering disciplines have known and employed for years.
 >
-> 3. It has **passed a critical threshold of maturity** as of version 4, particularly given the introduction of [the visualizer](https://statecharts.github.io/xstate-viz). And that's just the tip of the iceberg of where it could go next, as it (and [its community](https://spectrum.chat/statecharts)) introduces tooling that takes advantage of how a statechart can be visualized, analyzed, and tested.
+> 3. It has **passed a critical threshold of maturity** as of version 4, particularly given the introduction of [the visualizer](https://statecharts.github.io/xstate-viz). And that's just the tip of the iceberg of where it could go next, as it (and [its community](https://github.com/davidkpiano/xstate/discussions)) introduces tooling that takes advantage of how a statechart can be visualized, analyzed, and tested.
 >
 > 4. The **community** that is growing around it and the awareness it is bringing to finite state machines and statecharts. If you read back through this gitter history, there's a wealth of links to research papers, other FSM and Statechart implementations, etc. that have been collected by [Erik Mogensen](https://twitter.com/mogsie) over at [statecharts.github.io](https://statecharts.github.io).

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -83,7 +83,7 @@ Read [📽 the slides](http://slides.com/davidkhourshid/finite-state-machines) (
 - [The World of Statecharts](https://statecharts.github.io/) by Erik Mogensen
 - [Pure UI](https://rauchg.com/2015/pure-ui) by Guillermo Rauch
 - [Pure UI Control](https://medium.com/@asolove/pure-ui-control-ac8d1be97a8d) by Adam Solove
-- [Spectrum - Statecharts Community](https://spectrum.chat/statecharts)
+- [Spectrum - Statecharts Community](https://spectrum.chat/statecharts) (For XState specific questions, please use the [GitHub Discussions](https://github.com/davidkpiano/xstate/discussions))
 
 ## Finite State Machines
 


### PR DESCRIPTION
Either notice Discussions is for XState, not Spectrum or switch Gitter to Discord.

However I can **not** find the source for https://xstate.js.org/  Someone how has access to the landing page source needs to change it please.