### PR TITLE
Fixed @xstate/react UMD build by redeclaring toObserver

### DIFF
--- a/.changeset/unlucky-schools-arrive.md
+++ b/.changeset/unlucky-schools-arrive.md
@@ -1,0 +1,5 @@
+---
+'@xstate/react': patch
+---
+
+Fixed an issue with `toObserver` being internally imported from `xstate/lib/utils` which has broken UMD build and the declared peer dep contract.

--- a/packages/xstate-react/src/useInterpret.ts
+++ b/packages/xstate-react/src/useInterpret.ts
@@ -11,11 +11,30 @@ import {
   Typestate,
   Observer
 } from 'xstate';
-import { toObserver } from 'xstate/lib/utils';
 import { MaybeLazy } from './types';
 import useConstant from './useConstant';
 import { UseMachineOptions } from './useMachine';
 import { useReactEffectActions } from './useReactEffectActions';
+
+// copied from core/src/utils.ts
+// it avoids a breaking change between this package and XState which is its peer dep
+function toObserver<T>(
+  nextHandler: Observer<T> | ((value: T) => void),
+  errorHandler?: (error: any) => void,
+  completionHandler?: () => void
+): Observer<T> {
+  if (typeof nextHandler === 'object') {
+    return nextHandler;
+  }
+
+  const noop = () => void 0;
+
+  return {
+    next: nextHandler,
+    error: errorHandler || noop,
+    complete: completionHandler || noop
+  };
+}
 
 export function useInterpret<
   TContext,


### PR DESCRIPTION
I haven't tested this in full but it should fix the reported problem.

Fixes https://github.com/davidkpiano/xstate/issues/1948