### PR TITLE
[core] Unify ActorRef type

### DIFF
--- a/.changeset/dirty-points-reply.md
+++ b/.changeset/dirty-points-reply.md
@@ -1,0 +1,28 @@
+---
+'xstate': patch
+---
+
+The `SpawnedActorRef` TypeScript interface has been deprecated in favor of a unified `ActorRef` interface, which contains the following:
+
+```ts
+interface ActorRef<TEvent extends EventObject, TEmitted = any>
+  extends Subscribable<TEmitted> {
+  send: (event: TEvent) => void;
+  id: string;
+  subscribe(observer: Observer<T>): Subscription;
+  subscribe(
+    next: (value: T) => void,
+    error?: (error: any) => void,
+    complete?: () => void
+  ): Subscription;
+  getSnapshot: () => TEmitted | undefined;
+}
+```
+
+For simpler actor-ref-like objects, the `BaseActorRef<TEvent>` interface has been introduced.
+
+```ts
+interface BaseActorRef<TEvent extends EventObject> {
+  send: (event: TEvent) => void;
+}
+```

--- a/packages/core/src/Actor.ts
+++ b/packages/core/src/Actor.ts
@@ -108,10 +108,7 @@ export function isSpawnedActor(item: any): item is ActorRef<any> {
 export function toActorRef<
   TEvent extends EventObject,
   TEmitted = any,
-  TActorRefLike extends BaseActorRef<TEvent, TEmitted> = BaseActorRef<
-    TEvent,
-    TEmitted
-  >
+  TActorRefLike extends BaseActorRef<TEvent> = BaseActorRef<TEvent>
 >(
   actorRefLike: TActorRefLike
 ): TActorRefLike & ActorRef<TEvent, TEmitted> & { [key: string]: any } {

--- a/packages/core/src/Actor.ts
+++ b/packages/core/src/Actor.ts
@@ -109,9 +109,7 @@ export function toActorRef<
   TEvent extends EventObject,
   TEmitted = any,
   TActorRefLike extends BaseActorRef<TEvent> = BaseActorRef<TEvent>
->(
-  actorRefLike: TActorRefLike
-): TActorRefLike & ActorRef<TEvent, TEmitted> & { [key: string]: any } {
+>(actorRefLike: TActorRefLike): ActorRef<TEvent, TEmitted> {
   return {
     subscribe: () => ({ unsubscribe: () => void 0 }),
     id: 'anonymous',

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -59,13 +59,7 @@ import { isInFinalState } from './stateUtils';
 import { registry } from './registry';
 import { getGlobal, registerService } from './devTools';
 import * as serviceScope from './serviceScope';
-import {
-  ActorRef,
-  ActorRefFrom,
-  SpawnedActorRef,
-  StopActionObject,
-  Subscription
-} from '.';
+import { ActorRef, ActorRefFrom, StopActionObject, Subscription } from '.';
 
 export type StateListener<
   TContext,
@@ -114,7 +108,7 @@ export class Interpreter<
   TEvent extends EventObject = EventObject,
   TTypestate extends Typestate<TContext> = { value: any; context: TContext }
 > implements
-    SpawnedActorRef<TEvent, State<TContext, TEvent, TStateSchema, TTypestate>> {
+    ActorRef<TEvent, State<TContext, TEvent, TStateSchema, TTypestate>> {
   /**
    * The default interpreter options:
    *
@@ -171,7 +165,7 @@ export class Interpreter<
    * The globally unique process ID for this invocation.
    */
   public sessionId: string;
-  public children: Map<string | number, SpawnedActorRef<any>> = new Map();
+  public children: Map<string | number, ActorRef<any>> = new Map();
   private forwardTo: Set<string> = new Set();
 
   // Dev Tools
@@ -946,7 +940,7 @@ export class Interpreter<
     entity: Spawnable,
     name: string,
     options?: SpawnOptions
-  ): SpawnedActorRef<any> {
+  ): ActorRef<any> {
     if (isPromiseLike(entity)) {
       return this.spawnPromise(Promise.resolve(entity), name);
     } else if (isFunction(entity)) {
@@ -970,7 +964,7 @@ export class Interpreter<
   >(
     machine: StateMachine<TChildContext, TChildStateSchema, TChildEvent>,
     options: { id?: string; autoForward?: boolean; sync?: boolean } = {}
-  ): SpawnedActorRef<TChildEvent, State<TChildContext, TChildEvent>> {
+  ): ActorRef<TChildEvent, State<TChildContext, TChildEvent>> {
     const childService = new Interpreter(machine, {
       ...this.options, // inherit options from this interpreter
       parent: this,
@@ -1008,10 +1002,7 @@ export class Interpreter<
 
     return actor;
   }
-  private spawnPromise<T>(
-    promise: Promise<T>,
-    id: string
-  ): SpawnedActorRef<never, T> {
+  private spawnPromise<T>(promise: Promise<T>, id: string): ActorRef<never, T> {
     let canceled = false;
     let resolvedData: T | undefined = undefined;
 
@@ -1049,7 +1040,7 @@ export class Interpreter<
       }
     );
 
-    const actor: SpawnedActorRef<never, T> = {
+    const actor: ActorRef<never, T> = {
       id,
       send: () => void 0,
       subscribe: (next, handleError?, complete?) => {
@@ -1092,10 +1083,7 @@ export class Interpreter<
 
     return actor;
   }
-  private spawnCallback(
-    callback: InvokeCallback,
-    id: string
-  ): SpawnedActorRef<any> {
+  private spawnCallback(callback: InvokeCallback, id: string): ActorRef<any> {
     let canceled = false;
     const receivers = new Set<(e: EventObject) => void>();
     const listeners = new Set<(e: EventObject) => void>();
@@ -1157,7 +1145,7 @@ export class Interpreter<
   private spawnObservable<T extends TEvent>(
     source: Subscribable<T>,
     id: string
-  ): SpawnedActorRef<any, T> {
+  ): ActorRef<any, T> {
     let emitted: T | undefined = undefined;
 
     const subscription = source.subscribe(
@@ -1175,7 +1163,7 @@ export class Interpreter<
       }
     );
 
-    const actor: SpawnedActorRef<any, T> = {
+    const actor: ActorRef<any, T> = {
       id,
       send: () => void 0,
       subscribe: (next, handleError?, complete?) => {
@@ -1192,7 +1180,7 @@ export class Interpreter<
 
     return actor;
   }
-  private spawnActor<T extends SpawnedActorRef<any>>(actor: T): T {
+  private spawnActor<T extends ActorRef<any>>(actor: T): T {
     this.children.set(actor.id, actor);
 
     return actor;
@@ -1304,11 +1292,11 @@ export function spawn<TC, TE extends EventObject>(
 export function spawn(
   entity: Spawnable,
   nameOrOptions?: string | SpawnOptions
-): SpawnedActorRef<any>;
+): ActorRef<any>;
 export function spawn(
   entity: Spawnable,
   nameOrOptions?: string | SpawnOptions
-): SpawnedActorRef<any> {
+): ActorRef<any> {
   const resolvedOptions = resolveSpawnOptions(nameOrOptions);
 
   return serviceScope.consume((service) => {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -196,7 +196,7 @@ export interface ActivityDefinition<TContext, TEvent extends EventObject>
   type: string;
 }
 
-export type Sender<TEvent extends EventObject> = (event: Event<TEvent>) => void;
+export type Sender<TEvent extends EventObject> = (event: TEvent) => void;
 
 type ExcludeType<A> = { [K in Exclude<keyof A, 'type'>]: A[K] };
 
@@ -1280,12 +1280,12 @@ export type ExtractEvent<
 > = TEvent extends { type: TEventType } ? TEvent : never;
 
 export interface BaseActorRef<TEvent extends EventObject> {
-  send: Sender<TEvent>;
+  send: (event: TEvent) => void;
 }
 
 export interface ActorRef<TEvent extends EventObject, TEmitted = any>
   extends Subscribable<TEmitted> {
-  send: Sender<TEvent>;
+  send: Sender<TEvent>; // TODO: this should just be TEvent
   id: string;
   getSnapshot: () => TEmitted | undefined;
   stop?: () => void;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1279,30 +1279,38 @@ export type ExtractEvent<
   TEventType extends TEvent['type']
 > = TEvent extends { type: TEventType } ? TEvent : never;
 
+export interface BaseActorRef<TEvent extends EventObject, TEmitted = any> {
+  send: Sender<TEvent>;
+  id?: string;
+  getSnapshot?: () => TEmitted | undefined;
+  stop?: () => void;
+  toJSON?: () => any;
+  subscribe?: Subscribable<TEmitted>['subscribe'];
+}
+
 export interface ActorRef<TEvent extends EventObject, TEmitted = any>
   extends Subscribable<TEmitted> {
   send: Sender<TEvent>;
-}
-
-export interface SpawnedActorRef<TEvent extends EventObject, TEmitted = any>
-  extends ActorRef<TEvent, TEmitted> {
   id: string;
   getSnapshot: () => TEmitted | undefined;
   stop?: () => void;
   toJSON?: () => any;
 }
 
+/**
+ * @deprecated Use `ActorRef` instead.
+ */
+export type SpawnedActorRef<
+  TEvent extends EventObject,
+  TEmitted = any
+> = ActorRef<TEvent, TEmitted>;
+
 export type ActorRefFrom<
   T extends StateMachine<any, any, any> | Promise<any>
 > = T extends StateMachine<infer TContext, any, infer TEvent, infer TTypestate>
-  ? SpawnedActorRef<TEvent, State<TContext, TEvent, any, TTypestate>> & {
-      /**
-       * @deprecated
-       */
-      state: State<TContext, TEvent, any, TTypestate>;
-    }
+  ? ActorRef<TEvent, State<TContext, TEvent, any, TTypestate>>
   : T extends Promise<infer U>
-  ? SpawnedActorRef<never, U>
+  ? ActorRef<never, U>
   : never;
 
 export type AnyInterpreter = Interpreter<any, any, any, any>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1303,7 +1303,12 @@ export type SpawnedActorRef<
 export type ActorRefFrom<
   T extends StateMachine<any, any, any> | Promise<any>
 > = T extends StateMachine<infer TContext, any, infer TEvent, infer TTypestate>
-  ? ActorRef<TEvent, State<TContext, TEvent, any, TTypestate>>
+  ? ActorRef<TEvent, State<TContext, TEvent, any, TTypestate>> & {
+      /**
+       * @deprecated Use `.getSnapshot()` instead.
+       */
+      state: State<TContext, TEvent, any, TTypestate>;
+    }
   : T extends Promise<infer U>
   ? ActorRef<never, U>
   : never;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -196,7 +196,7 @@ export interface ActivityDefinition<TContext, TEvent extends EventObject>
   type: string;
 }
 
-export type Sender<TEvent extends EventObject> = (event: TEvent) => void;
+export type Sender<TEvent extends EventObject> = (event: Event<TEvent>) => void;
 
 type ExcludeType<A> = { [K in Exclude<keyof A, 'type'>]: A[K] };
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1279,9 +1279,8 @@ export type ExtractEvent<
   TEventType extends TEvent['type']
 > = TEvent extends { type: TEventType } ? TEvent : never;
 
-export interface BaseActorRef<TEvent extends EventObject, TEmitted = any> {
+export interface BaseActorRef<TEvent extends EventObject> {
   send: Sender<TEvent>;
-  subscribe?: Subscribable<TEmitted>['subscribe'];
 }
 
 export interface ActorRef<TEvent extends EventObject, TEmitted = any>

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1279,13 +1279,8 @@ export type ExtractEvent<
   TEventType extends TEvent['type']
 > = TEvent extends { type: TEventType } ? TEvent : never;
 
-export interface BaseActorRef<TEvent extends EventObject, TEmitted = any> {
+export interface BaseActorRef<TEvent extends EventObject> {
   send: Sender<TEvent>;
-  id?: string;
-  getSnapshot?: () => TEmitted | undefined;
-  stop?: () => void;
-  toJSON?: () => any;
-  subscribe?: Subscribable<TEmitted>['subscribe'];
 }
 
 export interface ActorRef<TEvent extends EventObject, TEmitted = any>

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1279,8 +1279,9 @@ export type ExtractEvent<
   TEventType extends TEvent['type']
 > = TEvent extends { type: TEventType } ? TEvent : never;
 
-export interface BaseActorRef<TEvent extends EventObject> {
+export interface BaseActorRef<TEvent extends EventObject, TEmitted = any> {
   send: Sender<TEvent>;
+  subscribe?: Subscribable<TEmitted>['subscribe'];
 }
 
 export interface ActorRef<TEvent extends EventObject, TEmitted = any>

--- a/packages/xstate-inspect/src/types.ts
+++ b/packages/xstate-inspect/src/types.ts
@@ -1,11 +1,4 @@
-import type {
-  ActorRef,
-  Interpreter,
-  SCXML,
-  SpawnedActorRef,
-  State,
-  StateMachine
-} from 'xstate';
+import type { ActorRef, Interpreter, SCXML, State, StateMachine } from 'xstate';
 import { XStateDevInterface } from 'xstate/lib/devTools';
 import { InspectMachineEvent } from './inspectMachine';
 
@@ -72,10 +65,7 @@ export type ParsedReceiverEvent =
     }
   | { type: 'service.event'; event: SCXML.Event<any>; sessionId: string };
 
-export type InspectReceiver = SpawnedActorRef<
-  ReceiverCommand,
-  ParsedReceiverEvent
->;
+export type InspectReceiver = ActorRef<ReceiverCommand, ParsedReceiverEvent>;
 
 export interface WindowReceiverOptions {
   window: Window;

--- a/packages/xstate-react/src/useActor.ts
+++ b/packages/xstate-react/src/useActor.ts
@@ -1,7 +1,7 @@
 import { useState, useRef } from 'react';
 import useIsomorphicLayoutEffect from 'use-isomorphic-layout-effect';
 import { Sender } from './types';
-import { ActorRef, EventObject, SpawnedActorRef } from 'xstate';
+import { ActorRef, EventObject } from 'xstate';
 import useConstant from './useConstant';
 
 export function isActorWithState<T extends ActorRef<any>>(
@@ -29,7 +29,7 @@ const noop = () => {
 };
 
 function defaultGetSnapshot<TEmitted>(
-  actorRef: ActorRef<any, TEmitted> | SpawnedActorRef<any, TEmitted>
+  actorRef: ActorRef<any, TEmitted>
 ): TEmitted | undefined {
   return isActorWithState(actorRef)
     ? actorRef.state

--- a/packages/xstate-react/test/useActor.test.tsx
+++ b/packages/xstate-react/test/useActor.test.tsx
@@ -6,9 +6,9 @@ import {
   assign,
   spawn,
   ActorRef,
-  ActorRefFrom,
-  SpawnedActorRef
+  ActorRefFrom
 } from 'xstate';
+import { toActorRef } from 'xstate/lib/Actor';
 import { render, cleanup, fireEvent } from '@testing-library/react';
 import { useActor } from '../src/useActor';
 import { useState } from 'react';
@@ -242,7 +242,9 @@ describe('useActor', () => {
   });
 
   it('actor should provide snapshot value immediately', () => {
-    const simpleActor: ActorRef<any, number> & { latestValue: number } = {
+    const simpleActor: ActorRef<any, number> & {
+      latestValue: number;
+    } = toActorRef({
       send: () => {
         /* ... */
       },
@@ -254,7 +256,7 @@ describe('useActor', () => {
           }
         };
       }
-    };
+    });
 
     const Test = () => {
       const [state] = useActor(simpleActor, (a) => a.latestValue);
@@ -270,7 +272,7 @@ describe('useActor', () => {
   });
 
   it('should provide value from `actor.getSnapshot()`', () => {
-    const simpleActor: SpawnedActorRef<any, number> = {
+    const simpleActor: ActorRef<any, number> = {
       id: 'test',
       send: () => {
         /* ... */
@@ -301,19 +303,20 @@ describe('useActor', () => {
   it('should update snapshot value when actor changes', () => {
     const createSimpleActor = (
       value: number
-    ): ActorRef<any, number> & { latestValue: number } => ({
-      send: () => {
-        /* ... */
-      },
-      latestValue: value,
-      subscribe: () => {
-        return {
-          unsubscribe: () => {
-            /* ... */
-          }
-        };
-      }
-    });
+    ): ActorRef<any, number> & { latestValue: number } =>
+      toActorRef({
+        send: () => {
+          /* ... */
+        },
+        latestValue: value,
+        subscribe: () => {
+          return {
+            unsubscribe: () => {
+              /* ... */
+            }
+          };
+        }
+      });
 
     const Test = () => {
       const [actor, setActor] = useState(createSimpleActor(42));
@@ -352,16 +355,16 @@ describe('useActor', () => {
     const noop = () => {
       /* ... */
     };
-    const firstActor: ActorRef<any> = {
+    const firstActor = toActorRef({
       send: noop,
       subscribe: fakeSubscribe
-    };
-    const lastActor: ActorRef<any> = {
+    });
+    const lastActor = toActorRef({
       send: () => {
         done();
       },
       subscribe: fakeSubscribe
-    };
+    });
 
     const Test = () => {
       const [actor, setActor] = useState(firstActor);

--- a/packages/xstate-react/test/useActor.test.tsx
+++ b/packages/xstate-react/test/useActor.test.tsx
@@ -242,9 +242,7 @@ describe('useActor', () => {
   });
 
   it('actor should provide snapshot value immediately', () => {
-    const simpleActor: ActorRef<any, number> & {
-      latestValue: number;
-    } = toActorRef({
+    const simpleActor = toActorRef({
       send: () => {
         /* ... */
       },
@@ -256,7 +254,9 @@ describe('useActor', () => {
           }
         };
       }
-    });
+    }) as ActorRef<any, number> & {
+      latestValue: number;
+    };
 
     const Test = () => {
       const [state] = useActor(simpleActor, (a) => a.latestValue);
@@ -272,7 +272,7 @@ describe('useActor', () => {
   });
 
   it('should provide value from `actor.getSnapshot()`', () => {
-    const simpleActor: ActorRef<any, number> = {
+    const simpleActor = toActorRef({
       id: 'test',
       send: () => {
         /* ... */
@@ -285,7 +285,7 @@ describe('useActor', () => {
           }
         };
       }
-    };
+    });
 
     const Test = () => {
       const [state] = useActor(simpleActor);
@@ -301,9 +301,7 @@ describe('useActor', () => {
   });
 
   it('should update snapshot value when actor changes', () => {
-    const createSimpleActor = (
-      value: number
-    ): ActorRef<any, number> & { latestValue: number } =>
+    const createSimpleActor = (value: number) =>
       toActorRef({
         send: () => {
           /* ... */
@@ -316,7 +314,7 @@ describe('useActor', () => {
             }
           };
         }
-      });
+      }) as ActorRef<any> & { latestValue: number };
 
     const Test = () => {
       const [actor, setActor] = useState(createSimpleActor(42));


### PR DESCRIPTION
This PR unifies the `ActorRef` type to contain all methods previously only present on the `SpawnedActorRef` type. This was found to be redundant in #2271, so now the types are as follows:

- `ActorRef` contains all methods (required)
- `BaseActorRef` only requires `send`; all other methods are optional. This should seldom be used.
- `SpawnedActorRef` is now an alias to `ActorRef`; it is deprecated and will be removed in v5.

