### PR TITLE
[@xstate/react] Fix circular dependency

### DIFF
--- a/.changeset/eighty-fishes-smoke.md
+++ b/.changeset/eighty-fishes-smoke.md
@@ -1,0 +1,5 @@
+---
+'@xstate/react': patch
+---
+
+The `executeEffect` function is no longer exported (was meant to be internal and is useless as a public function anyway). This also fixes a circular dependency issue.

--- a/packages/xstate-react/src/useMachine.ts
+++ b/packages/xstate-react/src/useMachine.ts
@@ -10,12 +10,7 @@ import {
   Typestate,
   ActionFunction
 } from 'xstate';
-import {
-  MaybeLazy,
-  ReactActionFunction,
-  ReactActionObject,
-  ReactEffectType
-} from './types';
+import { MaybeLazy, ReactActionFunction, ReactEffectType } from './types';
 import { useInterpret } from './useInterpret';
 
 function createReactActionFunction<TContext, TEvent extends EventObject>(
@@ -47,25 +42,6 @@ export function asLayoutEffect<TContext, TEvent extends EventObject>(
   exec: ActionFunction<TContext, TEvent>
 ): ReactActionFunction<TContext, TEvent> {
   return createReactActionFunction(exec, ReactEffectType.LayoutEffect);
-}
-
-export type ActionStateTuple<TContext, TEvent extends EventObject> = [
-  ReactActionObject<TContext, TEvent>,
-  State<TContext, TEvent, any, any>
-];
-
-export function executeEffect<TContext, TEvent extends EventObject>(
-  action: ReactActionObject<TContext, TEvent>,
-  state: State<TContext, TEvent, any, any>
-): void {
-  const { exec } = action;
-  const originalExec = exec!(state.context, state._event.data, {
-    action,
-    state,
-    _event: state._event
-  });
-
-  originalExec();
 }
 
 export interface UseMachineOptions<TContext, TEvent extends EventObject> {

--- a/packages/xstate-react/src/useReactEffectActions.ts
+++ b/packages/xstate-react/src/useReactEffectActions.ts
@@ -1,9 +1,22 @@
 import { useEffect, useRef } from 'react';
 import useIsomorphicLayoutEffect from 'use-isomorphic-layout-effect';
 import { EventObject, State, Interpreter } from 'xstate';
-import { ReactActionObject, ReactEffectType } from './types';
+import { ReactActionObject, ReactEffectType, ActionStateTuple } from './types';
 import { partition } from './utils';
-import { ActionStateTuple, executeEffect } from './useMachine';
+
+export function executeEffect<TContext, TEvent extends EventObject>(
+  action: ReactActionObject<TContext, TEvent>,
+  state: State<TContext, TEvent, any, any>
+): void {
+  const { exec } = action;
+  const originalExec = exec!(state.context, state._event.data, {
+    action,
+    state,
+    _event: state._event
+  });
+
+  originalExec();
+}
 
 export function useReactEffectActions<TContext, TEvent extends EventObject>(
   service: Interpreter<TContext, any, TEvent, any>

--- a/packages/xstate-react/src/useReactEffectActions.ts
+++ b/packages/xstate-react/src/useReactEffectActions.ts
@@ -4,7 +4,7 @@ import { EventObject, State, Interpreter } from 'xstate';
 import { ReactActionObject, ReactEffectType, ActionStateTuple } from './types';
 import { partition } from './utils';
 
-export function executeEffect<TContext, TEvent extends EventObject>(
+function executeEffect<TContext, TEvent extends EventObject>(
   action: ReactActionObject<TContext, TEvent>,
   state: State<TContext, TEvent, any, any>
 ): void {


### PR DESCRIPTION
This PR fixes a circular dep that `executeEffect` caused, which is an internal function that shouldn't be exported anyway.