### PR TITLE
Fix useService hook API docs

### DIFF
--- a/docs/packages/xstate-react/index.md
+++ b/docs/packages/xstate-react/index.md
@@ -119,7 +119,7 @@ A [React hook](https://reactjs.org/hooks) that subscribes to state changes from 
 
 **Arguments**
 
-- `service` - An [XState service](https://xstate.js.org/docs/guides/interpretation.html).
+- `service` - A started [XState service](https://xstate.js.org/docs/guides/interpretation.html).
 
 **Returns** a tuple of `[state, send]`:
 

--- a/docs/packages/xstate-vue/index.md
+++ b/docs/packages/xstate-vue/index.md
@@ -110,7 +110,7 @@ A [Vue composition function](https://v3.vuejs.org/guide/composition-api-introduc
 
 **Arguments**
 
-- `service` - An [XState service](https://xstate.js.org/docs/guides/communication.html).
+- `service` - A started [XState service](https://xstate.js.org/docs/guides/communication.html).
 
 **Returns** `{state, send}`:
 


### PR DESCRIPTION
The `service` given to `useService` should be started with `.start()`, or else an error occurs.

This may be an obvious step but it took me awhile to realise (after looking at the test suites for react & vue) 😅