### PR TITLE
add simple failing test for parallel machine state value

### DIFF
--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -139,6 +139,12 @@ describe('Parallel StateSchema', () => {
   it('should work with a parallel StateSchema defined', () => {
     expect(true).toBeTruthy();
   });
+
+  it('should infer correct state value', () => {
+    const service = interpret(parallelMachine);
+    const startedService = service.start();
+    expect(startedService.state.value.baz).toEqual('one');
+  });
 });
 
 describe('Nested parallel stateSchema', () => {


### PR DESCRIPTION
hi,

first of all: thanks for the work put into `xstate`, i really appreciate the concept and implementation. :purple_heart: 

i'm starting to use `xstate` in a project to replace other state management (redux or react hooks), but am currently stuck on a failing TypeScript type mismatch for my parallel machine's state value.

i'd expect (and at runtime this is the case) that the state value is a nested object with keys per parallel state, however the TypeScript compiler expects that the state value is a single string.

i tried to add a failing test to exemplify my current situation, however it's very possible i'm doing something wrong, so am very happy for any feedback. :smiley_cat: 

![image](https://user-images.githubusercontent.com/719605/116022185-ca5b7600-a69d-11eb-8169-5bec3f0122cc.png)

cheers! :seedling: 