### PR TITLE
Calculate meta in State

### DIFF
--- a/.changeset/strange-poets-tap.md
+++ b/.changeset/strange-poets-tap.md
@@ -1,0 +1,36 @@
+---
+'xstate': patch
+---
+
+The `state.meta` value is now calculated directly from `state.configuration`. This is most useful when starting a service from a persisted state:
+
+```ts
+  const machine = createMachine({
+    id: 'test',
+    initial: 'first',
+    states: {
+      first: {
+        meta: {
+          name: 'first state'
+        }
+      },
+      second: {
+        meta: {
+          name: 'second state'
+        }
+      }
+    }
+  });
+
+  const service = interpret(machine);
+
+  service.start('second'); // `meta` will be computed
+
+  // the state will have
+  // meta: {
+  //   'test.second': {
+  //     name: 'second state'
+  //   }
+  // }
+});
+```

--- a/packages/core/src/State.ts
+++ b/packages/core/src/State.ts
@@ -16,7 +16,7 @@ import {
 import { EMPTY_ACTIVITY_MAP } from './constants';
 import { matchesState, keys, isString } from './utils';
 import { StateNode } from './StateNode';
-import { nextEvents } from './stateUtils';
+import { getMeta, nextEvents } from './stateUtils';
 import { initEvent } from './actions';
 
 export function stateValuesEqual(
@@ -240,7 +240,7 @@ export class State<
     this.history = config.history as this;
     this.actions = config.actions || [];
     this.activities = config.activities || EMPTY_ACTIVITY_MAP;
-    this.meta = config.meta || {};
+    this.meta = getMeta(config.configuration);
     this.events = config.events || [];
     this.matches = this.matches.bind(this);
     this.toStrings = this.toStrings.bind(this);

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -1225,13 +1225,6 @@ class StateNode<
       ? currentState.configuration
       : [];
 
-    const meta = resolvedConfiguration.reduce((acc, stateNode) => {
-      if (stateNode.meta !== undefined) {
-        acc[stateNode.id] = stateNode.meta;
-      }
-      return acc;
-    }, {} as Record<string, string>);
-
     const isDone = isInFinalState(resolvedConfiguration, this);
 
     const nextState = new State<TContext, TEvent, TStateSchema, TTypestate>({
@@ -1257,11 +1250,6 @@ class StateNode<
         : currentState
         ? currentState.activities
         : {},
-      meta: resolvedStateValue
-        ? meta
-        : currentState
-        ? currentState.meta
-        : undefined,
       events: [],
       configuration: resolvedConfiguration,
       transitions: stateTransition.transitions,

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -192,3 +192,12 @@ export function isInFinalState<TC, TE extends EventObject>(
 
   return false;
 }
+
+export function getMeta(configuration: StateNode[] = []): Record<string, any> {
+  return configuration.reduce((acc, stateNode) => {
+    if (stateNode.meta !== undefined) {
+      acc[stateNode.id] = stateNode.meta;
+    }
+    return acc;
+  }, {} as Record<string, any>);
+}

--- a/packages/core/test/meta.test.ts
+++ b/packages/core/test/meta.test.ts
@@ -1,4 +1,4 @@
-import { createMachine, Machine } from '../src/index';
+import { createMachine, interpret, Machine } from '../src/index';
 
 describe('state meta data', () => {
   const pedestrianStates = {
@@ -97,6 +97,36 @@ describe('state meta data', () => {
         walkData: 'walk data'
       }
     });
+  });
+
+  // https://github.com/davidkpiano/xstate/issues/1105
+  it('services started from a persisted state should calculate meta data', (done) => {
+    const machine = createMachine({
+      id: 'test',
+      initial: 'first',
+      states: {
+        first: {
+          meta: {
+            name: 'first state'
+          }
+        },
+        second: {
+          meta: {
+            name: 'second state'
+          }
+        }
+      }
+    });
+
+    const service = interpret(machine).onTransition((state) => {
+      expect(state.meta).toEqual({
+        'test.second': {
+          name: 'second state'
+        }
+      });
+      done();
+    });
+    service.start('second');
   });
 });
 


### PR DESCRIPTION
This PR makes `.meta` a property derived from the `.configuration` passed into `State` instead of defined externally (which it shouldn't be).

This allows for `meta` to be calculated from a restored state without it having to be specified:

```js
service.start('someState'); // will fill in `meta`
```

Fixes #1105