### PR TITLE
Add exception when next state config is undefined

### DIFF
--- a/packages/xstate-fsm/src/index.ts
+++ b/packages/xstate-fsm/src/index.ts
@@ -159,14 +159,10 @@ export function createMachine<
       const eventObject = toEventObject<TEvent>(event);
       const stateConfig = fsmConfig.states[value];
 
-      if (!IS_PRODUCTION) {
-        if (!stateConfig) {
-          throw new Error(
-            `State '${value}' not found on machine${
-              fsmConfig.id ? ` '${fsmConfig.id}'` : ''
-            }.`
-          );
-        }
+      if (!IS_PRODUCTION && !stateConfig) {
+        throw new Error(
+          `State '${value}' not found on machine ${fsmConfig.id ?? ''}`
+        );
       }
 
       if (stateConfig.on) {
@@ -186,8 +182,18 @@ export function createMachine<
 
           const isTargetless = target === undefined;
 
+          const nextStateValue = target ?? value;
+          const nextStateConfig = fsmConfig.states[nextStateValue];
+
+          if (!IS_PRODUCTION && !nextStateConfig) {
+            throw new Error(
+              `State '${nextStateValue}' not found on machine ${
+                fsmConfig.id ?? ''
+              }`
+            );
+          }
+
           if (cond(context, eventObject)) {
-            const nextStateConfig = fsmConfig.states[target ?? value];
             const allActions = (isTargetless
               ? toArray(actions)
               : ([] as any[])

--- a/packages/xstate-fsm/test/fsm.test.ts
+++ b/packages/xstate-fsm/test/fsm.test.ts
@@ -10,7 +10,8 @@ describe('@xstate/fsm', () => {
   type LightEvent =
     | { type: 'TIMER' }
     | { type: 'INC' }
-    | { type: 'EMERGENCY'; value: number };
+    | { type: 'EMERGENCY'; value: number }
+    | { type: 'TARGET_INVALID' };
 
   type LightState =
     | {
@@ -25,6 +26,8 @@ describe('@xstate/fsm', () => {
         value: 'red';
         context: LightContext & { go: false };
       };
+
+  const invalidState = 'invalid';
 
   const lightConfig: StateMachine.Config<
     LightContext,
@@ -48,6 +51,9 @@ describe('@xstate/fsm', () => {
           TIMER: {
             target: 'yellow',
             actions: ['g-y 1', 'g-y 2']
+          },
+          TARGET_INVALID: {
+            target: invalidState
           }
         }
       },
@@ -138,6 +144,14 @@ describe('@xstate/fsm', () => {
     expect(() => {
       lightFSM.transition('unknown', 'TIMER');
     }).toThrow();
+  });
+
+  it('should throw an error for undefined next state config', () => {
+    expect(() => {
+      lightFSM.transition('green', 'TARGET_INVALID');
+    }).toThrow(
+      `State '${invalidState}' not found on machine ${lightConfig.id ?? ''}`
+    );
   });
 
   it('should work with guards', () => {


### PR DESCRIPTION
I added an error throw in case the `nextStateConfig` is undefined, so we don't get a runtime error later in the code (when accessing `nextStateConfig.entry`, specifically). 

I also tidied up another `if` statement earlier in the same function, if that's all right with you.

I added a test to verify the behavior. It's find it a bit convoluted, as I had to modify the test machine config, so I'm open to better ways of testing this. In any case, all tests are passing.