### PR TITLE
Drop unnecessary overloads from createMachine and State.from

### DIFF
--- a/packages/core/src/Machine.ts
+++ b/packages/core/src/Machine.ts
@@ -9,14 +9,6 @@ import { MachineNode } from './MachineNode';
 import { Model, ModelContextFrom, ModelEventsFrom } from './model';
 
 export function createMachine<
-  TContext extends never,
-  TEvent extends EventObject = AnyEventObject,
-  TTypestate extends Typestate<TContext> = { value: any; context: TContext }
->(
-  config: MachineConfig<TContext, TEvent, any>,
-  options?: Partial<MachineImplementations<TContext, TEvent>>
-): MachineNode<TContext, TEvent, any, TTypestate>;
-export function createMachine<
   TModel extends Model<any, any, any>,
   TContext = ModelContextFrom<TModel>,
   TEvent extends EventObject = ModelEventsFrom<TModel>,

--- a/packages/core/src/State.ts
+++ b/packages/core/src/State.ts
@@ -99,13 +99,6 @@ export class State<
    * @param stateValue
    * @param context
    */
-  public static from<TE extends EventObject = EventObject>(
-    stateValue: State<never, TE, any, any> | StateValue
-  ): State<never, TE, any, any>;
-  public static from<TC, TE extends EventObject = EventObject>(
-    stateValue: State<TC, TE, any, any> | StateValue,
-    context: TC
-  ): State<TC, TE, any, any>;
   public static from<TC, TE extends EventObject = EventObject>(
     stateValue: State<TC, TE, any, any> | StateValue,
     context?: TC | undefined

--- a/packages/core/test/machine.test.ts
+++ b/packages/core/test/machine.test.ts
@@ -236,7 +236,6 @@ describe('machine', () => {
       });
 
       const changedBarMachine = fooBarMachine.withContext({
-        // @ts-expect-error
         bar: 42
       });
 


### PR DESCRIPTION
Related to the discussion here: https://github.com/davidkpiano/xstate/pull/2060/files#r606933468

I could not find a reason behind those overloads - maybe they were needed at some point in time but they are not anymore? Tests and typecheck are ✅ so I think this should be good to go. If those overloads are needed then we should add tests to cover that.