### PR TITLE
Fixed type errors in tests after introducing createMachine's overload related to Model

### DIFF
--- a/packages/xstate-react/test/useMachine.test.tsx
+++ b/packages/xstate-react/test/useMachine.test.tsx
@@ -731,7 +731,7 @@ describe('useMachine (strict mode)', () => {
   });
 
   it('should not miss initial synchronous updates', () => {
-    const m = createMachine<any>({
+    const m = createMachine<{ count: number }>({
       initial: 'idle',
       context: {
         count: 0
@@ -749,7 +749,7 @@ describe('useMachine (strict mode)', () => {
 
     const App = () => {
       const [state] = useMachine(m);
-      return state.context.count;
+      return <>{state.context.count}</>;
     };
 
     const { container } = render(<App />);

--- a/packages/xstate-react/test/useService.test.tsx
+++ b/packages/xstate-react/test/useService.test.tsx
@@ -189,7 +189,7 @@ describe('useService hook', () => {
 
   it('service should accept the 2-argument variant', () => {
     const service = interpret(
-      createMachine<any, { type: 'EVENT'; value: number }>({
+      createMachine<{ value: number }, { type: 'EVENT'; value: number }>({
         initial: 'first',
         states: {
           first: {


### PR DESCRIPTION
All the other generics have defaults so using this:
```ts
createMachine<any>({})
```
has been caught by the first overload (the Model-related one) and resulted in this:
<img width="975" alt="Screenshot 2021-03-14 at 21 59 02" src="https://user-images.githubusercontent.com/9800850/111083966-9888b880-8510-11eb-805a-445478590d4f.png">
which in turn has caused some TS error down the road when accessing the `context` which got inferred to unknown: https://github.com/davidkpiano/xstate/pull/1955/checks?check_run_id=2104765685#step:6:1150