### PR TITLE
[core] Add event schema map

### DIFF
--- a/packages/core/src/Machine.ts
+++ b/packages/core/src/Machine.ts
@@ -6,7 +6,10 @@ import {
   StateSchema,
   EventObject,
   AnyEventObject,
-  Typestate
+  Typestate,
+  EventFromEventSchemaMap,
+  MachineConfigWithSchema,
+  MachineOptionsFromMachineSchema
 } from './types';
 import { StateNode } from './StateNode';
 import { Model, ModelContextFrom, ModelEventsFrom } from './model';
@@ -49,6 +52,15 @@ export function Machine<
   ) as StateMachine<TContext, TStateSchema, TEvent>;
 }
 
+export function createMachine<TConfig extends MachineConfigWithSchema<any>>(
+  config: TConfig,
+  options?: Partial<MachineOptionsFromMachineSchema<TConfig['schema']>>
+): StateMachine<
+  TConfig['schema']['context'],
+  any,
+  EventFromEventSchemaMap<TConfig['schema']['events']>,
+  Typestate<TConfig['schema']['context']>
+>;
 export function createMachine<
   TModel extends Model<any, any, any>,
   TContext = ModelContextFrom<TModel>,

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -65,7 +65,8 @@ import {
   DelayExpr,
   InvokeSourceDefinition,
   ActorRef,
-  MachineSchema
+  MachineSchema,
+  MachineConfigWithSchema
 } from './types';
 import { matchesState } from './utils';
 import { State, stateValuesEqual } from './State';
@@ -247,7 +248,7 @@ class StateNode<
 
   public options: MachineOptions<TContext, TEvent>;
 
-  public schema: MachineSchema<TContext, TEvent>;
+  public schema: MachineSchema<TContext>;
 
   public __xstatenode: true = true;
 
@@ -316,7 +317,7 @@ class StateNode<
         : 'atomic');
     this.schema = this.parent
       ? this.machine.schema
-      : (this.config as MachineConfig<TContext, TStateSchema, TEvent>).schema ??
+      : (this.config as MachineConfigWithSchema<any>).schema ??
         ({} as this['schema']);
 
     if (!IS_PRODUCTION) {

--- a/packages/core/test/schema.test.ts
+++ b/packages/core/test/schema.test.ts
@@ -53,7 +53,10 @@ describe('schema', () => {
             }
           }
         }),
-        events: createSchema<{ type: 'FOO' } | { type: 'BAR' }>()
+        events: {
+          FOO: {},
+          BAR: createSchema<{ value: number }>()
+        }
       },
       context: { foo: '', bar: 0, baz: { one: '' } },
       initial: 'active',
@@ -66,7 +69,10 @@ describe('schema', () => {
 
     noop(m.context.foo);
     noop(m.context.baz.one);
-    m.transition('active', 'BAR');
+    m.transition('active', { type: 'BAR', value: 31 });
+
+    // @ts-expect-error
+    m.transition('active', { type: 'BAR', value: 'a string' });
 
     // @ts-expect-error
     noop(m.context.something);


### PR DESCRIPTION
This PR does two things:

1. Changes `config.schema.events` to be a mapping of events to their individual schemas instead of a unified schema

2. Adds an overload to `createMachine` that special-cases a `config` with a `.schema` property present for better inference