### PR TITLE
Clarify that tests will fail unless "yarn build" has been ran

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Pull requests are encouraged. If you want to add a feature or fix a bug:
 2. [Create a separate branch](https://docs.github.com/en/desktop/contributing-and-collaborating-using-github-desktop/managing-branches) for your changes
 3. Make your changes, and ensure that it is formatted by [Prettier](https://prettier.io) and type-checks without errors in [TypeScript](https://www.typescriptlang.org/)
 4. Write tests that validate your change and/or fix.
-5. Run tests with `yarn test` (for all packages) or `yarn test:core` (for only changes to core XState)
+5. Run `yarn build` and then run tests with `yarn test` (for all packages) or `yarn test:core` (for only changes to core XState).
 6. Create a changeset by running `yarn changeset`. [More info](https://github.com/atlassian/changesets).
 7. Push your branch and open a PR 🚀
 


### PR DESCRIPTION
This is something small, but it bit me when I first tried to do local changes to xstate.

`yarn dev` also will perform a build and make standalone `yarn test` work, but stating it explicitly like this seems most straightforward.