### PR TITLE
[docs] Replace createMachineConfig with MachineConfig

### DIFF
--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -100,7 +100,7 @@ Ensure that your tsconfig file does not include `"keyofStringsOnly": true,`.
 The generic types for `MachineConfig<TContext, TSchema, TEvent>` are the same as those for `createMachine<TContext, TSchema, TEvent>`. This is useful when you are defining a machine config object _outside_ of the `createMachine(...)` function, and helps prevent [inference errors](https://github.com/davidkpiano/xstate/issues/310):
 
 ```ts
-import { createMachineConfig } from 'xstate';
+import { MachineConfig } from 'xstate';
 
 const myMachineConfig: MachineConfig<TContext, TSchema, TEvent> = {
   id: 'controller',


### PR DESCRIPTION
Does not seem like `createMachineConfig` exists anywhere