### PR TITLE
[core] Add schema

### DIFF
--- a/.changeset/chilled-windows-destroy.md
+++ b/.changeset/chilled-windows-destroy.md
@@ -46,9 +46,7 @@ import { createSchema, createMachine } from 'xstate';
 // Both `context` and `events` are inferred in the rest of the machine!
 const machine = createMachine({
   schema: {
-    context: createSchema<{ count: number }>({
-      // ...
-    }),
+    context: createSchema<{ count: number }>(),
     // No arguments necessary
     events: createSchema<{ type: 'FOO' } | { type: 'BAR' }>()
   }

--- a/.changeset/chilled-windows-destroy.md
+++ b/.changeset/chilled-windows-destroy.md
@@ -1,0 +1,57 @@
+---
+'xstate': minor
+---
+
+The `schema` property has been introduced to the machine config passed into `createMachine(machineConfig)`, which allows you to provide metadata for the following:
+
+- Context
+- Events
+- Actions
+- Guards
+- Services
+
+This metadata can be accessed as-is from `machine.schema`:
+
+```js
+const machine = createMachine({
+  schema: {
+    // Example in JSON Schema (anything can be used)
+    context: {
+      type: 'object',
+      properties: {
+        foo: { type: 'string' },
+        bar: { type: 'number' },
+        baz: {
+          type: 'object',
+          properties: {
+            one: { type: 'string' }
+          }
+        }
+      }
+    },
+    events: {
+      FOO: { type: 'object' },
+      BAR: { type: 'object' }
+    }
+  }
+  // ...
+});
+```
+
+Additionally, the new `createSchema()` identity function allows any schema "metadata" to be represented by a specific type, which makes type inference easier without having to specify generic types:
+
+```ts
+import { createSchema, createMachine } from 'xstate';
+
+// Both `context` and `events` are inferred in the rest of the machine!
+const machine = createMachine({
+  schema: {
+    context: createSchema<{ count: number }>({
+      // ...
+    }),
+    // No arguments necessary
+    events: createSchema<{ type: 'FOO' } | { type: 'BAR' }>()
+  }
+  // ...
+});
+```

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -97,7 +97,7 @@ import {
 } from './stateUtils';
 import { createInvocableActor } from './Actor';
 import { toInvokeDefinition } from './invokeUtils';
-import { ActorRef } from '.';
+import { ActorRef, MachineSchema } from '.';
 
 const NULL_EVENT = '';
 const STATE_IDENTIFIER = '#';
@@ -246,6 +246,8 @@ class StateNode<
 
   public options: MachineOptions<TContext, TEvent>;
 
+  public schema: MachineSchema<TContext, TEvent>;
+
   public __xstatenode: true = true;
 
   private __cache = {
@@ -285,7 +287,7 @@ class StateNode<
     /**
      * The initial extended state
      */
-    public context?: Readonly<TContext>
+    public context: Readonly<TContext> = undefined as any // TODO: this is unsafe, but we're removing it in v5 anyway
   ) {
     this.options = Object.assign(createDefaultOptions<TContext>(), options);
     this.parent = this.options._parent;
@@ -310,6 +312,10 @@ class StateNode<
         : this.config.history
         ? 'history'
         : 'atomic');
+    this.schema = this.parent
+      ? this.machine.schema
+      : (this.config as MachineConfig<TContext, TStateSchema, TEvent>).schema ??
+        ({} as this['schema']);
 
     if (!IS_PRODUCTION) {
       warn(

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -63,7 +63,9 @@ import {
   Typestate,
   TransitionDefinitionMap,
   DelayExpr,
-  InvokeSourceDefinition
+  InvokeSourceDefinition,
+  ActorRef,
+  MachineSchema
 } from './types';
 import { matchesState } from './utils';
 import { State, stateValuesEqual } from './State';
@@ -97,7 +99,6 @@ import {
 } from './stateUtils';
 import { createInvocableActor } from './Actor';
 import { toInvokeDefinition } from './invokeUtils';
-import { ActorRef, MachineSchema } from '.';
 
 const NULL_EVENT = '';
 const STATE_IDENTIFIER = '#';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,6 +30,7 @@ import {
   InterpreterStatus
 } from './interpreter';
 import { matchState } from './match';
+import { createSchema } from './schema';
 
 const actions = {
   raise,
@@ -69,7 +70,8 @@ export {
   matchState,
   spawn,
   doneInvoke,
-  createMachine
+  createMachine,
+  createSchema
 };
 
 export * from './types';

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -1,0 +1,3 @@
+export function createSchema<T>(schema?: any): T {
+  return schema as T;
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -678,6 +678,15 @@ export interface MachineConfig<
    * The machine's own version.
    */
   version?: string;
+  schema?: MachineSchema<TContext, TEvent>;
+}
+
+export interface MachineSchema<TContext, TEvent extends EventObject> {
+  context?: TContext;
+  events?: TEvent;
+  actions?: ActionObject<TContext, TEvent>;
+  guards?: any;
+  services?: any;
 }
 
 export interface StandardMachineConfig<

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -684,9 +684,9 @@ export interface MachineConfig<
 export interface MachineSchema<TContext, TEvent extends EventObject> {
   context?: TContext;
   events?: TEvent;
-  actions?: ActionObject<TContext, TEvent>;
-  guards?: any;
-  services?: any;
+  actions?: { type: string; [key: string]: any };
+  guards?: { type: string; [key: string]: any };
+  services?: { type: string; [key: string]: any };
 }
 
 export interface StandardMachineConfig<

--- a/packages/core/test/schema.test.ts
+++ b/packages/core/test/schema.test.ts
@@ -1,4 +1,5 @@
 import { createMachine } from '../src';
+import { createSchema } from '../src/schema';
 
 namespace JSONSchema {
   export interface String {
@@ -53,12 +54,14 @@ describe('schema', () => {
             }
           }
         }),
-        events: (null as any) as { type: 'FOO' } | { type: 'BAR' }
+        events: createSchema<{ type: 'FOO' } | { type: 'BAR' }>()
       },
       context: { foo: '', bar: 0, baz: { one: '' } },
       initial: 'active',
       states: {
-        active: {}
+        active: {
+          entry: ['asdf']
+        }
       }
     });
 

--- a/packages/core/test/schema.test.ts
+++ b/packages/core/test/schema.test.ts
@@ -1,5 +1,4 @@
-import { createMachine } from '../src';
-import { createSchema } from '../src/schema';
+import { createMachine, createSchema } from '../src';
 
 namespace JSONSchema {
   export interface String {

--- a/packages/core/test/schema.test.ts
+++ b/packages/core/test/schema.test.ts
@@ -1,0 +1,97 @@
+import { createMachine } from '../src';
+
+namespace JSONSchema {
+  export interface String {
+    type: 'string';
+  }
+  export interface Number {
+    type: 'number';
+  }
+  export interface Object<TK extends string> {
+    type: 'object';
+    properties: {
+      [key in TK]: JSONSchema.Thing;
+    };
+  }
+  export type Thing =
+    | JSONSchema.String
+    | JSONSchema.Number
+    | JSONSchema.Object<string>;
+  export type TypeFrom<T extends JSONSchema.Thing> = T extends JSONSchema.String
+    ? string
+    : T extends JSONSchema.Number
+    ? number
+    : T extends JSONSchema.Object<infer Keys>
+    ? {
+        [Key in Keys]: TypeFrom<T['properties'][Key]>;
+      }
+    : unknown;
+}
+
+function fromJSONSchema<T extends JSONSchema.Thing>(
+  schema: T
+): JSONSchema.TypeFrom<T> {
+  return schema as any;
+}
+
+describe('schema', () => {
+  it('should infer types from provided schema', () => {
+    const noop = (_: any) => void 0;
+
+    const m = createMachine({
+      schema: {
+        context: fromJSONSchema({
+          type: 'object',
+          properties: {
+            foo: { type: 'string' },
+            bar: { type: 'number' },
+            baz: {
+              type: 'object',
+              properties: {
+                one: { type: 'string' }
+              }
+            }
+          }
+        }),
+        events: (null as any) as { type: 'FOO' } | { type: 'BAR' }
+      },
+      context: { foo: '', bar: 0, baz: { one: '' } },
+      initial: 'active',
+      states: {
+        active: {}
+      }
+    });
+
+    noop(m.context.foo);
+    noop(m.context.baz.one);
+    m.transition('active', 'BAR');
+
+    // @ts-expect-error
+    noop(m.context.something);
+
+    // @ts-expect-error
+    m.transition('active', 'INVALID');
+  });
+
+  it('schema should be present in the machine definition', () => {
+    const schema = {
+      context: fromJSONSchema({
+        type: 'object',
+        properties: {
+          foo: { type: 'string' }
+        }
+      })
+    };
+
+    const m = createMachine({
+      schema,
+      context: { foo: '' },
+      initial: 'active',
+      states: {
+        active: {}
+      }
+    });
+
+    expect(m.schema).toEqual(schema);
+  });
+});


### PR DESCRIPTION
This PR adds the `schema` property to the machine config and definition.

```ts
const machine = createMachine({
  // ...
  schema: {
    // These can be arbitrary meta data, accessible at runtime
    // Typecast these (something as SpecificType) for inferred types!
    context: someContextSchema,
    events: someEventSchemaMap,
    actions: someActionSchemaMap,
    guards: someGuardSchemaMap,
    services: someServiceSchemaMap
  },
  // ...
});
```

Purpose of this PR:

- Provides a place to specify important metadata for runtime types and validation (e.g., with JSON Schema) as part of the machine definition
- Allows for easier type inference without having to specify generics. Notice how the `context` and `events` are strongly typed, even though their generic types aren't specified:

<img width="515" alt="Screen Shot 2021-03-10 at 10 10 00 PM" src="https://user-images.githubusercontent.com/1093738/110730034-c064dd00-81ed-11eb-9c89-6e61647609f1.png">
