### PR TITLE
Add additional environment variable for devTools

### DIFF
--- a/.changeset/nervous-toes-exercise.md
+++ b/.changeset/nervous-toes-exercise.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Add new environment variable, `XSTATE_PRODUCTION_DEVTOOLS=true` to allow using inspect/devtools inside built storybook which is built under "Production" environment.

--- a/packages/core/src/devTools.ts
+++ b/packages/core/src/devTools.ts
@@ -1,5 +1,5 @@
 import { Interpreter } from '.';
-import { IS_PRODUCTION } from './environment';
+import { IS_PRODUCTION, PRODUCTION_DEVTOOLS } from './environment';
 import { AnyInterpreter } from './types';
 
 type ServiceListener = (service: AnyInterpreter) => void;
@@ -40,7 +40,7 @@ function getDevTools(): XStateDevInterface | undefined {
 }
 
 export function registerService(service: AnyInterpreter) {
-  if (IS_PRODUCTION || !getGlobal()) {
+  if ((IS_PRODUCTION && !PRODUCTION_DEVTOOLS) || !getGlobal()) {
     return;
   }
 

--- a/packages/core/src/environment.ts
+++ b/packages/core/src/environment.ts
@@ -1,1 +1,3 @@
 export const IS_PRODUCTION = process.env.NODE_ENV === 'production';
+export const PRODUCTION_DEVTOOLS =
+  process.env.XSTATE_PRODUCTION_DEVTOOLS === 'true';


### PR DESCRIPTION
When attempting to use devtools to “preview” in a storybook story, this works in development but not in production build due to the IS_PRODUCTION variable. I need to bypass this variable when running `build-storybook` or the devTools do not run at all.

Found this little problem here when building my storybook addon. Works great in local dev, but not in build mode. https://github.com/SimeonC/storybook-xstate-addon/issues/6