### PR TITLE
Fixed an issue with tags not being set correctly after sending an event to a machine that didn't result in selecting any transitions

### DIFF
--- a/.changeset/soft-cats-trade.md
+++ b/.changeset/soft-cats-trade.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Fixed an issue with tags not being set correctly after sending an event to a machine that didn't result in selecting any transitions.

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -1263,7 +1263,8 @@ class StateNode<
       configuration: resolvedConfiguration,
       transitions: stateTransition.transitions,
       children,
-      done: isDone
+      done: isDone,
+      tags: currentState?.tags
     });
 
     const didUpdateContext = currentContext !== updatedContext;

--- a/packages/core/test/tags.test.ts
+++ b/packages/core/test/tags.test.ts
@@ -91,6 +91,22 @@ describe('tags', () => {
     expect(state.tags).toEqual(new Set(['yes', 'no']));
   });
 
+  it('sets tags correctly after not selecting any transition', () => {
+    const machine = createMachine({
+      initial: 'a',
+      states: {
+        a: {
+          tags: 'myTag'
+        }
+      }
+    });
+
+    const state = machine.transition(machine.initialState, {
+      type: 'UNMATCHED'
+    });
+    expect(state.hasTag('myTag')).toBeTruthy();
+  });
+
   it('tags can be single (not array)', () => {
     const machine = createMachine({
       initial: 'green',


### PR DESCRIPTION
Fixes https://github.com/davidkpiano/xstate/issues/2172

When we don't select any transitions then we just return here:
https://github.com/davidkpiano/xstate/blob/64ab1150e0a383202f4af1d586b28e081009c929/packages/core/src/StateNode.ts#L1280-L1282
but tags are set later on, here:
https://github.com/davidkpiano/xstate/blob/64ab1150e0a383202f4af1d586b28e081009c929/packages/core/src/StateNode.ts#L1328-L1330

So this didn't have a chance to be set correctly for the fixed test case.