### PR TITLE
Add assertEvent() helper

### DIFF
--- a/.changeset/ten-buckets-exist.md
+++ b/.changeset/ten-buckets-exist.md
@@ -2,7 +2,9 @@
 'xstate': patch
 ---
 
-Add `assertEvent()` helper.
+Add `assertEvent()` helper that throws an exception when the given event is not of the expected type.
+
+This is usefull to type-narrow events inside actions, and make sure that expected data exists on an event object.
 
 Example:
 
@@ -14,25 +16,32 @@ type Context = {
   date: Date;
 };
 
-type Event = { type: 'SHOW_DATE' } | { type: 'UPDATE_DATE'; date: Date };
+type Event =
+  | { type: 'SHOW_DATE' }
+  | { type: 'NEW_DATE'; date: Date }
+  | { type: 'UPDATE_DATE': date; Date }
 
 const machine = createMachine<Context, Event>(
+  context: {
+    date: new Date(),
+  },
   {
     on: {
       SHOW_DATE: { actions: 'showDate' },
-      UPDATE_DATE: { actions: 'updateDate' }
+      NEW_DATE: { actions: 'assignDate' }
+      UPDATE_DATE: { actions: 'assignDate' }
     }
   },
   {
     actions: {
-      showDate: (ctx, e) => {
-        assertEvent(e, 'SHOW_DATE');
+      showDate: (ctx, event) => {
+        assertEvent(event, 'SHOW_DATE');
         alert(ctx.date.toISOString());
       },
-      updateDate: assign({
-        date: (_, e) => {
-          assertEvent(e, 'UPDATE_DATE');
-          return e.date; // has type "Date"
+      assignDate: assign({
+        date: (_, event) => {
+          assertEvent(event, ['NEW_DATE', 'UPDATE_DATE']);
+          return event.date; // has type "Date"
         }
       })
     }

--- a/.changeset/ten-buckets-exist.md
+++ b/.changeset/ten-buckets-exist.md
@@ -1,0 +1,41 @@
+---
+'xstate': patch
+---
+
+Add `assertEvent()` helper.
+
+Example:
+
+```typescript
+import { assign, createMachine, ExtractEvent } from 'xstate';
+import { assertEvent } from 'xstate/lib/assertEvent';
+
+type Context = {
+  date: Date;
+};
+
+type Event = { type: 'SHOW_DATE' } | { type: 'UPDATE_DATE'; date: Date };
+
+const machine = createMachine<Context, Event>(
+  {
+    on: {
+      SHOW_DATE: { actions: 'showDate' },
+      UPDATE_DATE: { actions: 'updateDate' }
+    }
+  },
+  {
+    actions: {
+      showDate: (ctx, e) => {
+        assertEvent(e, 'SHOW_DATE');
+        alert(ctx.date.toISOString());
+      },
+      updateDate: assign({
+        date: (_, e) => {
+          assertEvent(e, 'UPDATE_DATE');
+          return e.date; // has type "Date"
+        }
+      })
+    }
+  }
+);
+```

--- a/.changeset/ten-buckets-exist.md
+++ b/.changeset/ten-buckets-exist.md
@@ -19,7 +19,7 @@ type Context = {
 type Event =
   | { type: 'SHOW_DATE' }
   | { type: 'NEW_DATE'; date: Date }
-  | { type: 'UPDATE_DATE': date; Date }
+  | { type: 'UPDATE_DATE'; date: Date }
 
 const machine = createMachine<Context, Event>(
   context: {

--- a/packages/core/src/assertEvent.ts
+++ b/packages/core/src/assertEvent.ts
@@ -1,0 +1,23 @@
+import { EventObject, ExtractEvent } from './types';
+
+export function assertEvent<
+  TEventType extends TEvent['type'],
+  TEvent extends EventObject = EventObject
+>(e: TEvent, type: TEventType): asserts e is ExtractEvent<TEvent, TEventType>;
+export function assertEvent<
+  TEventType extends TEvent['type'],
+  TEvent extends EventObject = EventObject
+>(e: TEvent, type: TEventType[]): asserts e is ExtractEvent<TEvent, TEventType>;
+export function assertEvent<TEvent extends EventObject = EventObject>(
+  e: TEvent,
+  types: string | string[]
+) {
+  types = Array.isArray(types) ? types : [types];
+  if (!types.includes(e.type)) {
+    throw new Error(
+      `Expected event${types.length > 1 ? 's' : ''} "${types.join(
+        ', '
+      )}" but got "${e.type}".`
+    );
+  }
+}

--- a/packages/core/src/assertEvent.ts
+++ b/packages/core/src/assertEvent.ts
@@ -1,23 +1,29 @@
 import { EventObject, ExtractEvent } from './types';
 
 export function assertEvent<
-  TEventType extends TEvent['type'],
-  TEvent extends EventObject = EventObject
->(e: TEvent, type: TEventType): asserts e is ExtractEvent<TEvent, TEventType>;
+  TEvent extends EventObject,
+  TEventType extends TEvent['type']
+>(
+  event: TEvent,
+  type: TEventType
+): asserts event is ExtractEvent<TEvent, TEventType>;
 export function assertEvent<
-  TEventType extends TEvent['type'],
-  TEvent extends EventObject = EventObject
->(e: TEvent, type: TEventType[]): asserts e is ExtractEvent<TEvent, TEventType>;
-export function assertEvent<TEvent extends EventObject = EventObject>(
-  e: TEvent,
+  TEvent extends EventObject,
+  TEventType extends TEvent['type']
+>(
+  event: TEvent,
+  type: TEventType[]
+): asserts event is ExtractEvent<TEvent, TEventType>;
+export function assertEvent<TEvent extends EventObject>(
+  event: TEvent,
   types: string | string[]
 ) {
   types = Array.isArray(types) ? types : [types];
-  if (!types.includes(e.type)) {
+  if (!types.includes(event.type)) {
     throw new Error(
       `Expected event${types.length > 1 ? 's' : ''} "${types.join(
         ', '
-      )}" but got "${e.type}".`
+      )}" but got "${event.type}".`
     );
   }
 }

--- a/packages/core/test/assertEvent.test.ts
+++ b/packages/core/test/assertEvent.test.ts
@@ -1,0 +1,43 @@
+import { assertEvent } from '../src/assertEvent';
+
+describe('assertEvent', () => {
+  type Event =
+    | { type: 'EVENT_1'; data: number }
+    | { type: 'EVENT_2'; data: string }
+    | { type: 'EVENT_3'; data: boolean };
+
+  it('allows asserting by string', () => {
+    const e = { type: 'EVENT_1', data: 1 } as Event;
+    assertEvent(e, 'EVENT_1');
+    const data: number = e.data;
+    expect(data).toEqual(1);
+  });
+
+  it('allows asserting by array', () => {
+    const e = { type: 'EVENT_2', data: '1' } as Event;
+    assertEvent(e, ['EVENT_2']);
+    const data: string = e.data;
+    expect(data).toEqual('1');
+  });
+
+  it('allows asserting to multiple ', () => {
+    const e = { type: 'EVENT_3', data: true } as Event;
+    assertEvent(e, ['EVENT_1', 'EVENT_3']);
+    const data: number | boolean = e.data;
+    expect(data).toEqual(true);
+  });
+
+  it('throws for single event assertion', () => {
+    const e = { type: 'EVENT_3', data: true } as Event;
+    expect(() => assertEvent(e, 'EVENT_1')).toThrow(
+      'Expected event "EVENT_1" but got "EVENT_3".'
+    );
+  });
+
+  it('throws for array event assertion', () => {
+    const e = { type: 'EVENT_3', data: true } as Event;
+    expect(() => assertEvent(e, ['EVENT_1', 'EVENT_2'])).toThrow(
+      'Expected events "EVENT_1, EVENT_2" but got "EVENT_3".'
+    );
+  });
+});


### PR DESCRIPTION
Add `assertEvent()` helper.

Example:

```typescript
import { assign, createMachine, ExtractEvent } from 'xstate';
import { assertEvent } from 'xstate/lib/assertEvent';

type Context = {
  date: Date;
};

type Event = 
 | { type: 'SHOW_DATE' } 
 | { type: 'UPDATE_DATE'; date: Date };

const machine = createMachine<Context, Event>(
  {
    on: {
      SHOW_DATE: { actions: 'showDate' },
      UPDATE_DATE: { actions: 'updateDate' }
    }
  },
  {
    actions: {
      showDate: (ctx, e) => {
        assertEvent(e, 'SHOW_DATE');
        alert(ctx.date.toISOString());
      },
      updateDate: assign({
        date: (_, e) => {
          assertEvent(e, 'UPDATE_DATE');
          return e.date; // has type "Date" !
        }
      })
    }
  }
);
```