### PR TITLE
Change componentDidUnload to disconnectedCallback

### DIFF
--- a/docs/recipes/stencil.md
+++ b/docs/recipes/stencil.md
@@ -52,7 +52,7 @@ export class Toggle {
     this._service.start();
   }
 
-  componentDidUnload() {
+  disconnectedCallback() {
     this._service.stop();
   }
 


### PR DESCRIPTION
The "componentDidUnload()" method was removed in Stencil 2. The "disconnectedCallback()" method should be used instead.