### PR TITLE
Fixes #2084: `interpert` vs. `useInterpret`

### DIFF
--- a/.changeset/good-poets-sell.md
+++ b/.changeset/good-poets-sell.md
@@ -1,0 +1,6 @@
+---
+'@xstate/react': minor
+'@xstate/vue': minor
+---
+
+`useInterpret()` / `useMachine()` will no longer overwrite `machine.context` with an empty object when it's `undefined`.

--- a/.changeset/moody-ligers-cry.md
+++ b/.changeset/moody-ligers-cry.md
@@ -1,0 +1,6 @@
+---
+'@xstate/react': patch
+'@xstate/vue': patch
+---
+
+Fixed inconsistent behavior with initial state using `interpret` vs. `useInterpret`

--- a/.changeset/moody-ligers-cry.md
+++ b/.changeset/moody-ligers-cry.md
@@ -1,6 +1,0 @@
----
-'@xstate/react': patch
-'@xstate/vue': patch
----
-
-Fixed inconsistent behavior with initial state using `interpret` vs. `useInterpret`

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@changesets/changelog-github": "^0.2.6",
     "@changesets/cli": "^2.9.1",
     "@manypkg/cli": "^0.16.1",
+    "@testing-library/react-hooks": "^5.1.1",
     "@types/jest": "^24.0.23",
     "@types/node": "^12.11.1",
     "@types/use-subscription": "^1.0.0",

--- a/packages/xstate-react/src/useInterpret.ts
+++ b/packages/xstate-react/src/useInterpret.ts
@@ -89,12 +89,12 @@ export function useInterpret<
     };
     const machineWithConfig = machine.withConfig(
       machineConfig,
-      (machine.context || context
+      machine.context || context
         ? {
             ...machine.context,
             ...context
           }
-        : undefined) as TContext
+        : undefined
     );
 
     return interpret(machineWithConfig, {

--- a/packages/xstate-react/src/useInterpret.ts
+++ b/packages/xstate-react/src/useInterpret.ts
@@ -87,10 +87,15 @@ export function useInterpret<
       services,
       delays
     };
-    const machineWithConfig = machine.withConfig(machineConfig, {
-      ...machine.context,
-      ...context
-    } as TContext);
+    const machineWithConfig = machine.withConfig(
+      machineConfig,
+      (machine.context || context
+        ? {
+            ...machine.context,
+            ...context
+          }
+        : undefined) as TContext
+    );
 
     return interpret(machineWithConfig, {
       deferEvents: true,

--- a/packages/xstate-react/test/useInterpret.test.tsx
+++ b/packages/xstate-react/test/useInterpret.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createMachine } from 'xstate';
+import { createMachine, interpret } from 'xstate';
 import { render, cleanup, fireEvent } from '@testing-library/react';
 import { useInterpret } from '../src';
 
@@ -110,5 +110,29 @@ describe('useInterpret', () => {
     rerender(<App value={42} />);
 
     expect(actual).toEqual([1, 42]);
+  });
+
+  it('should behave the same as `interpret` when initial context is not defined', (done) => {
+    const machine = createMachine({
+      initial: 'foo',
+      states: {
+        foo: {}
+      }
+    });
+
+    const interpretService = interpret(machine);
+
+    const App = () => {
+      const useInterpretService = useInterpret(machine);
+
+      expect(useInterpretService.initialState.context).toEqual(
+        interpretService.initialState.context
+      );
+      done();
+
+      return null;
+    };
+
+    render(<App />);
   });
 });

--- a/packages/xstate-react/test/useInterpret.test.tsx
+++ b/packages/xstate-react/test/useInterpret.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { createMachine, interpret } from 'xstate';
 import { render, cleanup, fireEvent } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
 import { useInterpret } from '../src';
 
 afterEach(cleanup);
