### PR TITLE
[v5] Remove `StateSchema`

### DIFF
--- a/.changeset/pretty-beans-pretend.md
+++ b/.changeset/pretty-beans-pretend.md
@@ -1,0 +1,5 @@
+---
+'xstate': major
+---
+
+The `StateSchema` type has been removed from all generic type signatures.

--- a/packages/core/src/Machine.ts
+++ b/packages/core/src/Machine.ts
@@ -14,25 +14,25 @@ export function createMachine<
   TEvent extends EventObject = ModelEventsFrom<TModel>,
   TTypestate extends Typestate<TContext> = { value: any; context: TContext }
 >(
-  config: MachineConfig<TContext, TEvent, any>,
+  config: MachineConfig<TContext, TEvent>,
   options?: Partial<MachineImplementations<TContext, TEvent>>
-): MachineNode<TContext, TEvent, any, TTypestate>;
+): MachineNode<TContext, TEvent, TTypestate>;
 export function createMachine<
   TContext,
   TEvent extends EventObject = AnyEventObject,
   TTypestate extends Typestate<TContext> = { value: any; context: TContext }
 >(
-  config: MachineConfig<TContext, TEvent, any>,
+  config: MachineConfig<TContext, TEvent>,
   options?: Partial<MachineImplementations<TContext, TEvent>>
-): MachineNode<TContext, TEvent, any, TTypestate>;
+): MachineNode<TContext, TEvent, TTypestate>;
 export function createMachine<
   TContext,
   TEvent extends EventObject = AnyEventObject,
   TTypestate extends Typestate<TContext> = { value: any; context: TContext }
 >(
-  definition: MachineConfig<TContext, TEvent, any>,
+  definition: MachineConfig<TContext, TEvent>,
   implementations?: Partial<MachineImplementations<TContext, TEvent>>
-): MachineNode<TContext, TEvent, any, TTypestate> {
+): MachineNode<TContext, TEvent, TTypestate> {
   return new MachineNode<TContext, TEvent, TTypestate>(
     definition,
     implementations

--- a/packages/core/src/MachineNode.ts
+++ b/packages/core/src/MachineNode.ts
@@ -4,7 +4,6 @@ import {
   StateValue,
   MachineImplementations,
   EventObject,
-  StateSchema,
   MachineConfig,
   SCXML,
   Typestate,
@@ -63,9 +62,8 @@ function resolveContext<TContext>(
 export class MachineNode<
   TContext = any,
   TEvent extends EventObject = EventObject,
-  TStateSchema extends StateSchema = any,
   TTypestate extends Typestate<TContext> = any
-> extends StateNode<TContext, TEvent, TStateSchema> {
+> extends StateNode<TContext, TEvent> {
   public context: TContext;
   /**
    * The machine's own version.
@@ -90,7 +88,7 @@ export class MachineNode<
     /**
      * The raw config used to create the machine.
      */
-    public config: MachineConfig<TContext, TEvent, TStateSchema>,
+    public config: MachineConfig<TContext, TEvent>,
     options?: Partial<MachineImplementations<TContext, TEvent>>
   ) {
     super(config, {
@@ -155,7 +153,7 @@ export class MachineNode<
    */
   public provide(
     implementations: Partial<MachineImplementations<TContext, TEvent>>
-  ): MachineNode<TContext, TEvent, TStateSchema> {
+  ): MachineNode<TContext, TEvent> {
     const { actions, guards, actors, delays } = this.options;
 
     return new MachineNode(this.config, {
@@ -176,7 +174,7 @@ export class MachineNode<
    */
   public withContext(
     context: Partial<TContext>
-  ): MachineNode<TContext, TEvent, TStateSchema> {
+  ): MachineNode<TContext, TEvent> {
     return this.provide({
       context: resolveContext(this.context, context)
     });
@@ -210,7 +208,7 @@ export class MachineNode<
   public transition(
     state: StateValue | State<TContext, TEvent> = this.initialState,
     event: Event<TEvent> | SCXML.Event<TEvent>
-  ): State<TContext, TEvent, TStateSchema, TTypestate> {
+  ): State<TContext, TEvent, TTypestate> {
     const currentState = toState(state, this);
 
     return macrostep(currentState, event, this);
@@ -224,9 +222,9 @@ export class MachineNode<
    * @param event The received event
    */
   public microstep(
-    state: StateValue | State<TContext, TEvent> = this.initialState,
+    state: StateValue | State<TContext, TEvent, TTypestate> = this.initialState,
     event: Event<TEvent> | SCXML.Event<TEvent>
-  ): State<TContext, TEvent, TStateSchema, TTypestate> {
+  ): State<TContext, TEvent, TTypestate> {
     const resolvedState = toState(state, this);
     const _event = toSCXMLEvent(event);
 
@@ -252,13 +250,12 @@ export class MachineNode<
    * The initial State instance, which includes all actions to be executed from
    * entering the initial state.
    */
-  public get initialState(): State<TContext, TEvent, TStateSchema, TTypestate> {
+  public get initialState(): State<TContext, TEvent, TTypestate> {
     this._init();
     const nextState = resolveMicroTransition(this, [], undefined, undefined);
     return macrostep(nextState, null as any, this) as State<
       TContext,
       TEvent,
-      TStateSchema,
       TTypestate
     >;
   }
@@ -266,13 +263,12 @@ export class MachineNode<
   /**
    * Returns the initial `State` instance, with reference to `self` as an `ActorRef`.
    */
-  public getInitialState(): State<TContext, TEvent, TStateSchema, TTypestate> {
+  public getInitialState(): State<TContext, TEvent, TTypestate> {
     this._init();
     const nextState = resolveMicroTransition(this, [], undefined, undefined);
     return macrostep(nextState, null as any, this) as State<
       TContext,
       TEvent,
-      TStateSchema,
       TTypestate
     >;
   }

--- a/packages/core/src/State.ts
+++ b/packages/core/src/State.ts
@@ -5,7 +5,6 @@ import {
   EventType,
   StateConfig,
   SCXML,
-  StateSchema,
   TransitionDefinition,
   Typestate,
   HistoryValue,
@@ -20,11 +19,8 @@ import { SpawnedActorRef } from '../dist/xstate.cjs';
 export function isState<
   TContext,
   TEvent extends EventObject,
-  TStateSchema extends StateSchema<TContext> = any,
   TTypestate extends Typestate<TContext> = { value: any; context: TContext }
->(
-  state: object | string
-): state is State<TContext, TEvent, TStateSchema, TTypestate> {
+>(state: object | string): state is State<TContext, TEvent, TTypestate> {
   if (isString(state)) {
     return false;
   }
@@ -33,7 +29,7 @@ export function isState<
 }
 export function bindActionToState<TC, TE extends EventObject>(
   action: ActionObject<TC, TE>,
-  state: State<TC, TE, any, any>
+  state: State<TC, TE, any>
 ): ActionObject<TC, TE> {
   const { exec } = action;
   const boundAction: ActionObject<TC, TE> = {
@@ -55,12 +51,11 @@ export function bindActionToState<TC, TE extends EventObject>(
 export class State<
   TContext,
   TEvent extends EventObject = EventObject,
-  TStateSchema extends StateSchema<TContext> = any,
   TTypestate extends Typestate<TContext> = { value: any; context: TContext }
 > {
   public value: StateValue;
   public context: TContext;
-  public history?: State<TContext, TEvent, TStateSchema, TTypestate>;
+  public history?: State<TContext, TEvent, TTypestate>;
   public historyValue: HistoryValue<TContext, TEvent> = {};
   public actions: Array<ActionObject<TContext, TEvent>> = [];
   public meta: any = {};
@@ -101,9 +96,9 @@ export class State<
    * @param context
    */
   public static from<TC, TE extends EventObject = EventObject>(
-    stateValue: State<TC, TE, any, any> | StateValue,
+    stateValue: State<TC, TE, any> | StateValue,
     context?: TC | undefined
-  ): State<TC, TE, any, any> {
+  ): State<TC, TE, any> {
     if (stateValue instanceof State) {
       if (stateValue.context !== context) {
         return new State<TC, TE>({
@@ -144,7 +139,7 @@ export class State<
    */
   public static create<TC, TE extends EventObject = EventObject>(
     config: StateConfig<TC, TE>
-  ): State<TC, TE, any, any> {
+  ): State<TC, TE, any> {
     return new State(config);
   }
   /**
@@ -249,7 +244,6 @@ export class State<
         : never
       : never)['context'],
     TEvent,
-    TStateSchema,
     TTypestate
   > & { value: TSV } {
     return matchesState(parentStateValue as StateValue, this.value);

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -18,7 +18,6 @@ import {
   TransitionDefinition,
   DelayedTransitionDefinition,
   StateNodeConfig,
-  StateSchema,
   StatesDefinition,
   StateNodesConfig,
   FinalStateNodeConfig,
@@ -53,8 +52,7 @@ interface StateNodeOptions<TContext, TEvent extends EventObject> {
 
 export class StateNode<
   TContext = any,
-  TEvent extends EventObject = EventObject,
-  TStateSchema extends StateSchema = any
+  TEvent extends EventObject = EventObject
 > {
   /**
    * The relative key of the state node, which represents its location in the overall state value.
@@ -81,7 +79,7 @@ export class StateNode<
   /**
    * The child state nodes.
    */
-  public states: StateNodesConfig<TContext, TEvent, TStateSchema>;
+  public states: StateNodesConfig<TContext, TEvent>;
   /**
    * The type of history on this state node. Can be:
    *
@@ -108,7 +106,7 @@ export class StateNode<
   /**
    * The meta data associated with this state node, which will be returned in State instances.
    */
-  public meta?: TStateSchema extends { meta: infer D } ? D : any;
+  public meta?: any;
   /**
    * The data sent with the "done.state._id_" event if this is a final state node.
    */
@@ -155,7 +153,7 @@ export class StateNode<
     /**
      * The raw config used to create the machine.
      */
-    public config: StateNodeConfig<TContext, TEvent, TStateSchema>,
+    public config: StateNodeConfig<TContext, TEvent>,
     options: StateNodeOptions<TContext, TEvent>
   ) {
     const isMachine = !this.parent;
@@ -163,7 +161,7 @@ export class StateNode<
     this.key = this.config.key || options._key;
     this.machine = this.parent
       ? this.parent.machine
-      : ((this as unknown) as MachineNode<TContext, TEvent, TStateSchema>);
+      : ((this as unknown) as MachineNode<TContext, TEvent>);
     this.path = this.parent ? this.parent.path.concat(this.key) : [];
     this.id =
       this.config.id ||
@@ -195,7 +193,7 @@ export class StateNode<
             return stateNode;
           }
         )
-      : EMPTY_OBJECT) as StateNodesConfig<TContext, TEvent, TStateSchema>;
+      : EMPTY_OBJECT) as StateNodesConfig<TContext, TEvent>;
 
     if (this.type === 'compound' && !this.config.initial) {
       throw new Error(
@@ -229,7 +227,7 @@ export class StateNode<
   /**
    * The well-structured state node definition.
    */
-  public get definition(): StateNodeDefinition<TContext, TEvent, TStateSchema> {
+  public get definition(): StateNodeDefinition<TContext, TEvent> {
     return {
       id: this.id,
       key: this.key,
@@ -253,7 +251,7 @@ export class StateNode<
       history: this.history,
       states: mapValues(this.states, (state: StateNode<TContext, TEvent>) => {
         return state.definition;
-      }) as StatesDefinition<TContext, TEvent, TStateSchema>,
+      }) as StatesDefinition<TContext, TEvent>,
       on: this.on,
       transitions: this.transitions,
       entry: this.entry,

--- a/packages/core/src/patterns.ts
+++ b/packages/core/src/patterns.ts
@@ -3,7 +3,6 @@ import {
   StatesConfig,
   Event,
   EventObject,
-  StateSchema,
   StateNodeConfig
 } from './types';
 import { toEventObject } from './utils';
@@ -33,18 +32,15 @@ const defaultSequencePatternOptions = {
   prevEvent: 'PREV'
 };
 
-export function sequence<
-  TEvent extends EventObject,
-  TStateSchema extends StateSchema
->(
+export function sequence<TEvent extends EventObject>(
   items: string[],
   options?: Partial<SequencePatternOptions<TEvent>>
 ): {
   initial: string;
-  states: StatesConfig<any, TEvent, TStateSchema>;
+  states: StatesConfig<any, TEvent>;
 } {
   const resolvedOptions = { ...defaultSequencePatternOptions, ...options };
-  const states = {} as Record<keyof TStateSchema['states'], any>;
+  const states = {} as Record<string, any>;
   const nextEventObject =
     resolvedOptions.nextEvent === undefined
       ? undefined
@@ -55,7 +51,7 @@ export function sequence<
       : toEventObject(resolvedOptions.prevEvent);
 
   items.forEach((item, i) => {
-    const state: StateNodeConfig<TEvent, TEvent, TStateSchema> = {
+    const state: StateNodeConfig<TEvent, TEvent> = {
       on: {}
     };
 
@@ -76,6 +72,6 @@ export function sequence<
 
   return {
     initial: items[0] as string,
-    states: states as StatesConfig<any, TEvent, TStateSchema>
+    states: states as StatesConfig<any, TEvent>
   };
 }

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -78,7 +78,7 @@ type AdjList<TC, TE extends EventObject> = Map<
   Array<StateNode<TC, TE>>
 >;
 
-export const isAtomicStateNode = (stateNode: StateNode<any, any, any>) =>
+export const isAtomicStateNode = (stateNode: StateNode<any, any>) =>
   stateNode.type === 'atomic' || stateNode.type === 'final';
 
 export function getChildren<TC, TE extends EventObject>(
@@ -1413,7 +1413,7 @@ export function microstep<TContext, TEvent extends EventObject>(
 }
 
 function selectEventlessTransitions<TContext, TEvent extends EventObject>(
-  state: State<TContext, TEvent, any, any>
+  state: State<TContext, TEvent, any>
 ): Transitions<TContext, TEvent> {
   const enabledTransitions: Set<
     TransitionDefinition<TContext, TEvent>
@@ -1459,7 +1459,7 @@ export function resolveMicroTransition<
   transitions: Transitions<TContext, TEvent>,
   currentState?: State<TContext, TEvent>,
   _event: SCXML.Event<TEvent> = initEvent as SCXML.Event<TEvent>
-): State<TContext, TEvent, any, TTypestate> {
+): State<TContext, TEvent, TTypestate> {
   // Transition will "apply" if:
   // - the state node is the initial state (there is no current state)
   // - OR there are transitions
@@ -1525,7 +1525,7 @@ export function resolveMicroTransition<
 
   const { context, actions: nonRaisedActions } = resolved;
 
-  const nextState = new State<TContext, TEvent, any, TTypestate>({
+  const nextState = new State<TContext, TEvent, TTypestate>({
     value: getStateValue(machine, resolved.configuration),
     context,
     _event,
@@ -1575,7 +1575,7 @@ function resolveActionsAndContext<TContext, TEvent extends EventObject>(
   actions: Array<ActionObject<TContext, TEvent>>,
   machine: MachineNode<TContext, TEvent, any>,
   _event: SCXML.Event<TEvent>,
-  currentState: State<TContext, TEvent, any, any> | undefined
+  currentState: State<TContext, TEvent, any> | undefined
 ): {
   actions: typeof actions;
   raised: Array<RaiseActionObject<TEvent>>;
@@ -1735,7 +1735,7 @@ export function macrostep<
   TEvent extends EventObject,
   TTypestate extends Typestate<TContext>
 >(
-  state: State<TContext, TEvent, any, TTypestate>,
+  state: State<TContext, TEvent, TTypestate>,
   event: Event<TEvent> | SCXML.Event<TEvent> | null,
   machine: MachineNode<TContext, TEvent, any>
 ): typeof state {
@@ -1778,7 +1778,7 @@ export function macrostep<
 }
 
 function resolveHistoryValue<TContext, TEvent extends EventObject>(
-  currentState: State<TContext, TEvent, any, any> | undefined,
+  currentState: State<TContext, TEvent, any> | undefined,
   exitSet: Array<StateNode<TContext, TEvent>>
 ): HistoryValue<TContext, TEvent> {
   const historyValue: Record<

--- a/packages/xstate-react/src/useInterpret.ts
+++ b/packages/xstate-react/src/useInterpret.ts
@@ -41,14 +41,14 @@ export function useInterpret<
   TEvent extends EventObject,
   TTypestate extends Typestate<TContext> = { value: any; context: TContext }
 >(
-  getMachine: MaybeLazy<MachineNode<TContext, TEvent, any, TTypestate>>,
+  getMachine: MaybeLazy<MachineNode<TContext, TEvent, TTypestate>>,
   options: Partial<InterpreterOptions> &
     Partial<UseMachineOptions<TContext, TEvent>> &
     Partial<MachineImplementations<TContext, TEvent>> = {},
   observerOrListener?:
-    | Observer<State<TContext, TEvent, any, TTypestate>>
-    | ((value: State<TContext, TEvent, any, TTypestate>) => void)
-): Interpreter<TContext, TEvent, any, TTypestate> {
+    | Observer<State<TContext, TEvent, TTypestate>>
+    | ((value: State<TContext, TEvent, TTypestate>) => void)
+): Interpreter<TContext, TEvent, TTypestate> {
   const machine = useConstant(() => {
     return typeof getMachine === 'function' ? getMachine() : getMachine;
   });

--- a/packages/xstate-react/src/useMachine.ts
+++ b/packages/xstate-react/src/useMachine.ts
@@ -61,17 +61,17 @@ export function useMachine<
   TEvent extends EventObject,
   TTypestate extends Typestate<TContext> = { value: any; context: TContext }
 >(
-  getMachine: MaybeLazy<MachineNode<TContext, TEvent, any, TTypestate>>,
+  getMachine: MaybeLazy<MachineNode<TContext, TEvent, TTypestate>>,
   options: Partial<InterpreterOptions> &
     Partial<UseMachineOptions<TContext, TEvent>> &
     Partial<MachineImplementations<TContext, TEvent>> = {}
 ): [
-  State<TContext, TEvent, any, TTypestate>,
-  InterpreterOf<MachineNode<TContext, TEvent, any, TTypestate>>['send'],
-  InterpreterOf<MachineNode<TContext, TEvent, any, TTypestate>>
+  State<TContext, TEvent, TTypestate>,
+  InterpreterOf<MachineNode<TContext, TEvent, TTypestate>>['send'],
+  InterpreterOf<MachineNode<TContext, TEvent, TTypestate>>
 ] {
   const listener = useCallback(
-    (nextState: State<TContext, TEvent, any, TTypestate>) => {
+    (nextState: State<TContext, TEvent, TTypestate>) => {
       // Only change the current state if:
       // - the incoming state is the "live" initial state (since it might have new actors)
       // - OR the incoming state actually changed.
@@ -94,7 +94,7 @@ export function useMachine<
     const { initialState } = service.machine;
     return (options.state
       ? State.create(options.state)
-      : initialState) as State<TContext, TEvent, any, TTypestate>;
+      : initialState) as State<TContext, TEvent, TTypestate>;
   });
 
   return [state, service.send, service];

--- a/packages/xstate-react/src/useReactEffectActions.ts
+++ b/packages/xstate-react/src/useReactEffectActions.ts
@@ -6,7 +6,7 @@ import { partition } from './utils';
 
 function executeEffect<TContext, TEvent extends EventObject>(
   action: ReactActionObject<TContext, TEvent>,
-  state: State<TContext, TEvent, any, any>
+  state: State<TContext, TEvent, any>
 ): void {
   const { exec } = action;
   const originalExec = exec!(state.context, state._event.data, {
@@ -19,17 +19,13 @@ function executeEffect<TContext, TEvent extends EventObject>(
 }
 
 export function useReactEffectActions<TContext, TEvent extends EventObject>(
-  service: Interpreter<TContext, TEvent, any, any>
+  service: Interpreter<TContext, TEvent, any>
 ) {
   const effectActionsRef = useRef<
-    Array<
-      [ReactActionObject<TContext, TEvent>, State<TContext, TEvent, any, any>]
-    >
+    Array<[ReactActionObject<TContext, TEvent>, State<TContext, TEvent, any>]>
   >([]);
   const layoutEffectActionsRef = useRef<
-    Array<
-      [ReactActionObject<TContext, TEvent>, State<TContext, TEvent, any, any>]
-    >
+    Array<[ReactActionObject<TContext, TEvent>, State<TContext, TEvent, any>]>
   >([]);
 
   useIsomorphicLayoutEffect(() => {

--- a/packages/xstate-react/src/useSelector.ts
+++ b/packages/xstate-react/src/useSelector.ts
@@ -3,7 +3,7 @@ import { ActorRef, Interpreter, Subscribable } from 'xstate';
 import { isActorWithState } from './useActor';
 import { getServiceSnapshot } from './useService';
 
-function isService(actor: any): actor is Interpreter<any, any, any, any> {
+function isService(actor: any): actor is Interpreter<any, any, any> {
   return 'state' in actor && 'machine' in actor;
 }
 

--- a/packages/xstate-react/src/useService.ts
+++ b/packages/xstate-react/src/useService.ts
@@ -2,9 +2,9 @@ import { EventObject, State, Interpreter, Typestate } from 'xstate';
 import { useActor } from './useActor';
 import { PayloadSender } from './types';
 
-export function getServiceSnapshot<
-  TService extends Interpreter<any, any, any, any>
->(service: TService): TService['state'] {
+export function getServiceSnapshot<TService extends Interpreter<any, any, any>>(
+  service: TService
+): TService['state'] {
   // TODO: remove compat lines in a new major, replace literal number with InterpreterStatus then as well
   return ('status' in service ? service.status : (service as any)._status) !== 0
     ? service.state
@@ -16,8 +16,8 @@ export function useService<
   TEvent extends EventObject,
   TTypestate extends Typestate<TContext> = { value: any; context: TContext }
 >(
-  service: Interpreter<TContext, TEvent, any, TTypestate>
-): [State<TContext, TEvent, any, TTypestate>, PayloadSender<TEvent>] {
+  service: Interpreter<TContext, TEvent, TTypestate>
+): [State<TContext, TEvent, TTypestate>, PayloadSender<TEvent>] {
   if (process.env.NODE_ENV !== 'production' && !('machine' in service)) {
     throw new Error(
       `Attempted to use an actor-like object instead of a service in the useService() hook. Please use the useActor() hook instead.`

--- a/packages/xstate-react/test/useMachine.test.tsx
+++ b/packages/xstate-react/test/useMachine.test.tsx
@@ -304,7 +304,7 @@ describe('useMachine hook', () => {
     });
 
     const ServiceApp: React.FC<{
-      service: Interpreter<TestContext, any, any, TestState>;
+      service: Interpreter<TestContext, any, TestState>;
     }> = ({ service }) => {
       const [state] = useService(service);
 

--- a/packages/xstate-scxml/src/index.ts
+++ b/packages/xstate-scxml/src/index.ts
@@ -103,7 +103,7 @@ function actionsToSCXML(
   };
 }
 
-function stateNodeToSCXML(stateNode: StateNode<any, any, any>): XMLElement {
+function stateNodeToSCXML(stateNode: StateNode<any, any>): XMLElement {
   const childStates = Object.keys(stateNode.states).map((key) => {
     const childStateNode = stateNode.states[key];
 

--- a/packages/xstate-svelte/src/index.ts
+++ b/packages/xstate-svelte/src/index.ts
@@ -30,7 +30,7 @@ export function useMachine<
   TEvent extends EventObject,
   TTypestate extends Typestate<TContext>
 >(
-  machine: MachineNode<TContext, TEvent, any, TTypestate>,
+  machine: MachineNode<TContext, TEvent, TTypestate>,
   options: Partial<InterpreterOptions> &
     Partial<UseMachineOptions<TContext, TEvent>> &
     Partial<MachineImplementations<TContext, TEvent>> = {}

--- a/packages/xstate-test/src/types.ts
+++ b/packages/xstate-test/src/types.ts
@@ -140,5 +140,5 @@ export interface TestModelCoverage {
 }
 
 export interface CoverageOptions<TContext> {
-  filter?: (stateNode: StateNode<TContext, any, any>) => boolean;
+  filter?: (stateNode: StateNode<TContext, any>) => boolean;
 }

--- a/packages/xstate-vue/src/useInterpret.ts
+++ b/packages/xstate-vue/src/useInterpret.ts
@@ -37,14 +37,14 @@ export function useInterpret<
   TEvent extends EventObject,
   TTypestate extends Typestate<TContext> = { value: any; context: TContext }
 >(
-  getMachine: MaybeLazy<MachineNode<TContext, TEvent, any, TTypestate>>,
+  getMachine: MaybeLazy<MachineNode<TContext, TEvent, TTypestate>>,
   options: Partial<InterpreterOptions> &
     Partial<UseMachineOptions<TContext, TEvent>> &
     Partial<MachineImplementations<TContext, TEvent>> = {},
   observerOrListener?:
-    | Observer<State<TContext, TEvent, any, TTypestate>>
-    | ((value: State<TContext, TEvent, any, TTypestate>) => void)
-): Interpreter<TContext, TEvent, any, TTypestate> {
+    | Observer<State<TContext, TEvent, TTypestate>>
+    | ((value: State<TContext, TEvent, TTypestate>) => void)
+): Interpreter<TContext, TEvent, TTypestate> {
   const machine = typeof getMachine === 'function' ? getMachine() : getMachine;
 
   const {

--- a/packages/xstate-vue/src/useMachine.ts
+++ b/packages/xstate-vue/src/useMachine.ts
@@ -18,14 +18,14 @@ export function useMachine<
   TEvent extends EventObject,
   TTypestate extends Typestate<TContext> = { value: any; context: TContext }
 >(
-  getMachine: MaybeLazy<MachineNode<TContext, TEvent, any, TTypestate>>,
+  getMachine: MaybeLazy<MachineNode<TContext, TEvent, TTypestate>>,
   options: Partial<InterpreterOptions> &
     Partial<UseMachineOptions<TContext, TEvent>> &
     Partial<MachineImplementations<TContext, TEvent>> = {}
 ): {
-  state: Ref<State<TContext, TEvent, any, TTypestate>>;
-  send: Interpreter<TContext, TEvent, any, TTypestate>['send'];
-  service: Interpreter<TContext, TEvent, any, TTypestate>;
+  state: Ref<State<TContext, TEvent, TTypestate>>;
+  send: Interpreter<TContext, TEvent, TTypestate>['send'];
+  service: Interpreter<TContext, TEvent, TTypestate>;
 } {
   const service = useInterpret(getMachine, options, listener);
 
@@ -34,12 +34,11 @@ export function useMachine<
     (options.state ? State.create(options.state) : initialState) as State<
       TContext,
       TEvent,
-      any,
       TTypestate
     >
   );
 
-  function listener(nextState: State<TContext, TEvent, any, TTypestate>) {
+  function listener(nextState: State<TContext, TEvent, TTypestate>) {
     // Only change the current state if:
     // - the incoming state is the "live" initial state (since it might have new actors)
     // - OR the incoming state actually changed.

--- a/packages/xstate-vue/src/useService.ts
+++ b/packages/xstate-vue/src/useService.ts
@@ -10,9 +10,9 @@ import { Ref, isRef } from 'vue';
 
 import { useActor } from './useActor';
 
-export function getServiceSnapshot<
-  TService extends Interpreter<any, any, any, any>
->(service: TService): TService['state'] {
+export function getServiceSnapshot<TService extends Interpreter<any, any, any>>(
+  service: TService
+): TService['state'] {
   // TODO: remove compat lines in a new major, replace literal number with InterpreterStatus then as well
   return ('status' in service ? service.status : (service as any)._status) !== 0
     ? service.state
@@ -25,10 +25,10 @@ export function useService<
   TTypestate extends Typestate<TContext> = { value: any; context: TContext }
 >(
   service:
-    | Interpreter<TContext, TEvent, any, TTypestate>
-    | Ref<Interpreter<TContext, TEvent, any, TTypestate>>
+    | Interpreter<TContext, TEvent, TTypestate>
+    | Ref<Interpreter<TContext, TEvent, TTypestate>>
 ): {
-  state: Ref<State<TContext, TEvent, any, TTypestate>>;
+  state: Ref<State<TContext, TEvent, TTypestate>>;
   send: PayloadSender<TEvent>;
 } {
   if (


### PR DESCRIPTION
This PR removes `StateSchema` from all types in v5. We'll figure out a better way to have strong typing of state keys, but this is the first step.