### PR TITLE
Fixed an issue with creatorless models not being correctly matched by  `createMachine`'s overload

### DIFF
--- a/.changeset/funny-kiwis-explode.md
+++ b/.changeset/funny-kiwis-explode.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Fixed an issue with creatorless models not being correctly matched by `createMachine`'s overload responsible for using model-induced types.

--- a/packages/core/src/model.ts
+++ b/packages/core/src/model.ts
@@ -17,7 +17,7 @@ type Prop<T, K> = K extends keyof T ? T[K] : never;
 export interface Model<
   TContext,
   TEvent extends EventObject,
-  TModelCreators = never
+  TModelCreators = void
 > {
   initialContext: TContext;
   assign: <TEventType extends TEvent['type'] = TEvent['type']>(
@@ -79,7 +79,7 @@ type EventFromEventCreators<EventCreators> = {
 
 export function createModel<TContext, TEvent extends EventObject>(
   initialContext: TContext
-): Model<TContext, TEvent, never>;
+): Model<TContext, TEvent, void>;
 export function createModel<
   TContext,
   TModelCreators extends ModelCreators<TModelCreators>,

--- a/packages/core/test/model.test.ts
+++ b/packages/core/test/model.test.ts
@@ -199,4 +199,25 @@ describe('createModel', () => {
 
     expect(updatedState.context.age).toEqual(42);
   });
+
+  it('should typecheck `createMachine` for model without creators', () => {
+    const toggleModel = createModel({ count: 0 });
+
+    const machine = createMachine<typeof toggleModel>({
+      id: 'machine',
+      initial: 'inactive',
+      // using context here is crucial to validate that it can be assigned to the inferred TContext
+      context: toggleModel.initialContext,
+      states: {
+        inactive: {
+          on: { TOGGLE: 'active' }
+        },
+        active: {
+          on: { TOGGLE: 'inactive' }
+        }
+      }
+    });
+
+    expect(machine.initialState.context.count).toBe(0);
+  });
 });


### PR DESCRIPTION
addresses the issue mentioned [here](https://github.com/davidkpiano/xstate/issues/2036#issuecomment-806943242)

cc @VanTanev