### PR TITLE
Reorder createMachine overloads

### DIFF
--- a/packages/core/src/Machine.ts
+++ b/packages/core/src/Machine.ts
@@ -50,17 +50,17 @@ export function Machine<
 }
 
 export function createMachine<
-  TModel extends Model<any, any>,
-  TContext = ModelContextFrom<TModel>,
-  TEvent extends EventObject = ModelEventsFrom<TModel>,
+  TContext,
+  TEvent extends EventObject = AnyEventObject,
   TTypestate extends Typestate<TContext> = { value: any; context: TContext }
 >(
   config: MachineConfig<TContext, any, TEvent>,
   options?: Partial<MachineOptions<TContext, TEvent>>
 ): StateMachine<TContext, any, TEvent, TTypestate>;
 export function createMachine<
-  TContext,
-  TEvent extends EventObject = AnyEventObject,
+  TModel extends Model<any, any>,
+  TContext = ModelContextFrom<TModel>,
+  TEvent extends EventObject = ModelEventsFrom<TModel>,
   TTypestate extends Typestate<TContext> = { value: any; context: TContext }
 >(
   config: MachineConfig<TContext, any, TEvent>,


### PR DESCRIPTION
I would also intuitively put the Model-related overload first but it seems that this was problematic in here - all the other generics have defaults so using this:
```ts
createMachine<any>({})
```
has been caught by the first overload (the Model-related one) and resulted in this:
<img width="975" alt="Screenshot 2021-03-14 at 21 59 02" src="https://user-images.githubusercontent.com/9800850/111083966-9888b880-8510-11eb-805a-445478590d4f.png">
which in turn has caused some TS error down the road when accessing the `context` which got inferred to unknown: https://github.com/davidkpiano/xstate/pull/1955/checks?check_run_id=2104765685#step:6:1150

And it really seems that up until now the user expectation was different - this meant `TContext` being `any` so this change makes this behave closer to what we have on the master branch.