### PR TITLE
add typestate type to service returned from react/fsm useMachine

### DIFF
--- a/.changeset/fifty-bears-smash.md
+++ b/.changeset/fifty-bears-smash.md
@@ -1,0 +1,5 @@
+---
+'@xstate/react': patch
+---
+
+Fix typing of the service returned from the fsm useMachine hook by passing it Typestate

--- a/packages/xstate-react/src/fsm.ts
+++ b/packages/xstate-react/src/fsm.ts
@@ -36,8 +36,8 @@ export function useMachine<
   }
 ): [
   StateMachine.State<TContext, TEvent, TState>,
-  StateMachine.Service<TContext, TEvent>['send'],
-  StateMachine.Service<TContext, TEvent>
+  StateMachine.Service<TContext, TEvent, TState>['send'],
+  StateMachine.Service<TContext, TEvent, TState>
 ] {
   if (process.env.NODE_ENV !== 'production') {
     const [initialMachine] = useState(stateMachine);
@@ -88,11 +88,9 @@ export function useService<
   StateMachine.Service<TContext, TEvent, TState>['send'],
   StateMachine.Service<TContext, TEvent, TState>
 ] {
-  const subscription: Subscription<StateMachine.State<
-    TContext,
-    TEvent,
-    TState
-  >> = useMemo(() => {
+  const subscription: Subscription<
+    StateMachine.State<TContext, TEvent, TState>
+  > = useMemo(() => {
     let currentState = getServiceState(service);
 
     return {


### PR DESCRIPTION
This PR stems from the discussion I started here: https://github.com/davidkpiano/xstate/discussions/1944.

I was able to create a failing test and I confirmed that passing the Typestate to the returned service from `useMachine` fixes the issue.