### PR TITLE
Add a failing test for invoked actor not being started correctly when reentering invoking state in the same macrostep

### DIFF
--- a/packages/core/test/invoke.test.ts
+++ b/packages/core/test/invoke.test.ts
@@ -2280,6 +2280,40 @@ describe('invoke', () => {
 
       service.send('NEXT');
     });
+
+    it('should invoke an actor when reentering invoking state within a single macrostep', () => {
+      let actorStartedCount = 0;
+
+      const transientMachine = Machine<{ counter: number }>({
+        initial: 'active',
+        context: { counter: 0 },
+        states: {
+          active: {
+            invoke: {
+              src: invokeCallback(() => () => {
+                actorStartedCount++;
+              })
+            },
+            always: [
+              {
+                guard: (ctx) => ctx.counter === 0,
+                target: 'inactive'
+              }
+            ]
+          },
+          inactive: {
+            entry: assign({ counter: (ctx) => ++ctx.counter }),
+            always: 'active'
+          }
+        }
+      });
+
+      const service = interpret(transientMachine);
+
+      service.start();
+
+      expect(actorStartedCount).toBe(1);
+    });
   });
 
   describe('error handling', () => {


### PR DESCRIPTION
The bug is caused by too simplistic logic here:
https://github.com/davidkpiano/xstate/blob/421f85e3bcbfe045ab98bf9f84b84a800b996926/packages/core/src/invoke.ts#L116-L124

Maybe instead of querying actions, we should bookkeep soon-to-be-started actors in the temporary structure (like SCXML does it)?