### PR TITLE
docs: Fix invalid import statements

### DIFF
--- a/docs/packages/xstate-react/index.md
+++ b/docs/packages/xstate-react/index.md
@@ -329,7 +329,7 @@ This special `useMachine` hook is imported from `@xstate/react/fsm`
 
 ```js
 import { useEffect } from 'react';
-import { useMachine } from `@xstate/react/fsm`;
+import { useMachine } from '@xstate/react/fsm';
 import { createMachine } from '@xstate/fsm';
 
 const context = {

--- a/packages/xstate-react/README.md
+++ b/packages/xstate-react/README.md
@@ -319,7 +319,7 @@ This special `useMachine` hook is imported from `@xstate/react/fsm`
 
 ```js
 import { useEffect } from 'react';
-import { useMachine } from `@xstate/react/fsm`;
+import { useMachine } from '@xstate/react/fsm';
 import { createMachine } from '@xstate/fsm';
 
 const context = {


### PR DESCRIPTION
Import statements can't use template literals, I don't believe. That's it. That's the PR!