### PR TITLE
docs: fix external link target

### DIFF
--- a/docs/guides/actions.md
+++ b/docs/guides/actions.md
@@ -623,7 +623,7 @@ const maybeDoThese = choose([
 ]);
 ```
 
-This is analogous to the SCXML `<if>`, `<elseif>`, and `<else>` elements: [www.w3.org/TR/scxml/#if](www.w3.org/TR/scxml/#if)
+This is analogous to the SCXML `<if>`, `<elseif>`, and `<else>` elements: [www.w3.org/TR/scxml/#if](https://www.w3.org/TR/scxml/#if)
 
 ## Pure Action
 


### PR DESCRIPTION
Adds the missing "https://" protocol to a W3 link.

This is huge.