### PR TITLE
[@xstate/vue] Update Docs: Add new useActor & useInterpret Hooks + Fixes

### DIFF
--- a/packages/xstate-vue/README.md
+++ b/packages/xstate-vue/README.md
@@ -116,13 +116,103 @@ This special `useMachine` hook is imported from `@xstate/vue/lib/fsm`
 
 **Example** (TODO)
 
-## Configuring Machines (TODO)
+## Configuring Machines
 
 Existing machines can be configured by passing the machine options as the 2nd argument of `useMachine(machine, options)`.
 
 Example: the `'fetchData'` service and `'notifySuccess'` action are both configurable:
 
-**Example** (TODO)
+```vue
+<template>
+  <template v-if="state.value === 'idle'">
+    <button @click="send('FETCH', { query: 'something' })">
+      Search for something
+    </button>
+  </template>
+
+  <template v-else-if="state.value === 'loading'">
+    <div>Searching...</div>
+  </template>
+
+  <template v-else-if="state.value === 'success'">
+    <div>Success! {{ state.context.data }}</div>
+  </template>
+
+  <template v-else-if="state.value === 'failure'">
+    <p>{{ state.context.error.message }}</p>
+    <button @click="send('RETRY')">Retry</button>
+  </template>
+</template>
+
+<script>
+import { assign, Machine } from 'xstate';
+import { useMachine } from '@xstate/vue';
+
+const fetchMachine = Machine({
+  id: 'fetch',
+  initial: 'idle',
+  context: {
+    data: undefined,
+    error: undefined
+  },
+  states: {
+    idle: {
+      on: { FETCH: 'loading' }
+    },
+    loading: {
+      invoke: {
+        src: 'fetchData',
+        onDone: {
+          target: 'success',
+          actions: assign({
+            data: (_context, event) => event.data
+          })
+        },
+        onError: {
+          target: 'failure',
+          actions: assign({
+            error: (_context, event) => event.data
+          })
+        }
+      }
+    },
+    success: {
+      entry: 'notifySuccess',
+      type: 'final'
+    },
+    failure: {
+      on: {
+        RETRY: 'loading'
+      }
+    }
+  }
+});
+
+export default {
+  props: {
+    onResolve: {
+      type: Function,
+      default: () => {}
+    }
+  },
+  setup(props) {
+    const { state, send } = useMachine(fetchMachine, {
+      actions: {
+        notifySuccess: (ctx) => props.onResolve(ctx.data)
+      },
+      services: {
+        fetchData: (_context, event) =>
+          fetch(`some/api/${event.query}`).then((res) => res.json())
+      }
+    });
+    return {
+      state,
+      send
+    };
+  }
+};
+</script>
+```
 
 ## Matching States
 

--- a/packages/xstate-vue/README.md
+++ b/packages/xstate-vue/README.md
@@ -1,5 +1,20 @@
 # @xstate/vue
 
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [@xstate/vue](#xstatevue)
+  - [Quick Start](#quick-start)
+  - [API](#api)
+    - [`useMachine(machine, options?)`](#usemachinemachine-options)
+    - [`useService(service)`](#useserviceservice)
+    - [`useMachine(machine)` with `@xstate/fsm`](#usemachinemachine-with-xstatefsm)
+  - [Configuring Machines](#configuring-machines)
+  - [Matching States](#matching-states)
+  - [Persisted and Rehydrated State](#persisted-and-rehydrated-state)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 ## Quick Start
 
 1. Install `xstate` and `@xstate/vue`:


### PR DESCRIPTION
Hi again!
I've updated the Vue docs, so they have the latest hooks from #1991.

I've also added:
- A table of contents with doctoc at the top as @xstate/react has.
- Added the missing Configuring Machines from #1973 PR that was done only to the docs folder and is deleted when building the project.
- Fixed the Vue links so they point to the latest Vue v3 docs.