### PR TITLE
Add support for single-state (combinatorial) machines

### DIFF
--- a/.changeset/six-chicken-call.md
+++ b/.changeset/six-chicken-call.md
@@ -1,0 +1,18 @@
+---
+'xstate': minor
+---
+
+There is now support for "combinatorial machines" (state machines that only have one state):
+
+```js
+const testMachine = createMachine({
+  context: { value: 42 },
+  on: {
+    INC: {
+      actions: assign({ value: (ctx) => ctx.value + 1 })
+    }
+  }
+});
+```
+
+These machines omit the `initial` and `state` properties, as the entire machine is treated as a single state.

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -1499,6 +1499,9 @@ class StateNode<
         : {
             [this.initial]: this.states[this.initial].initialStateValue
           }) as StateValue;
+    } else {
+      // The finite state value of a machine without child states is just an empty object
+      initialStateValue = {};
     }
 
     this.__cache.initialStateValue = initialStateValue;

--- a/packages/core/test/initial.test.ts
+++ b/packages/core/test/initial.test.ts
@@ -56,8 +56,4 @@ describe('Initial states', () => {
       }
     });
   });
-
-  it('should return undefined for leaf nodes', () => {
-    expect(() => deepMachine.states.leaf.initialState).toThrow();
-  });
 });

--- a/packages/core/test/machine.test.ts
+++ b/packages/core/test/machine.test.ts
@@ -1,4 +1,4 @@
-import { Machine, interpret, createMachine } from '../src/index';
+import { Machine, interpret, createMachine, assign } from '../src/index';
 import { State } from '../src/State';
 
 const pedestrianStates = {
@@ -376,6 +376,27 @@ describe('machine', () => {
       expect(noStateNodeIDMachine.getStateNode('idle').id).toEqual(
         'some-id.idle'
       );
+    });
+  });
+
+  describe('combinatorial machines', () => {
+    it('should support combinatorial machines (single-state)', () => {
+      const testMachine = createMachine<{ value: number }>({
+        context: { value: 42 },
+        on: {
+          INC: {
+            actions: assign({ value: (ctx) => ctx.value + 1 })
+          }
+        }
+      });
+
+      const state = testMachine.initialState;
+
+      expect(state.value).toEqual({});
+
+      const nextState = testMachine.transition(state, 'INC');
+
+      expect(nextState.context.value).toEqual(43);
     });
   });
 });


### PR DESCRIPTION
This PR adds support for combinatorial machines:

- No `initial` property
- No `state` property
- Root-level transitions

```js
const testMachine = createMachine({
  context: { value: 42 },
  on: {
    INC: {
      actions: assign({ value: (ctx) => ctx.value + 1 })
    }
  }
});
```

The finite `state.value` of the combinatorial machine is an empty object: `{}`