### PR TITLE
Fixes 'final' state node names not showing in test plan description

### DIFF
--- a/.changeset/tall-olives-shop.md
+++ b/.changeset/tall-olives-shop.md
@@ -1,0 +1,5 @@
+---
+'@xstate/test': patch
+---
+
+Fixes issue where 'final' state node names were not shown in test plan description

--- a/packages/xstate-test/src/index.ts
+++ b/packages/xstate-test/src/index.ts
@@ -355,7 +355,7 @@ function getDescription<T, TContext>(state: State<TContext, any>): string {
     state.context === undefined ? '' : `(${JSON.stringify(state.context)})`;
 
   const stateStrings = state.configuration
-    .filter((sn) => sn.type === 'atomic')
+    .filter((sn) => sn.type === 'atomic' || sn.type === 'final')
     .map(({ id }) => {
       const meta = state.meta[id] as TestMeta<T, TContext>;
       if (!meta) {

--- a/packages/xstate-test/test/index.test.ts
+++ b/packages/xstate-test/test/index.test.ts
@@ -554,7 +554,10 @@ describe('plan description', () => {
     context: { count: 0 },
     states: {
       atomic: {
-        on: { NEXT: 'compound' }
+        on: { NEXT: 'compound', DONE: 'final' }
+      },
+      final: {
+        type: 'final'
       },
       compound: {
         initial: 'child',
@@ -604,6 +607,7 @@ describe('plan description', () => {
       Array [
         "reaches state: \\"#test.atomic\\" ({\\"count\\":0})",
         "reaches state: \\"#test.compound.child\\" ({\\"count\\":0})",
+        "reaches state: \\"#test.final\\" ({\\"count\\":0})",
         "reaches state: \\"child with meta\\" ({\\"count\\":0})",
         "reaches states: \\"#test.parallel.one\\", \\"two description\\" ({\\"count\\":0})",
         "reaches state: \\"noMetaDescription\\" ({\\"count\\":0})",


### PR DESCRIPTION
Fixes an issue where `'final'` state nodes were not showing up in the test plan description. For example, given the state node `success: { type: 'final' }`, the description was

```
 reaches states:  ({ some_context_val: 0 })
 ```
 
The description is now:

```
 reaches state: "success"  ({ some_context_val: 0 })
 ```