### PR TITLE
[v5] Simplify Behavior interface

### DIFF
--- a/packages/core/src/Actor.ts
+++ b/packages/core/src/Actor.ts
@@ -145,7 +145,7 @@ export class Actor<TEvent extends EventObject, TEmitted> {
   public current: TEmitted;
   private context: ActorContext;
   private behavior: Behavior<TEvent, TEmitted>;
-  private mailbox: Array<TEvent | LifecycleSignal> = [];
+  private mailbox: Array<TEvent> = [];
   private processingStatus: ProcessingStatus = ProcessingStatus.NotProcessing;
   public name: string;
 

--- a/packages/core/src/Actor.ts
+++ b/packages/core/src/Actor.ts
@@ -145,7 +145,7 @@ export class Actor<TEvent extends EventObject, TEmitted> {
   public current: TEmitted;
   private context: ActorContext;
   private behavior: Behavior<TEvent, TEmitted>;
-  private mailbox: Array<TEvent> = [];
+  private mailbox: Array<TEvent | LifecycleSignal> = [];
   private processingStatus: ProcessingStatus = ProcessingStatus.NotProcessing;
   public name: string;
 
@@ -178,7 +178,7 @@ export class Actor<TEvent extends EventObject, TEmitted> {
   public subscribe(observer) {
     return this.behavior.subscribe?.(observer) || nullSubscription;
   }
-  public receive(event: TEvent) {
+  public receive(event: TEvent | LifecycleSignal) {
     this.mailbox.push(event);
     if (this.processingStatus === ProcessingStatus.NotProcessing) {
       this.flush();

--- a/packages/core/src/Actor.ts
+++ b/packages/core/src/Actor.ts
@@ -142,7 +142,7 @@ export function spawnFrom<TEvent extends EventObject>(
   name?: string
 ): ObservableActorRef<TEvent, undefined>;
 export function spawnFrom(entity: any): ObservableActorRef<any, any> {
-  return spawn(createBehaviorFrom(entity));
+  return spawn(createBehaviorFrom(entity)) as ObservableActorRef<any, any>; // TODO: fix
 }
 
 enum ProcessingStatus {

--- a/packages/core/src/Actor.ts
+++ b/packages/core/src/Actor.ts
@@ -40,8 +40,8 @@ export function isSpawnedActorRef(item: any): item is SpawnedActorRef<any> {
   return isActorRef(item) && 'name' in item;
 }
 
-export function fromObservable<T extends EventObject>(
-  observable: Subscribable<T>,
+export function fromObservable<TEvent extends EventObject>(
+  observable: Subscribable<TEvent>,
   name: string
 ): ActorRef<never> {
   return new ObservableActorRef(

--- a/packages/core/src/Actor.ts
+++ b/packages/core/src/Actor.ts
@@ -177,6 +177,7 @@ export class Actor<TEvent extends EventObject, TEmitted> {
     return this;
   }
   public stop() {
+    this.mailbox.length = 0; // TODO: test this behavior
     this.current = this.behavior.receive(
       this.current,
       stopSignal,

--- a/packages/core/src/Actor.ts
+++ b/packages/core/src/Actor.ts
@@ -10,11 +10,9 @@ import {
 } from './types';
 import { StateMachine } from './StateMachine';
 import { State } from './State';
-import { Interpreter } from './interpreter';
 import {
   Behavior,
   ActorContext,
-  createServiceBehavior,
   createMachineBehavior,
   createDeferredBehavior,
   createPromiseBehavior,
@@ -76,13 +74,6 @@ export function fromMachine<TContext, TEvent extends EventObject>(
   options?: Partial<InterpreterOptions>
 ): ActorRef<TEvent> {
   return new ObservableActorRef(createMachineBehavior(machine, options), name);
-}
-
-export function fromService<TContext, TEvent extends EventObject>(
-  service: Interpreter<TContext, TEvent, any>,
-  name: string = registry.bookId()
-): SpawnedActorRef<TEvent> {
-  return new ObservableActorRef(createServiceBehavior(service), name);
 }
 
 export function spawn<TReceived extends EventObject, TEmitted>(

--- a/packages/core/src/Actor.ts
+++ b/packages/core/src/Actor.ts
@@ -13,16 +13,16 @@ import { State } from './State';
 import { Interpreter } from './interpreter';
 import {
   Behavior,
-  startSignal,
   ActorContext,
-  stopSignal,
   createServiceBehavior,
   createMachineBehavior,
   createDeferredBehavior,
   createPromiseBehavior,
   createObservableBehavior,
   createBehaviorFrom,
-  LifecycleSignal
+  LifecycleSignal,
+  startSignal,
+  stopSignal
 } from './behavior';
 import { registry } from './registry';
 import * as capturedState from './capturedState';

--- a/packages/core/src/Actor.ts
+++ b/packages/core/src/Actor.ts
@@ -178,7 +178,7 @@ export class Actor<TEvent extends EventObject, TEmitted> {
   public subscribe(observer) {
     return this.behavior.subscribe?.(observer) || nullSubscription;
   }
-  public receive(event: TEvent | LifecycleSignal) {
+  public receive(event: TEvent) {
     this.mailbox.push(event);
     if (this.processingStatus === ProcessingStatus.NotProcessing) {
       this.flush();

--- a/packages/core/src/Actor.ts
+++ b/packages/core/src/Actor.ts
@@ -154,7 +154,7 @@ export class Actor<TEvent extends EventObject, TEmitted> {
   public current: TEmitted;
   private context: ActorContext;
   private behavior: Behavior<TEvent, TEmitted>;
-  private mailbox: TEvent[] = [];
+  private mailbox: Array<TEvent | LifecycleSignal> = [];
   private processingStatus: ProcessingStatus = ProcessingStatus.NotProcessing;
   public name: string;
 
@@ -186,15 +186,11 @@ export class Actor<TEvent extends EventObject, TEmitted> {
   public subscribe(observer) {
     return this.behavior.subscribe?.(observer) || nullSubscription;
   }
-  public receive(event) {
+  public receive(event: TEvent | LifecycleSignal) {
     this.mailbox.push(event);
     if (this.processingStatus === ProcessingStatus.NotProcessing) {
       this.flush();
     }
-  }
-  public receiveSignal(signal: LifecycleSignal) {
-    this.current = this.behavior.receive(this.current, signal, this.context);
-    return this;
   }
   private flush() {
     this.processingStatus = ProcessingStatus.Processing;

--- a/packages/core/src/Actor.ts
+++ b/packages/core/src/Actor.ts
@@ -169,11 +169,19 @@ export class Actor<TEvent extends EventObject, TEmitted> {
     this.current = behavior.initial;
   }
   public start() {
-    this.behavior = this.behavior.receiveSignal(this.context, startSignal);
+    this.current = this.behavior.receive(
+      this.current,
+      startSignal,
+      this.context
+    );
     return this;
   }
   public stop() {
-    this.behavior = this.behavior.receiveSignal(this.context, stopSignal);
+    this.current = this.behavior.receive(
+      this.current,
+      stopSignal,
+      this.context
+    );
   }
   public subscribe(observer) {
     return this.behavior.subscribe?.(observer) || nullSubscription;
@@ -185,7 +193,7 @@ export class Actor<TEvent extends EventObject, TEmitted> {
     }
   }
   public receiveSignal(signal: LifecycleSignal) {
-    this.behavior = this.behavior.receiveSignal(this.context, signal);
+    this.current = this.behavior.receive(this.current, signal, this.context);
     return this;
   }
   private flush() {
@@ -193,7 +201,7 @@ export class Actor<TEvent extends EventObject, TEmitted> {
     while (this.mailbox.length) {
       const event = this.mailbox.shift()!;
 
-      this.behavior = this.behavior.receive(this.context, event);
+      this.current = this.behavior.receive(this.current, event, this.context);
     }
     this.processingStatus = ProcessingStatus.NotProcessing;
   }

--- a/packages/core/src/ObservableActorRef.ts
+++ b/packages/core/src/ObservableActorRef.ts
@@ -4,7 +4,7 @@ import { Actor } from './Actor';
 
 export class ObservableActorRef<TEvent extends EventObject, TEmitted>
   implements ActorRef<TEvent, TEmitted> {
-  public current: TEmitted;
+  private current: TEmitted;
   public deferred = true;
   private context: ActorContext;
   private actor: Actor<TEvent, TEmitted>;

--- a/packages/core/src/ObservableActorRef.ts
+++ b/packages/core/src/ObservableActorRef.ts
@@ -1,5 +1,5 @@
 import { EventObject, ActorRef } from './types';
-import { Behavior, startSignal, ActorContext, stopSignal } from './behavior';
+import { Behavior, ActorContext, startSignal, stopSignal } from './behavior';
 import { Actor } from './Actor';
 
 export class ObservableActorRef<TEvent extends EventObject, TEmitted>

--- a/packages/core/src/ObservableActorRef.ts
+++ b/packages/core/src/ObservableActorRef.ts
@@ -21,12 +21,12 @@ export class ObservableActorRef<TEvent extends EventObject, TEmitted>
   }
   public start() {
     this.deferred = false;
-    this.actor.receiveSignal(startSignal);
+    this.actor.receive(startSignal);
 
     return this;
   }
   public stop() {
-    this.actor.receiveSignal(stopSignal);
+    this.actor.receive(stopSignal);
 
     return this;
   }

--- a/packages/core/src/behavior.ts
+++ b/packages/core/src/behavior.ts
@@ -325,26 +325,6 @@ export function createMachineBehavior<TContext, TEvent extends EventObject>(
   return behavior;
 }
 
-export function createServiceBehavior<TContext, TEvent extends EventObject>(
-  service: Interpreter<TContext, TEvent>
-): Behavior<TEvent, State<TContext, TEvent>> {
-  const behavior: Behavior<TEvent, State<TContext, TEvent>> = {
-    receive: (state, event, actorContext) => {
-      if (isSignal(event)) {
-        return state;
-      }
-      service.send(toSCXMLEvent(event, { origin: actorContext.self }));
-      return state;
-    },
-    subscribe: (observer) => {
-      return service.subscribe(observer);
-    },
-    initial: service.state
-  };
-
-  return behavior;
-}
-
 export function createBehaviorFrom<TEvent extends EventObject, TEmitted>(
   entity: PromiseLike<TEmitted>
 ): Behavior<TEvent, TEmitted>;

--- a/packages/core/src/behavior.ts
+++ b/packages/core/src/behavior.ts
@@ -43,10 +43,10 @@ export type LifecycleSignal = typeof startSignal | typeof stopSignal;
  * @template TEmitted The emitted value
  */
 
-export interface Behavior<T extends EventObject, TEmitted = any> {
+export interface Behavior<TEvent extends EventObject, TEmitted = any> {
   receive: (
     state: TEmitted,
-    message: T | LifecycleSignal,
+    message: TEvent | LifecycleSignal,
     ctx: ActorContext
   ) => TEmitted;
   initial: TEmitted;

--- a/packages/core/src/capturedState.ts
+++ b/packages/core/src/capturedState.ts
@@ -1,10 +1,10 @@
 import { InvokeActionObject } from '../dist/xstate.cjs';
 import { ObservableActorRef } from './ObservableActorRef';
-import { ActionTypes, ActorRef } from './types';
+import { ActionTypes } from './types';
 
 export const CapturedState = {
   current: {
-    actorRef: undefined as ActorRef<any> | undefined,
+    actorRef: undefined as ObservableActorRef<any, any> | undefined,
     spawns: [] as InvokeActionObject[]
   }
 };

--- a/packages/core/src/capturedState.ts
+++ b/packages/core/src/capturedState.ts
@@ -1,16 +1,15 @@
-import { InvokeActionObject } from '../dist/xstate.cjs';
-import { ObservableActorRef } from './ObservableActorRef';
-import { ActionTypes } from './types';
+import { SpawnedActorRef } from '.';
+import { ActionTypes, InvokeActionObject } from './types';
 
 export const CapturedState = {
   current: {
-    actorRef: undefined as ObservableActorRef<any, any> | undefined,
+    actorRef: undefined as SpawnedActorRef<any, any> | undefined,
     spawns: [] as InvokeActionObject[]
   }
 };
 
 export function captureSpawn(
-  actorRef: ObservableActorRef<any, any>,
+  actorRef: SpawnedActorRef<any, any>,
   name: string
 ) {
   CapturedState.current.spawns.push({

--- a/packages/core/src/dev/redux.ts
+++ b/packages/core/src/dev/redux.ts
@@ -12,7 +12,7 @@ export const createReduxDevTools = (
     if ((window as any).__REDUX_DEVTOOLS_EXTENSION__) {
       const devTools = (window as any).__REDUX_DEVTOOLS_EXTENSION__.connect(
         {
-          name: service.id,
+          name: service.name,
           autoPause: true,
           stateSanitizer: (state: State<any, any>): object => {
             return {

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -37,7 +37,7 @@ import {
   toEventObject
 } from './utils';
 import { Scheduler } from './scheduler';
-import { isActorRef, fromService } from './Actor';
+import { isActorRef } from './Actor';
 import { isInFinalState } from './stateUtils';
 import { registry } from './registry';
 import { StateMachine } from './StateMachine';
@@ -115,7 +115,7 @@ export class Interpreter<
 
   // Actor Ref
   public parent?: ActorRef<any>;
-  public id: string;
+  public name: string;
   public ref: SpawnedActorRef<TEvent>;
 
   /**
@@ -144,7 +144,7 @@ export class Interpreter<
 
     const resolvedId = id !== undefined ? id : machine.key;
 
-    this.id = resolvedId;
+    this.name = resolvedId;
     this.logger = logger;
     this.clock = clock;
     this.parent = parent;
@@ -155,7 +155,7 @@ export class Interpreter<
       deferEvents: this.options.deferEvents
     });
 
-    this.ref = fromService(this, resolvedId);
+    this.ref = this;
 
     this.sessionId = this.ref.name;
   }
@@ -235,7 +235,7 @@ export class Interpreter<
 
       for (const listener of this.doneListeners) {
         listener(
-          toSCXMLEvent(doneInvoke(this.id, doneData), { invokeid: this.id })
+          toSCXMLEvent(doneInvoke(this.name, doneData), { invokeid: this.name })
         );
       }
       this.stop();
@@ -590,7 +590,7 @@ export class Interpreter<
     if (!target) {
       if (!isParent) {
         const executionError = new Error(
-          `Unable to send event to child '${to}' from service '${this.id}'.`
+          `Unable to send event to child '${to}' from service '${this.name}'.`
         );
         this.send(
           toSCXMLEvent<TEvent>(actionTypes.errorExecution, {
@@ -603,7 +603,7 @@ export class Interpreter<
       if (!IS_PRODUCTION) {
         warn(
           false,
-          `Service '${this.id}' has no parent: unable to send event ${event.type}`
+          `Service '${this.name}' has no parent: unable to send event ${event.type}`
         );
       }
       return;
@@ -611,7 +611,8 @@ export class Interpreter<
 
     target.send({
       ...event,
-      name: event.name === actionTypes.error ? `${error(this.id)}` : event.name,
+      name:
+        event.name === actionTypes.error ? `${error(this.name)}` : event.name,
       origin: this
     });
   }
@@ -642,7 +643,7 @@ export class Interpreter<
 
       if (!child) {
         throw new Error(
-          `Unable to forward event '${event.name}' from interpreter '${this.id}' to nonexistant child '${id}'.`
+          `Unable to forward event '${event.name}' from interpreter '${this.name}' to nonexistant child '${id}'.`
         );
       }
 
@@ -824,7 +825,7 @@ export class Interpreter<
   }
   public toJSON() {
     return {
-      id: this.id
+      id: this.name
     };
   }
 

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -99,6 +99,7 @@ export class Interpreter<
   public clock: Clock;
   public options: Readonly<InterpreterOptions>;
 
+  public id: string;
   private scheduler: Scheduler = new Scheduler();
   private delayedEventsMap: Record<string, number> = {};
   private listeners: Set<
@@ -144,7 +145,7 @@ export class Interpreter<
 
     const resolvedId = id !== undefined ? id : machine.key;
 
-    this.name = resolvedId;
+    this.name = this.id = resolvedId;
     this.logger = logger;
     this.clock = clock;
     this.parent = parent;

--- a/packages/core/src/invoke.ts
+++ b/packages/core/src/invoke.ts
@@ -65,29 +65,32 @@ export function invokePromise<T>(
   };
 }
 
-export function invokeActivity<TC, TE extends EventObject>(
-  activityCreator: (ctx: TC, event: TE) => any
-): BehaviorCreator<TC, TE> {
-  const callbackCreator = (ctx: TC, event: TE) => () => {
+export function invokeActivity<TContext, TEvent extends EventObject>(
+  activityCreator: (ctx: TContext, event: TEvent) => any
+): BehaviorCreator<TContext, TEvent> {
+  const callbackCreator = (ctx: TContext, event: TEvent) => () => {
     return activityCreator(ctx, event);
   };
 
-  return invokeCallback<TC, TE>(callbackCreator);
+  return invokeCallback<TContext, TEvent>(callbackCreator);
 }
 
-export function invokeCallback<TC, TE extends EventObject = AnyEventObject>(
-  callbackCreator: (ctx: TC, e: TE) => InvokeCallback
-): BehaviorCreator<TC, TE> {
-  return (ctx, event): Behavior<SCXML.Event<TE>, undefined> => {
+export function invokeCallback<
+  TContext,
+  TEvent extends EventObject = AnyEventObject
+>(
+  callbackCreator: (ctx: TContext, e: TEvent) => InvokeCallback
+): BehaviorCreator<TContext, TEvent> {
+  return (ctx, event): Behavior<SCXML.Event<TEvent>, undefined> => {
     const lazyCallback = () => callbackCreator(ctx, event);
-    return createDeferredBehavior<SCXML.Event<TE>>(lazyCallback);
+    return createDeferredBehavior<SCXML.Event<TEvent>>(lazyCallback);
   };
 }
 
-export function invokeObservable<T extends EventObject = AnyEventObject>(
-  source: (ctx: any, event: any) => Subscribable<T>
+export function invokeObservable<TEvent extends EventObject = AnyEventObject>(
+  source: (ctx: any, event: any) => Subscribable<TEvent>
 ): BehaviorCreator<any, any> {
-  return (ctx, e): Behavior<never, T | undefined> => {
+  return (ctx, e): Behavior<never, TEvent | undefined> => {
     const resolvedSource = isFunction(source) ? source(ctx, e) : source;
     return createObservableBehavior(() => resolvedSource);
   };

--- a/packages/core/test/actor.test.ts
+++ b/packages/core/test/actor.test.ts
@@ -18,7 +18,6 @@ import {
   sendUpdate,
   respond
 } from '../src/actions';
-import { fromService } from '../src/Actor';
 import { interval } from 'rxjs';
 import { map } from 'rxjs/operators';
 import * as actionTypes from '../src/actionTypes';
@@ -391,7 +390,7 @@ describe('communicating with spawned actors', () => {
     const parentMachine = createMachine<{ existingRef: ActorRef<any> }>({
       initial: 'pending',
       context: {
-        existingRef: fromService(existingService)
+        existingRef: existingService
       },
       states: {
         pending: {

--- a/packages/core/test/assign.test.ts
+++ b/packages/core/test/assign.test.ts
@@ -388,23 +388,31 @@ describe('assign meta', () => {
     service.send('PING_CHILD');
     service.send('PING_CHILD');
 
-    expect(state.context).toEqual({
-      eventLog: [
-        { event: 'PING_CHILD', origin: undefined },
-        {
-          event: 'PONG',
-          origin: expect.objectContaining({
-            id: expect.stringMatching(/.+/)
-          })
-        },
-        { event: 'PING_CHILD', origin: undefined },
-        {
-          event: 'PONG',
-          origin: expect.objectContaining({
-            id: expect.stringMatching(/.+/)
-          })
-        }
-      ]
-    });
+    expect(state.context).toMatchInlineSnapshot(`
+      Object {
+        "eventLog": Array [
+          Object {
+            "event": "PING_CHILD",
+            "origin": undefined,
+          },
+          Object {
+            "event": "PONG",
+            "origin": Object {
+              "id": "child",
+            },
+          },
+          Object {
+            "event": "PING_CHILD",
+            "origin": undefined,
+          },
+          Object {
+            "event": "PONG",
+            "origin": Object {
+              "id": "child",
+            },
+          },
+        ],
+      }
+    `);
   });
 });

--- a/packages/core/test/interpreter.test.ts
+++ b/packages/core/test/interpreter.test.ts
@@ -888,18 +888,30 @@ describe('interpreter', () => {
     service.send('PING_CHILD');
 
     expect(logs.length).toBe(4);
-    expect(logs).toEqual([
-      { event: 'PING_CHILD', origin: undefined },
-      {
-        event: 'PONG',
-        origin: expect.objectContaining({ id: expect.stringMatching(/.*/) })
-      },
-      { event: 'PING_CHILD', origin: undefined },
-      {
-        event: 'PONG',
-        origin: expect.objectContaining({ id: expect.stringMatching(/.*/) })
-      }
-    ]);
+    expect(logs).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "event": "PING_CHILD",
+          "origin": undefined,
+        },
+        Object {
+          "event": "PONG",
+          "origin": Object {
+            "id": "child",
+          },
+        },
+        Object {
+          "event": "PING_CHILD",
+          "origin": undefined,
+        },
+        Object {
+          "event": "PONG",
+          "origin": Object {
+            "id": "child",
+          },
+        },
+      ]
+    `);
   });
 
   it('should receive correct _event (log action)', () => {

--- a/packages/xstate-viz/src/index.tsx
+++ b/packages/xstate-viz/src/index.tsx
@@ -80,8 +80,6 @@ export const ServiceViz: React.FC<{
 }> = ({ service }) => {
   const [state] = useService(service);
 
-  console.log(state);
-
   return (
     <StateContext.Provider value={state}>
       <pre>{JSON.stringify(state, null, 2)}</pre>
@@ -93,7 +91,7 @@ export const ServiceViz: React.FC<{
 export const ExtViz: React.FC = () => {
   const divRef = useRef(document.createElement('div'));
   const windowRef = useRef<Window | null>(null);
-  console.log((window as any).__xstate__.services);
+
   const [[serviceSet], setServiceSet] = useState([
     (window as any).__xstate__.services as Set<Interpreter<any, any>>,
   ]);
@@ -111,7 +109,6 @@ export const ExtViz: React.FC = () => {
 
   useEffect(() => {
     (window as any).__xstate__.onRegister(() => {
-      console.log('well yeah');
       setServiceSet([(window as any).__xstate__.services]);
     });
   }, []);
@@ -121,11 +118,9 @@ export const ExtViz: React.FC = () => {
       {Array.from(serviceSet).map((s) => {
         const serv = s as Interpreter<any, any>;
 
-        console.log(serv.id);
-
         return (
           <>
-            <ServiceViz key={serv.id} service={serv} />
+            <ServiceViz key={serv.name} service={serv} />
           </>
         );
       })}


### PR DESCRIPTION
This PR simplifies the `Behavior` interface by consolidating `receive` and `receiveSignal` under the same reducer (as in XActor)