### PR TITLE
Mark @xstate/examples-fetch as private

### DIFF
--- a/examples/fetch/package.json
+++ b/examples/fetch/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@xstate/examples-fetch",
   "version": "1.0.0",
+  "private": true,
   "main": "index.js",
   "author": "David Khourshid",
   "license": "MIT",


### PR DESCRIPTION
This got accidentally published to npm and this flag should prevent it in the future.