### PR TITLE
Improve the type of callback invoke params

### DIFF
--- a/.changeset/stupid-windows-sniff.md
+++ b/.changeset/stupid-windows-sniff.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+In callback invokes, the types of `callback` and `onReceive` are properly scoped to the machine TEvent.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -230,9 +230,9 @@ export type Receiver<TEvent extends EventObject> = (
   listener: (event: TEvent) => void
 ) => void;
 
-export type InvokeCallback = (
-  callback: Sender<any>,
-  onReceive: Receiver<EventObject>
+export type InvokeCallback<TEvent extends EventObject = AnyEventObject> = (
+  callback: Sender<TEvent>,
+  onReceive: Receiver<TEvent>
 ) => any;
 
 export interface InvokeMeta {
@@ -255,7 +255,7 @@ export interface InvokeMeta {
  */
 export type InvokeCreator<
   TContext,
-  TEvent = AnyEventObject,
+  TEvent extends EventObject = AnyEventObject,
   TFinalContext = any
 > = (
   context: TContext,
@@ -265,7 +265,7 @@ export type InvokeCreator<
   | PromiseLike<TFinalContext>
   | StateMachine<TFinalContext, any, any>
   | Subscribable<any>
-  | InvokeCallback;
+  | InvokeCallback<TEvent>;
 
 export interface InvokeDefinition<TContext, TEvent extends EventObject>
   extends ActivityDefinition<TContext, TEvent> {


### PR DESCRIPTION
```typescript
type Event = { type: 'START' } | { type: 'STOP' }

const machine = createMachine<{}, Event>({
  invoke: {
    id: 'callback-service',
    src: () => (callback, onReceive) => {
      onReceive(event => {
        // event is { type: 'START' } | { type: 'STOP' }
      })
      callback({ type: 'I_DONT_EXIST' }) // type errors
    }
  }
})
```