### PR TITLE
Add tests for action order for parallel transitions

### DIFF
--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -1445,3 +1445,64 @@ describe('sendParent', () => {
     expect(child).toBeTruthy();
   });
 });
+
+it('should call transition actions in document order for same-level parallel regions', () => {
+  const actual: string[] = [];
+
+  const machine = createMachine({
+    type: 'parallel',
+    states: {
+      a: {
+        on: {
+          FOO: {
+            actions: () => actual.push('a')
+          }
+        }
+      },
+      b: {
+        on: {
+          FOO: {
+            actions: () => actual.push('b')
+          }
+        }
+      }
+    }
+  });
+  const service = interpret(machine).start();
+  service.send({ type: 'FOO' });
+
+  expect(actual).toEqual(['a', 'b']);
+});
+
+it('should call transition actions in document order for states at different levels of parallel regions', () => {
+  const actual: string[] = [];
+
+  const machine = createMachine({
+    type: 'parallel',
+    states: {
+      a: {
+        initial: 'a1',
+        states: {
+          a1: {
+            on: {
+              FOO: {
+                actions: () => actual.push('a1')
+              }
+            }
+          }
+        }
+      },
+      b: {
+        on: {
+          FOO: {
+            actions: () => actual.push('b')
+          }
+        }
+      }
+    }
+  });
+  const service = interpret(machine).start();
+  service.send({ type: 'FOO' });
+
+  expect(actual).toEqual(['a1', 'b']);
+});


### PR DESCRIPTION
~The second test is not passing since `a1` is never pushed to the array - it seems like something that should be fixed. Good news is that both pass on the `next` branch.~

For some reason the second test was failing for me locally, maybe some cache issue - nvmd though as it's OK now and CI passes as well