### PR TITLE
[v5] Separate StateMachine and StateNode

### DIFF
--- a/packages/core/src/Actor.ts
+++ b/packages/core/src/Actor.ts
@@ -79,7 +79,7 @@ export function fromMachine<TContext, TEvent extends EventObject>(
 }
 
 export function fromService<TContext, TEvent extends EventObject>(
-  service: Interpreter<TContext, TEvent>,
+  service: Interpreter<TContext, TEvent, any>,
   name: string = registry.bookId()
 ): SpawnedActorRef<TEvent> {
   return new ObservableActorRef(createServiceBehavior(service), name);

--- a/packages/core/src/Actor.ts
+++ b/packages/core/src/Actor.ts
@@ -8,7 +8,7 @@ import {
   SpawnedActorRef,
   Lazy
 } from './types';
-import { MachineNode } from './MachineNode';
+import { StateMachine } from './StateMachine';
 import { State } from './State';
 import { Interpreter } from './interpreter';
 import {
@@ -71,7 +71,7 @@ export function fromCallback<TEvent extends EventObject>(
 }
 
 export function fromMachine<TContext, TEvent extends EventObject>(
-  machine: MachineNode<TContext, TEvent>,
+  machine: StateMachine<TContext, TEvent>,
   name: string,
   options?: Partial<InterpreterOptions>
 ): ActorRef<TEvent> {
@@ -109,7 +109,7 @@ export function spawnObservable<T extends EventObject>(
 }
 
 export function spawnMachine(
-  machine: MachineNode<any, any, any>,
+  machine: StateMachine<any, any, any>,
   name?: string
 ) {
   return spawn(createMachineBehavior(machine), name);
@@ -134,7 +134,7 @@ export function spawnFrom<
   TEvent extends EventObject,
   TEmitted extends State<any, any>
 >(
-  entity: MachineNode<TEmitted['context'], any, TEmitted['event']>,
+  entity: StateMachine<TEmitted['context'], any, TEmitted['event']>,
   name?: string
 ): ObservableActorRef<TEvent, TEmitted>;
 export function spawnFrom<TEvent extends EventObject>(

--- a/packages/core/src/Machine.ts
+++ b/packages/core/src/Machine.ts
@@ -5,7 +5,7 @@ import {
   AnyEventObject,
   Typestate
 } from './types';
-import { MachineNode } from './MachineNode';
+import { StateMachine } from './StateMachine';
 import { Model, ModelContextFrom, ModelEventsFrom } from './model';
 
 export function createMachine<
@@ -16,7 +16,7 @@ export function createMachine<
 >(
   config: MachineConfig<TContext, TEvent>,
   options?: Partial<MachineImplementations<TContext, TEvent>>
-): MachineNode<TContext, TEvent, TTypestate>;
+): StateMachine<TContext, TEvent, TTypestate>;
 export function createMachine<
   TContext,
   TEvent extends EventObject = AnyEventObject,
@@ -24,7 +24,7 @@ export function createMachine<
 >(
   config: MachineConfig<TContext, TEvent>,
   options?: Partial<MachineImplementations<TContext, TEvent>>
-): MachineNode<TContext, TEvent, TTypestate>;
+): StateMachine<TContext, TEvent, TTypestate>;
 export function createMachine<
   TContext,
   TEvent extends EventObject = AnyEventObject,
@@ -32,8 +32,8 @@ export function createMachine<
 >(
   definition: MachineConfig<TContext, TEvent>,
   implementations?: Partial<MachineImplementations<TContext, TEvent>>
-): MachineNode<TContext, TEvent, TTypestate> {
-  return new MachineNode<TContext, TEvent, TTypestate>(
+): StateMachine<TContext, TEvent, TTypestate> {
+  return new StateMachine<TContext, TEvent, TTypestate>(
     definition,
     implementations
   );

--- a/packages/core/src/MachineNode.ts
+++ b/packages/core/src/MachineNode.ts
@@ -17,19 +17,13 @@ import { IS_PRODUCTION } from './environment';
 import { STATE_DELIMITER } from './constants';
 import {
   getConfiguration,
-  getChildren,
   getAllStateNodes,
   resolveMicroTransition,
   macrostep,
   toState,
   isStateId
 } from './stateUtils';
-import {
-  getStateNodeById,
-  getStateNodes,
-  transitionNode,
-  resolveStateValue
-} from './stateUtils';
+import { getStateNodes, transitionNode, resolveStateValue } from './stateUtils';
 import { StateNode } from './StateNode';
 
 export const NULL_EVENT = '';

--- a/packages/core/src/MachineNode.ts
+++ b/packages/core/src/MachineNode.ts
@@ -169,7 +169,7 @@ export class MachineNode<
    *
    * @param state The state to resolve
    */
-  public resolveState(state: State<TContext, TEvent>): State<TContext, TEvent> {
+  public resolveState(state: State<TContext, TEvent, any>): typeof state {
     const configuration = Array.from(
       getConfiguration(getStateNodes(this.root, state.value))
     );

--- a/packages/core/src/State.ts
+++ b/packages/core/src/State.ts
@@ -147,17 +147,25 @@ export class State<
    * @param stateValue
    * @param context
    */
+  public static inert<TState extends State<any, any, any>>(
+    state: TState,
+    context: any
+  ): TState;
   public static inert<TC, TE extends EventObject = EventObject>(
-    stateValue: State<TC, TE> | StateValue,
+    stateValue: StateValue,
     context: TC
-  ): State<TC, TE> {
+  ): State<TC, TE>;
+  public static inert(
+    stateValue: State<any, any> | StateValue,
+    context: any
+  ): State<any, any> {
     if (stateValue instanceof State) {
       if (!stateValue.actions.length) {
-        return stateValue as State<TC, TE>;
+        return stateValue;
       }
-      const _event = initEvent as SCXML.Event<TE>;
+      const _event = initEvent as SCXML.Event<any>;
 
-      return new State<TC, TE>({
+      return new State<any>({
         value: stateValue.value,
         context,
         _event,
@@ -169,7 +177,7 @@ export class State<
       });
     }
 
-    return State.from<TC, TE>(stateValue, context);
+    return State.from(stateValue, context);
   }
 
   /**

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -54,7 +54,7 @@ function resolveContext<TContext>(
   };
 }
 
-export class MachineNode<
+export class StateMachine<
   TContext = any,
   TEvent extends EventObject = EventObject,
   TTypestate extends Typestate<TContext> = any
@@ -135,10 +135,10 @@ export class MachineNode<
    */
   public provide(
     implementations: Partial<MachineImplementations<TContext, TEvent>>
-  ): MachineNode<TContext, TEvent> {
+  ): StateMachine<TContext, TEvent> {
     const { actions, guards, actors, delays } = this.options;
 
-    return new MachineNode(this.config, {
+    return new StateMachine(this.config, {
       actions: { ...actions, ...implementations.actions },
       guards: { ...guards, ...implementations.guards },
       actors: { ...actors, ...implementations.actors },
@@ -156,7 +156,7 @@ export class MachineNode<
    */
   public withContext(
     context: Partial<TContext>
-  ): MachineNode<TContext, TEvent> {
+  ): StateMachine<TContext, TEvent> {
     return this.provide({
       context: resolveContext(this.context, context)
     });

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -40,7 +40,7 @@ import {
   getCandidates
 } from './stateUtils';
 import { evaluateGuard } from './guards';
-import { MachineNode } from './MachineNode';
+import { StateMachine } from './StateMachine';
 import { STATE_DELIMITER } from './constants';
 
 const EMPTY_OBJECT = {};
@@ -48,7 +48,7 @@ const EMPTY_OBJECT = {};
 interface StateNodeOptions<TContext, TEvent extends EventObject> {
   _key: string;
   _parent?: StateNode<TContext, TEvent>;
-  _machine: MachineNode<TContext, TEvent>;
+  _machine: StateMachine<TContext, TEvent>;
 }
 
 export class StateNode<
@@ -103,7 +103,7 @@ export class StateNode<
   /**
    * The root machine node.
    */
-  public machine: MachineNode<TContext, TEvent>;
+  public machine: StateMachine<TContext, TEvent>;
   /**
    * The meta data associated with this state node, which will be returned in State instances.
    */

--- a/packages/core/src/behavior.ts
+++ b/packages/core/src/behavior.ts
@@ -20,7 +20,7 @@ import {
   isFunction
 } from './utils';
 import { doneInvoke, error, actionTypes } from './actions';
-import { MachineNode } from './MachineNode';
+import { StateMachine } from './StateMachine';
 import { interpret, Interpreter } from './interpreter';
 import { State } from './State';
 import { CapturedState } from './capturedState';
@@ -244,13 +244,15 @@ export function createObservableBehavior<
 }
 
 export function createMachineBehavior<TContext, TEvent extends EventObject>(
-  machine: MachineNode<TContext, TEvent> | Lazy<MachineNode<TContext, TEvent>>,
+  machine:
+    | StateMachine<TContext, TEvent>
+    | Lazy<StateMachine<TContext, TEvent>>,
   options?: Partial<InterpreterOptions>
 ): Behavior<TEvent, State<TContext, TEvent>> {
   const parent = CapturedState.current?.actorRef;
   let service: Interpreter<TContext, TEvent> | undefined;
   let subscription: Subscription;
-  let resolvedMachine: MachineNode<TContext, TEvent>;
+  let resolvedMachine: StateMachine<TContext, TEvent>;
 
   const behavior: Behavior<TEvent, State<TContext, TEvent>> = {
     receiveSignal: (actorContext, signal) => {
@@ -337,7 +339,7 @@ export function createBehaviorFrom<
   TEvent extends EventObject,
   TEmitted extends State<any, any>
 >(
-  entity: MachineNode<TEmitted['context'], any, TEmitted['event']>
+  entity: StateMachine<TEmitted['context'], any, TEmitted['event']>
 ): Behavior<TEvent, TEmitted>;
 export function createBehaviorFrom<TEvent extends EventObject>(
   entity: InvokeCallback

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,7 +23,7 @@ import {
 } from './actions';
 import { interpret, Interpreter, InterpreterStatus } from './interpreter';
 import { matchState } from './match';
-export { MachineNode } from './MachineNode';
+export { StateMachine as MachineNode } from './StateMachine';
 export { SimulatedClock } from './SimulatedClock';
 export {
   spawn,

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -142,7 +142,7 @@ export class Interpreter<
 
     const { clock, logger, parent, id } = resolvedOptions;
 
-    const resolvedId = id !== undefined ? id : machine.id;
+    const resolvedId = id !== undefined ? id : machine.key;
 
     this.id = resolvedId;
     this.logger = logger;
@@ -219,13 +219,13 @@ export class Interpreter<
       listener(state, state.event);
     }
 
-    const isDone = isInFinalState(state.configuration || [], this.machine);
+    const isDone = isInFinalState(state.configuration || [], this.machine.root);
 
     if (this.state.configuration && isDone) {
       // get final child state node
       const finalChildStateNode = state.configuration.find(
         (stateNode) =>
-          stateNode.type === 'final' && stateNode.parent === this.machine
+          stateNode.type === 'final' && stateNode.parent === this.machine.root
       );
 
       const doneData =
@@ -494,7 +494,7 @@ export class Interpreter<
         warn(
           false,
           `Event "${_event.name}" was sent to stopped service "${
-            this.machine.id
+            this.machine.key
           }". This service has already reached its final state, and will not transition.\nEvent: ${JSON.stringify(
             _event.data
           )}`
@@ -509,7 +509,7 @@ export class Interpreter<
     ) {
       throw new Error(
         `Event "${_event.name}" was sent to uninitialized service "${
-          this.machine.id
+          this.machine.key
           // tslint:disable-next-line:max-line-length
         }". Make sure .start() is called for this service, or set { deferEvents: true } in the service options.\nEvent: ${JSON.stringify(
           _event.data
@@ -546,7 +546,7 @@ export class Interpreter<
     } else if (this.status !== InterpreterStatus.Running) {
       throw new Error(
         // tslint:disable-next-line:max-line-length
-        `${events.length} event(s) were sent to uninitialized service "${this.machine.id}". Make sure .start() is called for this service, or set { deferEvents: true } in the service options.`
+        `${events.length} event(s) were sent to uninitialized service "${this.machine.key}". Make sure .start() is called for this service, or set { deferEvents: true } in the service options.`
       );
     }
 

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -537,7 +537,7 @@ export class Interpreter<
         warn(
           false,
           `${events.length} event(s) were sent to uninitialized service "${
-            this.machine.id
+            this.machine.key
           }" and are deferred. Make sure .start()  is called for this service.\nEvents: ${JSON.stringify(
             events
           )}`

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -322,7 +322,7 @@ export class Interpreter<
    *
    * @param listener The listener
    */
-  public onStop(listener: Listener): Interpreter<TContext, TEvent, TTypestate> {
+  public onStop(listener: Listener): this {
     this.stopListeners.add(listener);
     return this;
   }
@@ -333,7 +333,7 @@ export class Interpreter<
    *
    * @param listener The error listener
    */
-  public onError(listener: ErrorListener): Interpreter<TContext, TEvent> {
+  public onError(listener: ErrorListener): this {
     this.errorListeners.add(listener);
     return this;
   }

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -203,7 +203,7 @@ export class Interpreter<
   }
 
   private update(
-    state: State<TContext, TEvent, TTypestate>,
+    state: State<TContext, TEvent, any>,
     _event: SCXML.Event<TEvent>
   ): void {
     // Attach session ID to state
@@ -453,7 +453,7 @@ export class Interpreter<
   }
 
   private _transition(
-    state: State<TContext, TEvent>,
+    state: State<TContext, TEvent, any>,
     event: SCXML.Event<TEvent>
   ) {
     try {

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -40,7 +40,7 @@ import { Scheduler } from './scheduler';
 import { isActorRef, fromService } from './Actor';
 import { isInFinalState } from './stateUtils';
 import { registry } from './registry';
-import { MachineNode } from './MachineNode';
+import { StateMachine } from './StateMachine';
 import { devToolsAdapter } from './dev';
 import { CapturedState } from './capturedState';
 import { PayloadSender, SpawnedActorRef, StopActionObject } from '.';
@@ -132,7 +132,7 @@ export class Interpreter<
    * @param options Interpreter options
    */
   constructor(
-    public machine: MachineNode<TContext, TEvent, TTypestate>,
+    public machine: StateMachine<TContext, TEvent, TTypestate>,
     options?: Partial<InterpreterOptions>
   ) {
     const resolvedOptions: InterpreterOptions = {
@@ -845,7 +845,7 @@ export function interpret<
   TEvent extends EventObject = EventObject,
   TTypestate extends Typestate<TContext> = { value: any; context: TContext }
 >(
-  machine: MachineNode<TContext, TEvent, TTypestate>,
+  machine: StateMachine<TContext, TEvent, TTypestate>,
   options?: Partial<InterpreterOptions>
 ) {
   const interpreter = new Interpreter<TContext, TEvent, TTypestate>(

--- a/packages/core/src/invoke.ts
+++ b/packages/core/src/invoke.ts
@@ -9,7 +9,7 @@ import {
 
 import { isFunction, mapContext } from './utils';
 import { AnyEventObject } from './types';
-import { MachineNode } from './MachineNode';
+import { StateMachine } from './StateMachine';
 import {
   createMachineBehavior,
   createDeferredBehavior,
@@ -23,7 +23,7 @@ export const DEFAULT_SPAWN_OPTIONS = { sync: false };
 export function invokeMachine<
   TContext,
   TEvent extends EventObject,
-  TMachine extends MachineNode<any, any, any>
+  TMachine extends StateMachine<any, any, any>
 >(
   machine:
     | TMachine

--- a/packages/core/src/scxml.ts
+++ b/packages/core/src/scxml.ts
@@ -11,7 +11,7 @@ import { createMachine } from './index';
 import { mapValues, keys, isString, flatten } from './utils';
 import * as actions from './actions';
 import { invokeMachine } from './invoke';
-import { MachineNode } from './MachineNode';
+import { StateMachine } from './StateMachine';
 import { not, stateIn } from './guards';
 
 function getAttribute(
@@ -484,7 +484,7 @@ export interface ScxmlToMachineOptions {
 function scxmlToMachine(
   scxmlJson: XMLElement,
   options: ScxmlToMachineOptions
-): MachineNode {
+): StateMachine {
   const machineElement = scxmlJson.elements!.find(
     (element) => element.name === 'scxml'
   ) as XMLElement;
@@ -525,7 +525,7 @@ function scxmlToMachine(
 export function toMachine(
   xml: string,
   options: ScxmlToMachineOptions
-): MachineNode {
+): StateMachine {
   const json = xml2js(xml) as XMLElement;
   return scxmlToMachine(json, options);
 }

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -21,7 +21,6 @@ import {
   DelayedTransitionDefinition,
   NullEvent,
   SingleOrArray,
-  Typestate,
   DelayExpr,
   SCXML,
   Transitions,

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -861,7 +861,7 @@ export function transitionParallelNode<TContext, TEvent extends EventObject>(
 export function transitionNode<TContext, TEvent extends EventObject>(
   stateNode: StateNode<TContext, TEvent>,
   stateValue: StateValue,
-  state: State<TContext, TEvent>,
+  state: State<TContext, TEvent, any>,
   _event: SCXML.Event<TEvent>
 ): Transitions<TContext, TEvent> | undefined {
   // leaf node
@@ -1450,16 +1450,12 @@ function selectEventlessTransitions<TContext, TEvent extends EventObject>(
   );
 }
 
-export function resolveMicroTransition<
-  TContext,
-  TEvent extends EventObject,
-  TTypestate extends Typestate<TContext>
->(
+export function resolveMicroTransition<TContext, TEvent extends EventObject>(
   machine: MachineNode<TContext, TEvent>,
   transitions: Transitions<TContext, TEvent>,
-  currentState?: State<TContext, TEvent>,
+  currentState?: State<TContext, TEvent, any>,
   _event: SCXML.Event<TEvent> = initEvent as SCXML.Event<TEvent>
-): State<TContext, TEvent, TTypestate> {
+): State<TContext, TEvent, any> {
   // Transition will "apply" if:
   // - the state node is the initial state (there is no current state)
   // - OR there are transitions
@@ -1525,7 +1521,7 @@ export function resolveMicroTransition<
 
   const { context, actions: nonRaisedActions } = resolved;
 
-  const nextState = new State<TContext, TEvent, TTypestate>({
+  const nextState = new State<TContext, TEvent>({
     value: getStateValue(machine.root, resolved.configuration),
     context,
     _event,
@@ -1730,12 +1726,15 @@ function resolveActionsAndContext<TContext, TEvent extends EventObject>(
   };
 }
 
+type StateFromMachine<TMachine extends MachineNode> = TMachine['initialState'];
+
 export function macrostep<
-  TContext,
-  TEvent extends EventObject,
-  TMachine extends MachineNode<TContext, TEvent>
+  TMachine extends MachineNode,
+  TEvent extends EventObject = TMachine extends MachineNode<any, infer E>
+    ? E
+    : never
 >(
-  state: State<TContext, TEvent>,
+  state: StateFromMachine<TMachine>,
   event: Event<TEvent> | SCXML.Event<TEvent> | null,
   machine: TMachine
 ): typeof state {

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -1821,7 +1821,7 @@ export function resolveStateValue<TContext, TEvent extends EventObject>(
 export function toState<TMachine extends MachineNode<any, any, any>>(
   state: StateValue | TMachine['initialState'],
   machine: TMachine
-): TMachine['initialState'] {
+): StateFromMachine<TMachine> {
   if (state instanceof State) {
     return state;
   } else {

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -42,8 +42,7 @@ import {
   ChooseAction,
   StopActionObject,
   AnyEventObject,
-  InvokeSourceDefinition,
-  EventOfMachine
+  InvokeSourceDefinition
 } from './types';
 import { State } from './State';
 import {
@@ -1731,12 +1730,13 @@ function resolveActionsAndContext<TContext, TEvent extends EventObject>(
   };
 }
 
-export function macrostep<TMachine extends MachineNode<any, any>>(
-  state: TMachine['initialState'],
-  event:
-    | Event<EventOfMachine<TMachine>>
-    | SCXML.Event<EventOfMachine<TMachine>>
-    | null,
+export function macrostep<
+  TContext,
+  TEvent extends EventObject,
+  TMachine extends MachineNode<TContext, TEvent>
+>(
+  state: State<TContext, TEvent>,
+  event: Event<TEvent> | SCXML.Event<TEvent> | null,
   machine: TMachine
 ): typeof state {
   // Assume the state is at rest (no raised events)
@@ -1753,7 +1753,7 @@ export function macrostep<TMachine extends MachineNode<any, any>>(
 
     maybeNextState = machine.microstep(
       maybeNextState,
-      raisedEvent as SCXML.Event<EventOfMachine<TMachine>>
+      raisedEvent as SCXML.Event<TEvent>
     );
 
     _internalQueue.push(...maybeNextState._internalQueue);

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -669,7 +669,7 @@ export function getStateNode<TContext, TEvent extends EventObject>(
   stateKey: string
 ): StateNode<TContext, TEvent> {
   if (isStateId(stateKey)) {
-    return getStateNodeById(stateNode, stateKey);
+    return stateNode.machine.getStateNodeById(stateKey);
   }
   if (!stateNode.states) {
     throw new Error(
@@ -684,29 +684,7 @@ export function getStateNode<TContext, TEvent extends EventObject>(
   }
   return result;
 }
-/**
- * Returns the state node with the given `stateId`, or throws.
- *
- * @param stateId The state ID. The prefix "#" is removed.
- */
-export function getStateNodeById<TContext, TEvent extends EventObject>(
-  fromStateNode: StateNode<TContext, TEvent>,
-  stateId: string
-): StateNode<TContext, TEvent> {
-  const resolvedStateId = isStateId(stateId)
-    ? stateId.slice(STATE_IDENTIFIER.length)
-    : stateId;
-  if (resolvedStateId === fromStateNode.id) {
-    return fromStateNode;
-  }
-  const stateNode = fromStateNode.machine.idMap.get(resolvedStateId);
-  if (!stateNode) {
-    throw new Error(
-      `Child state node '#${resolvedStateId}' does not exist on machine '${fromStateNode.id}'`
-    );
-  }
-  return stateNode;
-}
+
 /**
  * Returns the relative state node from the given `statePath`, or throws.
  *
@@ -718,7 +696,7 @@ function getStateNodeByPath<TContext, TEvent extends EventObject>(
 ): StateNode<TContext, TEvent> {
   if (typeof statePath === 'string' && isStateId(statePath)) {
     try {
-      return getStateNodeById(stateNode, statePath.slice(1));
+      return stateNode.machine.getStateNodeById(statePath);
     } catch (e) {
       // try individual paths
       // throw e;

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -67,7 +67,7 @@ import {
 import { IS_PRODUCTION } from './environment';
 import { STATE_IDENTIFIER, NULL_EVENT, WILDCARD } from './constants';
 import { isSpawnedActorRef } from './Actor';
-import { MachineNode } from './MachineNode';
+import { StateMachine } from './StateMachine';
 import { evaluateGuard, toGuardDefinition } from './guards';
 
 type Configuration<TC, TE extends EventObject> = Iterable<StateNode<TC, TE>>;
@@ -1316,7 +1316,7 @@ export function microstep<TContext, TEvent extends EventObject>(
   transitions: Array<TransitionDefinition<TContext, TEvent>>,
   currentState: State<TContext, TEvent> | undefined,
   mutConfiguration: Set<StateNode<TContext, TEvent>>,
-  machine: MachineNode<TContext, TEvent>,
+  machine: StateMachine<TContext, TEvent>,
   _event: SCXML.Event<TEvent>
 ): {
   actions: Array<ActionObject<TContext, TEvent>>;
@@ -1428,7 +1428,7 @@ function selectEventlessTransitions<TContext, TEvent extends EventObject>(
 }
 
 export function resolveMicroTransition<TContext, TEvent extends EventObject>(
-  machine: MachineNode<TContext, TEvent>,
+  machine: StateMachine<TContext, TEvent>,
   transitions: Transitions<TContext, TEvent>,
   currentState?: State<TContext, TEvent, any>,
   _event: SCXML.Event<TEvent> = initEvent as SCXML.Event<TEvent>
@@ -1546,7 +1546,7 @@ export function resolveMicroTransition<TContext, TEvent extends EventObject>(
 
 function resolveActionsAndContext<TContext, TEvent extends EventObject>(
   actions: Array<ActionObject<TContext, TEvent>>,
-  machine: MachineNode<TContext, TEvent, any>,
+  machine: StateMachine<TContext, TEvent, any>,
   _event: SCXML.Event<TEvent>,
   currentState: State<TContext, TEvent, any> | undefined
 ): {
@@ -1703,11 +1703,11 @@ function resolveActionsAndContext<TContext, TEvent extends EventObject>(
   };
 }
 
-type StateFromMachine<TMachine extends MachineNode> = TMachine['initialState'];
+type StateFromMachine<TMachine extends StateMachine> = TMachine['initialState'];
 
 export function macrostep<
-  TMachine extends MachineNode,
-  TEvent extends EventObject = TMachine extends MachineNode<any, infer E>
+  TMachine extends StateMachine,
+  TEvent extends EventObject = TMachine extends StateMachine<any, infer E>
     ? E
     : never
 >(
@@ -1796,7 +1796,7 @@ export function resolveStateValue<TContext, TEvent extends EventObject>(
   return getStateValue(rootNode, [...configuration]);
 }
 
-export function toState<TMachine extends MachineNode<any, any, any>>(
+export function toState<TMachine extends StateMachine<any, any, any>>(
   state: StateValue | TMachine['initialState'],
   machine: TMachine
 ): StateFromMachine<TMachine> {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1207,3 +1207,7 @@ export type InterpreterFrom<
 > = T extends MachineNode<infer TContext, infer TEvent, infer TTypestate>
   ? Interpreter<TContext, TEvent, TTypestate>
   : never;
+
+export type EventOfMachine<
+  TMachine extends MachineNode<any, any>
+> = TMachine extends MachineNode<any, infer E> ? E : never;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,7 +1,7 @@
 import { StateNode } from './StateNode';
 import { State } from './State';
 import { Clock, Interpreter } from './interpreter';
-import { MachineNode } from './MachineNode';
+import { StateMachine } from './StateMachine';
 import { Behavior } from './behavior';
 
 export type EventType = string;
@@ -627,9 +627,9 @@ export type HistoryValue<TContext, TEvent extends EventObject> = Record<
   Array<StateNode<TContext, TEvent>>
 >;
 
-export type StateFrom<TMachine extends MachineNode<any, any, any>> = ReturnType<
-  TMachine['transition']
->;
+export type StateFrom<
+  TMachine extends StateMachine<any, any, any>
+> = ReturnType<TMachine['transition']>;
 
 export type Transitions<TContext, TEvent extends EventObject> = Array<
   TransitionDefinition<TContext, TEvent>
@@ -1059,8 +1059,8 @@ export type AnyInterpreter = Interpreter<any, any, any>;
  * @typeParam TM - the machine to infer the interpreter's types from
  */
 export type InterpreterOf<
-  TM extends MachineNode<any, any, any>
-> = TM extends MachineNode<infer TContext, infer TEvent, infer TTypestate>
+  TM extends StateMachine<any, any, any>
+> = TM extends StateMachine<infer TContext, infer TEvent, infer TTypestate>
   ? Interpreter<TContext, TEvent, TTypestate>
   : never;
 
@@ -1129,7 +1129,7 @@ export declare namespace SCXML {
 }
 
 export type Spawnable =
-  | MachineNode<any, any, any>
+  | StateMachine<any, any, any>
   | PromiseLike<any>
   | InvokeCallback
   | Subscribable<any>;
@@ -1190,7 +1190,7 @@ export interface SpawnedActorRef<TEvent extends EventObject, TEmitted = any>
   toJSON?: () => any;
 }
 
-export type ActorRefFrom<T extends Spawnable> = T extends MachineNode<
+export type ActorRefFrom<T extends Spawnable> = T extends StateMachine<
   infer TContext,
   infer TEvent,
   infer TTypestate
@@ -1203,11 +1203,11 @@ export type DevToolsAdapter = (service: AnyInterpreter) => void;
 export type Lazy<T> = () => T;
 
 export type InterpreterFrom<
-  T extends MachineNode<any, any, any>
-> = T extends MachineNode<infer TContext, infer TEvent, infer TTypestate>
+  T extends StateMachine<any, any, any>
+> = T extends StateMachine<infer TContext, infer TEvent, infer TTypestate>
   ? Interpreter<TContext, TEvent, TTypestate>
   : never;
 
 export type EventOfMachine<
-  TMachine extends MachineNode<any, any>
-> = TMachine extends MachineNode<any, infer E> ? E : never;
+  TMachine extends StateMachine<any, any>
+> = TMachine extends StateMachine<any, infer E> ? E : never;

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -20,7 +20,7 @@ import { STATE_DELIMITER, TARGETLESS_KEY } from './constants';
 import { IS_PRODUCTION } from './environment';
 import { StateNode } from './StateNode';
 import { InvokeConfig, SCXMLErrorEvent } from '.';
-import { MachineNode } from './MachineNode';
+import { StateMachine } from './StateMachine';
 import { Behavior } from './behavior';
 import { errorExecution, errorPlatform } from './actionTypes';
 
@@ -328,7 +328,9 @@ export const symbolObservable = (() =>
   (typeof Symbol === 'function' && (Symbol as any).observable) ||
   '@@observable')();
 
-export function isMachineNode(value: any): value is MachineNode<any, any, any> {
+export function isMachineNode(
+  value: any
+): value is StateMachine<any, any, any> {
   try {
     return '__xstatenode' in value && value.parent === undefined;
   } catch (e) {

--- a/packages/core/test/definition.test.ts
+++ b/packages/core/test/definition.test.ts
@@ -11,6 +11,6 @@ describe('definition', () => {
       }
     });
 
-    expect(invokeMachine.definition.invoke.length).toBe(2);
+    expect(invokeMachine.root.definition.invoke.length).toBe(2);
   });
 });

--- a/packages/core/test/fixtures/id.ts
+++ b/packages/core/test/fixtures/id.ts
@@ -42,28 +42,6 @@ export const machine = createMachine({
           id: 'B.dot'
         }
       }
-    },
-    getter: {
-      on: {
-        get NEXT() {
-          return machine.states.A;
-        },
-        get NEXT_DEEP() {
-          return machine.states.A.states.foo;
-        },
-        NEXT_TARGET: {
-          get target() {
-            return machine.states.B;
-          }
-        },
-        NEXT_TARGET_ARRAY: [
-          {
-            get target() {
-              return machine.states.B;
-            }
-          }
-        ]
-      }
     }
   }
 });

--- a/packages/core/test/machine.test.ts
+++ b/packages/core/test/machine.test.ts
@@ -370,7 +370,7 @@ describe('machine', () => {
         states: { idle: {} }
       });
 
-      expect(idMachine.id).toEqual('some-id');
+      expect(idMachine.key).toEqual('some-id');
     });
 
     it('should represent the ID (state node)', () => {
@@ -394,7 +394,7 @@ describe('machine', () => {
         states: { idle: {} }
       });
 
-      expect(noIDMachine.id).toEqual('some-key');
+      expect(noIDMachine.key).toEqual('some-key');
     });
 
     it('should use the key as the ID if no ID is provided (state node)', () => {

--- a/packages/core/test/order.test.ts
+++ b/packages/core/test/order.test.ts
@@ -60,7 +60,10 @@ describe('document order', () => {
       ]);
     }
 
-    const allStateNodeOrders = dfs(machine).map((sn) => [sn.key, sn.order]);
+    const allStateNodeOrders = dfs(machine.root).map((sn) => [
+      sn.key,
+      sn.order
+    ]);
 
     expect(allStateNodeOrders).toEqual([
       ['order', 0],

--- a/packages/core/test/resolve.test.ts
+++ b/packages/core/test/resolve.test.ts
@@ -63,7 +63,7 @@ describe('resolve()', () => {
     const unresolvedStateValue = { p1: { s1: { p2: 's4' }, s2: { p4: 's8' } } };
 
     const resolvedStateValue = resolveStateValue(
-      flatParallelMachine,
+      flatParallelMachine.root,
       unresolvedStateValue
     );
     expect(resolvedStateValue).toEqual({

--- a/packages/core/test/scxml.test.ts
+++ b/packages/core/test/scxml.test.ts
@@ -416,7 +416,7 @@ async function runTestToCompletion(
     }
     service.send(event.name);
 
-    const stateIds = getStateNodes(machine, nextState).map(
+    const stateIds = getStateNodes(machine.root, nextState).map(
       (stateNode) => stateNode.id
     );
 

--- a/packages/core/test/scxml.test.ts
+++ b/packages/core/test/scxml.test.ts
@@ -7,7 +7,7 @@ import { interpret } from '../src/interpreter';
 import { SimulatedClock } from '../src/SimulatedClock';
 import { State } from '../src';
 import { getStateNodes } from '../src/stateUtils';
-import { MachineNode } from '../src/MachineNode';
+import { StateMachine } from '../src/StateMachine';
 
 const TEST_FRAMEWORK = path.dirname(
   pkgUp.sync({
@@ -349,7 +349,7 @@ interface SCIONTest {
   }>;
 }
 
-async function runW3TestToCompletion(machine: MachineNode): Promise<void> {
+async function runW3TestToCompletion(machine: StateMachine): Promise<void> {
   await new Promise<void>((resolve, reject) => {
     let nextState: State<any>;
 
@@ -376,7 +376,7 @@ async function runW3TestToCompletion(machine: MachineNode): Promise<void> {
 }
 
 async function runTestToCompletion(
-  machine: MachineNode,
+  machine: StateMachine,
   test: SCIONTest
 ): Promise<void> {
   if (!test.events.length && test.initialConfiguration[0] === 'pass') {

--- a/packages/core/test/utils.ts
+++ b/packages/core/test/utils.ts
@@ -1,9 +1,9 @@
 import { State } from '../src/index';
 import { matchesState } from '../src';
-import { MachineNode } from '../src/MachineNode';
+import { StateMachine } from '../src/StateMachine';
 
 export function testMultiTransition<TContext>(
-  machine: MachineNode<TContext>,
+  machine: StateMachine<TContext>,
   fromState: string,
   eventTypes: string
 ) {
@@ -20,7 +20,7 @@ export function testMultiTransition<TContext>(
   return resultState;
 }
 
-export function testAll(machine: MachineNode, expected: {}): void {
+export function testAll(machine: StateMachine, expected: {}): void {
   Object.keys(expected).forEach((fromState) => {
     Object.keys(expected[fromState]).forEach((eventTypes) => {
       const toState = expected[fromState][eventTypes];

--- a/packages/xstate-graph/src/graph.ts
+++ b/packages/xstate-graph/src/graph.ts
@@ -342,7 +342,12 @@ export function getSimplePathsAsArray<
   return keys(result).map((key) => result[key]);
 }
 
-export function toDirectedGraph(stateNode: StateNode): DirectedGraphNode {
+export function toDirectedGraph(
+  machineNode: MachineNode | StateNode
+): DirectedGraphNode {
+  const stateNode =
+    machineNode instanceof StateNode ? machineNode : machineNode.root;
+
   const edges: DirectedGraphEdge[] = flatten(
     stateNode.transitions.map((t, transitionIndex) => {
       const targets = t.target ? t.target : [stateNode];

--- a/packages/xstate-graph/src/graph.ts
+++ b/packages/xstate-graph/src/graph.ts
@@ -346,7 +346,7 @@ export function toDirectedGraph(
   machineNode: MachineNode | StateNode
 ): DirectedGraphNode {
   const stateNode =
-    machineNode instanceof StateNode ? machineNode : machineNode.root;
+    machineNode instanceof StateNode ? machineNode : machineNode.root; // TODO: accept only machines
 
   const edges: DirectedGraphEdge[] = flatten(
     stateNode.transitions.map((t, transitionIndex) => {

--- a/packages/xstate-scxml/src/index.ts
+++ b/packages/xstate-scxml/src/index.ts
@@ -156,7 +156,7 @@ function stateNodeToSCXML(stateNode: StateNode<any, any>): XMLElement {
 }
 
 export function toSCXML(machine: MachineNode<any, any, any>): string {
-  const { states, initial } = machine;
+  const { states, initial } = machine.root;
 
   const elements = Object.keys(states).map<XMLElement>((key) => {
     const stateNode = states[key];

--- a/packages/xstate-scxml/src/scxml.ts
+++ b/packages/xstate-scxml/src/scxml.ts
@@ -11,7 +11,7 @@ import {
 import { mapValues, keys, isString, flatten } from 'xstate/src/utils';
 import * as actions from 'xstate/actions';
 import { invokeMachine } from 'xstate/invoke';
-import { MachineNode } from 'xstate/src/MachineNode';
+import { StateMachine } from 'xstate/src/StateMachine';
 import { not, stateIn } from 'xstate/guards';
 
 function getAttribute(
@@ -484,7 +484,7 @@ export interface ScxmlToMachineOptions {
 function scxmlToMachine(
   scxmlJson: XMLElement,
   options: ScxmlToMachineOptions
-): MachineNode {
+): StateMachine {
   const machineElement = scxmlJson.elements!.find(
     (element) => element.name === 'scxml'
   ) as XMLElement;
@@ -525,7 +525,7 @@ function scxmlToMachine(
 export function toMachine(
   xml: string,
   options: ScxmlToMachineOptions
-): MachineNode {
+): StateMachine {
   const json = xml2js(xml) as XMLElement;
   return scxmlToMachine(json, options);
 }

--- a/packages/xstate-scxml/test/scxml.test.ts
+++ b/packages/xstate-scxml/test/scxml.test.ts
@@ -4,9 +4,9 @@ import {
   interpret,
   MachineNode,
   SimulatedClock,
-  toMachine,
   getStateNodes
 } from 'xstate';
+import { toMachine } from 'xstate/src/scxml';
 import { xml2js } from 'xml-js';
 import { transitionToSCXML, toSCXML } from '../src';
 import * as fs from 'fs';
@@ -47,7 +47,7 @@ async function runTestToCompletion(
     }
     service.send(event.name);
 
-    const stateIds = getStateNodes(machine, nextState).map(
+    const stateIds = getStateNodes(machine.root, nextState).map(
       (stateNode) => stateNode.id
     );
 

--- a/packages/xstate-scxml/test/scxml.test.ts
+++ b/packages/xstate-scxml/test/scxml.test.ts
@@ -108,7 +108,7 @@ describe('scxml', () => {
           delimiter: '$'
         });
 
-        await runTestToCompletion(machine, scxmlTest);
+        await runTestToCompletion(machine as any, scxmlTest); // TODO: fix
       }, 2000);
     });
   });

--- a/packages/xstate-viz/src/index.tsx
+++ b/packages/xstate-viz/src/index.tsx
@@ -85,7 +85,7 @@ export const ServiceViz: React.FC<{
   return (
     <StateContext.Provider value={state}>
       <pre>{JSON.stringify(state, null, 2)}</pre>
-      <StateNodeViz stateNode={service.machine} />
+      <StateNodeViz stateNode={service.machine.root} />
     </StateContext.Provider>
   );
 };


### PR DESCRIPTION
This PR adds `machine.root` to the `StateMachine` class, which represents the root `StateNode` for the machine. Previously, the `StateMachine` (previously named `MachineNode`) _extended_ `StateNode`, but ideally these should be separate.

<img width="695" alt="CleanShot 2021-05-18 at 15 23 54@2x" src="https://user-images.githubusercontent.com/1093738/118711043-15742f00-b7ed-11eb-91bc-fc714d0ff15d.png">
