### PR TITLE
Provide convenience type InterpreterFrom<typeof machine>

### DIFF
--- a/.changeset/fifty-owls-check.md
+++ b/.changeset/fifty-owls-check.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Provide convenience type InterpreterFrom<typeof machine>

--- a/.changeset/fifty-owls-check.md
+++ b/.changeset/fifty-owls-check.md
@@ -2,4 +2,4 @@
 'xstate': patch
 ---
 
-Provide convenience type InterpreterFrom<typeof machine>
+Provide a convenience type for getting the `Interpreter` type based on the `StateMachine` type by transferring all generic parameters onto it. It can be used like this: `InterpreterFrom<typeof machine>`

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1285,3 +1285,14 @@ export type ActorRefFrom<
   : never;
 
 export type AnyInterpreter = Interpreter<any, any, any, any>;
+
+export type InterpreterFrom<
+  T extends StateMachine<any, any, any, any>
+> = T extends StateMachine<
+  infer TContext,
+  infer TStateSchema,
+  infer TEvent,
+  infer TTypestate
+>
+  ? Interpreter<TContext, TStateSchema, TEvent, TTypestate>
+  : never;


### PR DESCRIPTION
Add the convenience type
```typescript
export type InterpreterFrom<
  T extends StateMachine<any, any, any, any>
> = T extends StateMachine<
  infer TContext,
  infer TStateSchema,
  infer TEvent,
  infer TTypestate
>
  ? Interpreter<TContext, TStateSchema, TEvent, TTypestate>
  : never;
```

This is useful in the following pattern:
```typescript
import React from 'react'
import { createMachine, InterpreterFrom } from 'xstate'
import { useService } from '@xstate/react'

const machine = createMachine(...)
type MachineService = InterpreterFrom<typeof machine>

const MachineServiceContext = React.createContext<MachineService>(null!)
const useMachineService = (): MachineService  => {
  const service = React.useContext(MachineServiceContext)
  if (!service) throw new Error(`You must call useMachineService in a child component of <MachineProvider>`)
  return service
}
const MachineProvider: React.FC = ({ children }) => {
  const service = useInterpret(machine)
  return <MachineServiceContext.Provider value={service}>{children}</MachineServiceContext.Provider>
}

const App = () => {
  return <MachineProvider><Compontent /></MachineProvider>
}
const Component = () => {
  const service = useMachineService()
  const [state, send] = useService(service)
  // ...
}
```

This is a companion type to `ActorRefFrom<T>`.