### PR TITLE
Throw an error when we encounter cond on a transition to surface this migration problem early

### DIFF
--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -397,6 +397,11 @@ export function formatTransition<TContext, TEvent extends EventObject>(
       : true;
   const { guards } = stateNode.machine.options;
   const target = resolveTarget(stateNode, normalizedTarget);
+  if (!IS_PRODUCTION && (transitionConfig as any).cond) {
+    throw new Error(
+      `State "${stateNode.id}" has declared \`cond\` for one of its transitions. This property has been renamed to \`guard\`. Please update your code.`
+    );
+  }
   const transition = {
     ...transitionConfig,
     actions: toActionObjects(toArray(transitionConfig.actions)),


### PR DESCRIPTION
I've wasted a little bit of time on this when writing a new test on the `next` branch. This would help me to spot the problem much sooner and should result in the same for a good chunk of our users :)