### PR TITLE
[docs] Add links to xstate-vue2

### DIFF
--- a/docs/packages/xstate-vue/index.md
+++ b/docs/packages/xstate-vue/index.md
@@ -17,6 +17,10 @@
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
+::: warning Vue 2 Notice:
+If you're using Vue 2.x, please see [the Vue recipe](../../recipes/vue.html) instead, or use the [`xstate-vue2` package](https://github.com/ChrisShank/xstate-vue2) if you want to use the Vue Composition API.
+:::
+
 ## Quick Start
 
 1. Install `xstate` and `@xstate/vue`:
@@ -82,8 +86,6 @@ export default {
 };
 </script>
 ```
-
-**Vue 2.x notice:** If you're using Vue 2.x, please see [the recipe](https://xstate.js.org/docs/recipes/vue.html) instead.
 
 ## API
 

--- a/docs/recipes/vue.md
+++ b/docs/recipes/vue.md
@@ -1,5 +1,13 @@
 # Usage with Vue
 
+::: tip
+If you want to use the Vue Composition API, we recommend using the following packages:
+
+- [`@xstate/vue` package](../packages/xstate-vue) for Vue 3
+- [`xstate-vue2` package](https://github.com/ChrisShank/xstate-vue2) (3rd-party) for Vue 2
+
+:::
+
 Vue follows a similar pattern to [React](./react.md):
 
 - The machine can be defined externally;


### PR DESCRIPTION
This PR adds a link to [xstate-vue2](https://github.com/ChrisShank/xstate-vue2).

Addresses https://github.com/davidkpiano/xstate/discussions/2193

cc. @chrisshank