### PR TITLE
[docs] Fix example usage of updateAge

### DIFF
--- a/docs/guides/models.md
+++ b/docs/guides/models.md
@@ -89,7 +89,7 @@ const machine = createMachine(
             })
           },
           updateAge: {
-            actions: 'updateAge'
+            actions: 'assignAge'
           }
         }
       }
@@ -97,7 +97,7 @@ const machine = createMachine(
   },
   {
     actions: {
-      updateAge: userModel.assign({
+      assignAge: userModel.assign({
         age: (_, event) => event.value // inferred
       })
     }
@@ -184,7 +184,7 @@ const machine = createMachine<typeof userModel>(
       active: {
         on: {
           updateAge: {
-            actions: 'updateAge'
+            actions: 'assignAge'
           }
         }
       }
@@ -192,12 +192,12 @@ const machine = createMachine<typeof userModel>(
   },
   {
     actions: {
-      updateAge: userModel.assign(
+      assignAge: userModel.assign(
         {
-          age: (_, event) => event.value // inferred
+          // The `event.type` here is restricted to "updateAge"
+          age: (_, event) => event.value // inferred as `number`
         },
-        // infers the event type from userModel.events.updateAge
-        'updateAge'
+        'updateAge' // Restricts the `event` allowed by the "assignAge" action
       )
     }
   }


### PR DESCRIPTION
The action and event were named the same (`'updateAge'`) which caused confusion. This PR fixes that ✍️ 