### PR TITLE
[core] Add `.getSnapshot()` to actor refs

### DIFF
--- a/.changeset/neat-boxes-float.md
+++ b/.changeset/neat-boxes-float.md
@@ -1,0 +1,32 @@
+---
+'xstate': minor
+---
+
+All spawned and invoked actors now have a `.getSnapshot()` method, which allows you to retrieve the latest value emitted from that actor. That value may be `undefined` if no value has been emitted yet.
+
+```js
+const machine = createMachine({
+  context: {
+    promiseRef: null
+  },
+  initial: 'pending',
+  states: {
+    pending: {
+      entry: assign({
+        promiseRef: () => spawn(fetch(/* ... */), 'some-promise')
+      })
+    }
+  }
+});
+
+const service = interpret(machine)
+  .onTransition((state) => {
+    // Read promise value synchronously
+    const resolvedValue = state.context.promiseRef?.getSnapshot();
+    // => undefined (if promise not resolved yet)
+    // => { ... } (resolved data)
+  })
+  .start();
+
+// ...
+```

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1278,16 +1278,19 @@ export interface ActorRef<TEvent extends EventObject, TEmitted = any>
 export interface SpawnedActorRef<TEvent extends EventObject, TEmitted = any>
   extends ActorRef<TEvent, TEmitted> {
   id: string;
+  getSnapshot: () => TEmitted | undefined;
   stop?: () => void;
   toJSON?: () => any;
 }
 
 export type ActorRefFrom<
-  T extends StateMachine<any, any, any>
+  T extends StateMachine<any, any, any> | Promise<any>
 > = T extends StateMachine<infer TContext, any, infer TEvent, infer TTypestate>
   ? SpawnedActorRef<TEvent, State<TContext, TEvent, any, TTypestate>> & {
       state: State<TContext, TEvent, any, TTypestate>;
     }
+  : T extends Promise<infer U>
+  ? SpawnedActorRef<never, U>
   : never;
 
 export type AnyInterpreter = Interpreter<any, any, any, any>;


### PR DESCRIPTION
This PR adds the `.getSnapshot()` method, which allows you to synchronously retrieve the latest value emitted from that actor. That value may be `undefined` if no value has been emitted yet.

This is the first step in full actor persistence, since persisting the state of a machine at a specific point in time involves synchronously reading the "state" (really the last known emitted values) of each actor.

```js
const machine = createMachine({
  context: {
    promiseRef: null
  },
  initial: 'pending',
  states: {
    pending: {
      entry: assign({
        promiseRef: () => spawn(fetch(/* ... */), 'some-promise')
      })
    }
  }
});

const service = interpret(machine)
  .onTransition((state) => {
    // Read promise value synchronously
    const resolvedValue = state.context.promiseRef?.getSnapshot();
    // => undefined (if promise not resolved yet)
    // => { ... } (resolved data)
  })
  .start();

// ...
```