### PR TITLE
[docs] Fix edit link

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -10,6 +10,7 @@ module.exports = {
     lastUpdated: 'Last Updated',
     repo: 'davidkpiano/xstate',
     docsDir: 'docs',
+    docsBranch: 'main',
     editLinks: true,
     logo: '/logo.svg',
     algolia: {


### PR DESCRIPTION
This PR sets `docsBranch` to `'main'` so that the edit links work on the documentation pages.

Fixes #2219