### PR TITLE
Add CONTRIBUTING.md instruction for package docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Pull requests are encouraged. If you want to add a feature or fix a bug:
 3. Make your changes, and ensure that it is formatted by [Prettier](https://prettier.io) and type-checks without errors in [TypeScript](https://www.typescriptlang.org/)
 4. Write tests that validate your change and/or fix.
 5. Run `yarn build` and then run tests with `yarn test` (for all packages) or `yarn test:core` (for only changes to core XState).
-6. For package changes, add docs inside the `src/packages/*/README.md`. They will be copied on build to the corresponding `docs/packages/*/index.md` file.
+6. For package changes, add docs inside the `/packages/*/README.md`. They will be copied on build to the corresponding `/docs/packages/*/index.md` file.
 7. Create a changeset by running `yarn changeset`. [More info](https://github.com/atlassian/changesets).
 8. Push your branch and open a PR 🚀
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,8 @@ Pull requests are encouraged. If you want to add a feature or fix a bug:
 3. Make your changes, and ensure that it is formatted by [Prettier](https://prettier.io) and type-checks without errors in [TypeScript](https://www.typescriptlang.org/)
 4. Write tests that validate your change and/or fix.
 5. Run `yarn build` and then run tests with `yarn test` (for all packages) or `yarn test:core` (for only changes to core XState).
-6. Create a changeset by running `yarn changeset`. [More info](https://github.com/atlassian/changesets).
-7. Push your branch and open a PR 🚀
+6. For package changes, add docs inside the `src/packages/*/README.md`. They will be copied on build to the corresponding `docs/packages/*/index.md` file.
+7. Create a changeset by running `yarn changeset`. [More info](https://github.com/atlassian/changesets).
+8. Push your branch and open a PR 🚀
 
 PRs are reviewed promptly and merged in within a day or two (or even within an hour), if everything looks good.


### PR DESCRIPTION
All the time (myself included) we change the `/docs/packages/PACKAGE/index.md` file but later is overriden on build, as it's copied from `packages/PACKAGE/README.md`.

Here I add a comment on where we have to do the changes :)