@@ -134,5 +135,46 @@ describe('useInterpret', () => {
     };
 
     render(<App />);
+  });
+
+  it('does not set a context object when there was none in the definition', () => {
+    const machine = createMachine({
+      initial: 'foo',
+      states: {
+        foo: {}
+      }
+    });
+
+    const { result } = renderHook(() => useInterpret(machine));
+    expect(result.current.machine.context).toBeUndefined();
+  });
+
+  it('does set context object when provided as a config param, even when there was none in the definition', () => {
+    const machine = createMachine({
+      initial: 'foo',
+      states: {
+        foo: {}
+      }
+    });
+
+    const { result } = renderHook(() => useInterpret(machine, { context: {} }));
+    expect(result.current.machine.context).not.toBeUndefined();
+  });
+
+  it('can extend the default context object', () => {
+    const machine = createMachine({
+      initial: 'foo',
+      states: {
+        foo: {}
+      },
+      context: {
+        num: 1
+      }
+    });
+
+    const { result } = renderHook(() =>
+      useInterpret(machine, { context: { num: 2 } })
+    );
+    expect(result.current.machine.context).toEqual({ num: 2 });
   });
 });

--- a/packages/xstate-react/test/useInterpret.test.tsx
+++ b/packages/xstate-react/test/useInterpret.test.tsx
@@ -126,8 +126,8 @@ describe('useInterpret', () => {
     const App = () => {
       const useInterpretService = useInterpret(machine);
 
-      expect(useInterpretService.initialState.context).toEqual(
-        interpretService.initialState.context
+      expect(useInterpretService.machine.context).toEqual(
+        interpretService.machine.context
       );
       done();
 

--- a/packages/xstate-svelte/src/index.ts
+++ b/packages/xstate-svelte/src/index.ts
@@ -55,10 +55,15 @@ export function useMachine<
     delays
   };
 
-  const resolvedMachine = machine.withConfig(machineConfig, {
-    ...machine.context,
-    ...context
-  } as TContext);
+  const resolvedMachine = machine.withConfig(
+    machineConfig,
+    machine.context || context
+      ? {
+          ...machine.context,
+          ...context
+        }
+      : undefined
+  );
 
   const service = interpret(resolvedMachine, interpreterOptions).start(
     rehydratedState ? new State(rehydratedState) : undefined

--- a/packages/xstate-svelte/test/UseMachine.NoContext.svelte
+++ b/packages/xstate-svelte/test/UseMachine.NoContext.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import { useMachine } from '../src';
+  import { noContextMachine } from './noContextMachine';
+
+  const { state } = useMachine(noContextMachine);
+</script>
+
+<div data-testid="context">
+  {#if $state.context === undefined}context is undefined{:else}context is defined{/if}
+</div>

--- a/packages/xstate-svelte/test/noContextMachine.ts
+++ b/packages/xstate-svelte/test/noContextMachine.ts
@@ -1,0 +1,8 @@
+import { createMachine } from 'xstate';
+
+export const noContextMachine = createMachine({
+  initial: 'foo',
+  states: {
+    foo: {}
+  }
+});

--- a/packages/xstate-svelte/test/useMachine.test.ts
+++ b/packages/xstate-svelte/test/useMachine.test.ts
@@ -1,5 +1,6 @@
 import { render, fireEvent } from '@testing-library/svelte';
 import UseMachine from './UseMachine.svelte';
+import UseNoContextMachine from './UseMachine.NoContext.svelte';
 import { fetchMachine } from './fetchMachine';
 import { doneInvoke } from 'xstate';
 
@@ -39,5 +40,12 @@ describe('useMachine function', () => {
     await findByText(/Success/);
     const dataEl = getByTestId('data');
     expect(dataEl.textContent).toBe('persisted data');
+  });
+
+  it('does not set a context object when there was none in the definition', async () => {
+    const { findByText, getByTestId } = render(UseNoContextMachine);
+    await findByText(/context is/);
+    const resultEl = getByTestId('context');
+    expect(resultEl.textContent).toBe('context is undefined');
   });
 });

--- a/packages/xstate-vue/src/useInterpret.ts
+++ b/packages/xstate-vue/src/useInterpret.ts
@@ -67,10 +67,15 @@ export function useInterpret<
     delays
   };
 
-  const machineWithConfig = machine.withConfig(machineConfig, {
-    ...machine.context,
-    ...context
-  } as TContext);
+  const machineWithConfig = machine.withConfig(
+    machineConfig,
+    (machine.context || context
+      ? {
+          ...machine.context,
+          ...context
+        }
+      : undefined) as TContext
+  );
 
   const service = interpret(machineWithConfig, interpreterOptions).start(
     rehydratedState ? (State.create(rehydratedState) as any) : undefined

--- a/packages/xstate-vue/src/useInterpret.ts
+++ b/packages/xstate-vue/src/useInterpret.ts
@@ -69,12 +69,12 @@ export function useInterpret<
 
   const machineWithConfig = machine.withConfig(
     machineConfig,
-    (machine.context || context
+    machine.context || context
       ? {
           ...machine.context,
           ...context
         }
-      : undefined) as TContext
+      : undefined
   );
 
   const service = interpret(machineWithConfig, interpreterOptions).start(

--- a/packages/xstate-vue/test/useInterpret.test.ts
+++ b/packages/xstate-vue/test/useInterpret.test.ts
@@ -40,8 +40,6 @@ describe('useInterpret composable function', () => {
           interpretService.initialState.context
         );
         done();
-
-        return {};
       },
       template: 'foo'
     });

--- a/packages/xstate-vue/test/useInterpret.test.ts
+++ b/packages/xstate-vue/test/useInterpret.test.ts
@@ -1,4 +1,7 @@
 import { render, fireEvent, waitFor } from '@testing-library/vue';
+import { defineComponent } from 'vue';
+import { createMachine, interpret } from 'xstate';
+import { useInterpret } from '../src';
 import UseInterpret from './UseInterpret.vue';
 
 describe('useInterpret composable function', () => {
@@ -17,5 +20,32 @@ describe('useInterpret composable function', () => {
     await waitFor(() => expect(buttonEl.textContent).toBe('Turn on'));
     await fireEvent.click(buttonEl);
     await waitFor(() => expect(buttonEl.textContent).toBe('Turn off'));
+  });
+
+  it('should behave the same as `interpret` when initial context is not defined', (done) => {
+    const machine = createMachine({
+      initial: 'foo',
+      states: {
+        foo: {}
+      }
+    });
+
+    const interpretService = interpret(machine);
+
+    const App = defineComponent({
+      setup() {
+        const useInterpretService = useInterpret(machine);
+
+        expect(useInterpretService.initialState.context).toEqual(
+          interpretService.initialState.context
+        );
+        done();
+
+        return {};
+      },
+      template: 'foo'
+    });
+
+    render(App);
   });
 });

--- a/packages/xstate-vue/test/useInterpret.test.ts
+++ b/packages/xstate-vue/test/useInterpret.test.ts
@@ -36,8 +36,8 @@ describe('useInterpret composable function', () => {
       setup() {
         const useInterpretService = useInterpret(machine);
 
-        expect(useInterpretService.initialState.context).toEqual(
-          interpretService.initialState.context
+        expect(useInterpretService.machine.context).toEqual(
+          interpretService.machine.context
         );
         done();
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1667,6 +1667,18 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
+"@testing-library/react-hooks@^5.1.1":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-5.1.1.tgz#1fbaae8a4e8a4a7f97b176c23e1e890c41bbbfa5"
+  integrity sha512-52D2XnpelFDefnWpy/V6z2qGNj8JLIvW5DjYtelMvFXdEyWiykSaI7IXHwFy4ICoqXJDmmwHAiFRiFboub/U5g==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@types/react" ">=16.9.0"
+    "@types/react-dom" ">=16.9.0"
+    "@types/react-test-renderer" ">=16.9.0"
+    filter-console "^0.1.1"
+    react-error-boundary "^3.1.0"
+
 "@testing-library/react@^8.0.9":
   version "8.0.9"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-8.0.9.tgz#1ecd96bc3471b06dd2f9763b6e53a7ace28a54a2"
@@ -1926,6 +1938,13 @@
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.5.tgz#434711bdd49eb5ee69d90c1d67c354a9a8ecb18b"
   integrity sha512-/JHkVHtx/REVG0VVToGRGH2+23hsYLHdyG+GrvoUGlGAd0ErauXDyvHtRI/7H7mzLm+tBCKA7pfcpkQ1lf58iQ==
 
+"@types/react-dom@>=16.9.0":
+  version "17.0.3"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.3.tgz#7fdf37b8af9d6d40127137865bb3fff8871d7ee1"
+  integrity sha512-4NnJbCeWE+8YBzupn/YrJxZ8VnjcJq5iR1laqQ1vkpQgBiA7bwk0Rp24fxsdNinzJY2U+HHS4dJJDPdoMjdJ7w==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-dom@^16.9.4":
   version "16.9.10"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.10.tgz#4485b0bec3d41f856181b717f45fd7831101156f"
@@ -1940,12 +1959,28 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-test-renderer@>=16.9.0":
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz#3120f7d1c157fba9df0118dae20cb0297ee0e06b"
+  integrity sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*":
   version "17.0.0"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.0.tgz#5af3eb7fad2807092f0046a1302b7823e27919b8"
   integrity sha512-aj/L7RIMsRlWML3YB6KZiXB3fV2t41+5RBGYF8z+tAKU43Px8C3cYUZsDvf1/+Bm4FK21QWBrDutu8ZJ/70qOw==
   dependencies:
     "@types/prop-types" "*"
+    csstype "^3.0.2"
+
+"@types/react@>=16.9.0":
+  version "17.0.3"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.3.tgz#ba6e215368501ac3826951eef2904574c262cc79"
+  integrity sha512-wYOUxIgs2HZZ0ACNiIayItyluADNbONl7kt8lkLjVK8IitMH5QMyAh75Fwhmo37r1m7L2JaFj03sIfxBVDvRAg==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
     csstype "^3.0.2"
 
 "@types/react@^16", "@types/react@^16.9.11":
@@ -1969,6 +2004,11 @@
   integrity sha512-2XZovu4NwcqmtZtsBR5XYLw18T8cBCnU2USFHTnYLLHz9fkhnoEMoDsqShJIOFsFhn5aJHjweiUUdTrDGujegA==
   dependencies:
     "@types/node" "*"
+
+"@types/scheduler@*":
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.1.tgz#18845205e86ff0038517aab7a18a62a6b9f71275"
+  integrity sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==
 
 "@types/semver@^6.0.0", "@types/semver@^6.0.1":
   version "6.2.2"
@@ -6228,6 +6268,11 @@ fill-range@^7.0.1:
   integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
   dependencies:
     to-regex-range "^5.0.1"
+
+filter-console@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/filter-console/-/filter-console-0.1.1.tgz#6242be28982bba7415bcc6db74a79f4a294fa67c"
+  integrity sha512-zrXoV1Uaz52DqPs+qEwNJWJFAWZpYJ47UNmpN9q4j+/EYsz85uV0DC9k8tRND5kYmoVzL0W+Y75q4Rg8sRJCdg==
 
 finalhandler@~1.1.2:
   version "1.1.2"
@@ -11717,6 +11762,13 @@ react-dom@^16.12.0:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.19.1"
+
+react-error-boundary@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.1.tgz#932c5ca5cbab8ec4fe37fd7b415aa5c3a47597e7"
+  integrity sha512-W3xCd9zXnanqrTUeViceufD3mIW8Ut29BUD+S2f0eO2XCOU8b6UrJfY46RDGe5lxCJzfe4j0yvIfh0RbTZhKJw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
   version "16.13.1"


### PR DESCRIPTION
While working on #2084 I realized that the `useSelector` hook in @xstate/vue faces the same little inconsistency, so I decided to fix both.

The according tests are written and fail without the patch. Thanks again to @VanTanev for suggesting the fix itself! 👏

I am not sure about the changeset though, whether this is a breaking change or not. I decided to go for a *patch* version because according to the docs an initial context property should be provided anyway, so I classified it as a fix.

---

_BTW_: Thanks for the awesome project setup @davidkpiano and @Andarist (and of course everybody who contributed as well), it is such a joy that everything works out of the box (even on windows :o)! 🤩