### PR TITLE
exposing react/fsm as a separate entrypoint

### DIFF
--- a/.changeset/healthy-rice-shout.md
+++ b/.changeset/healthy-rice-shout.md
@@ -7,3 +7,4 @@ Added an explicit entrypoint for `@xstate/react/fsm` which you can use instead o
 ```diff
 -import { useMachine } from '@xstate/react/lib/fsm'
 +import { useMachine } from '@xstate/react/fsm'
+```

--- a/.changeset/healthy-rice-shout.md
+++ b/.changeset/healthy-rice-shout.md
@@ -1,0 +1,5 @@
+---
+'@xstate/react': patch
+---
+
+Exposing a separate entrypoint for @xstate/react/fsm

--- a/.changeset/healthy-rice-shout.md
+++ b/.changeset/healthy-rice-shout.md
@@ -2,4 +2,8 @@
 '@xstate/react': patch
 ---
 
-Exposing a separate entrypoint for @xstate/react/fsm
+Added an explicit entrypoint for `@xstate/react/fsm` which you can use instead of `@xstate/react/lib/fsm`. This is the only specifier that will be supported in the future - the other one will be dropped in the next major version.
+
+```diff
+-import { useMachine } from '@xstate/react/lib/fsm'
++import { useMachine } from '@xstate/react/fsm'

--- a/packages/xstate-react/README.md
+++ b/packages/xstate-react/README.md
@@ -302,7 +302,7 @@ Ensures that the `action` is executed as an effect in `useLayoutEffect`, rather 
 
 A [React hook](https://reactjs.org/hooks) that interprets the given finite state `machine` from [`@xstate/fsm`] and starts a service that runs for the lifetime of the component.
 
-This special `useMachine` hook is imported from `@xstate/react/lib/fsm`
+This special `useMachine` hook is imported from `@xstate/react/fsm`
 
 **Arguments**
 
@@ -319,7 +319,7 @@ This special `useMachine` hook is imported from `@xstate/react/lib/fsm`
 
 ```js
 import { useEffect } from 'react';
-import { useMachine } from `@xstate/react/lib/fsm`;
+import { useMachine } from `@xstate/react/fsm`;
 import { createMachine } from '@xstate/fsm';
 
 const context = {

--- a/packages/xstate-react/fsm/package.json
+++ b/packages/xstate-react/fsm/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "main": "../lib/fsm.js",
+  "module": "../es/fsm.js",
+  "types": "../lib/fsm.d.ts"
+}

--- a/packages/xstate-react/package.json
+++ b/packages/xstate-react/package.json
@@ -28,7 +28,8 @@
     "lib/**/*.d.ts",
     "dist/**/*.js",
     "es/**/*.js",
-    "es/**/*.d.ts"
+    "es/**/*.d.ts",
+    "fsm/package.json"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
Thank you for the library and thank you again for providing a bare minimum implementation for it.

However, the recommended way to use `react/lib/fsm` is something I would like to improve, and make it just `react/fsm`, with autopicking the correct implementation for the correct environment.

Not using fancy `package.exports` - adding separate entrypoint in an old fashion way, compatible with completely everything.

Long story short -
```diff
- import { useMachine } from `@xstate/react/lib/fsm`;
- import { useMachine } from `@xstate/react/es/fsm`;
+ import { useMachine } from `@xstate/react/fsm`;
```