### PR TITLE
Deprecate useService()

### DIFF
--- a/.changeset/fresh-carrots-rule.md
+++ b/.changeset/fresh-carrots-rule.md
@@ -1,0 +1,10 @@
+---
+'@xstate/react': minor
+---
+
+The `useService(...)` hook will be deprecated, since services are also actors. In future versions, the `useActor(...)` hook should be used instead:
+
+```diff
+-const [state, send] = useService(service);
++const [state, send] = useActor(service);
+```

--- a/packages/core/src/Actor.ts
+++ b/packages/core/src/Actor.ts
@@ -83,7 +83,6 @@ export function createDeferredActor(
 
   if (isMachine(entity)) {
     // "mute" the existing service scope so potential spawned actors within the `.initialState` stay deferred here
-    // @ts-ignore
     const initialState = serviceScope.provide(
       undefined,
       () => (data ? entity.withContext(data) : entity).initialState

--- a/packages/core/src/Actor.ts
+++ b/packages/core/src/Actor.ts
@@ -83,10 +83,10 @@ export function createDeferredActor(
 
   if (isMachine(entity)) {
     // "mute" the existing service scope so potential spawned actors within the `.initialState` stay deferred here
-    const initialState = serviceScope.provide(
+    const initialState = ((tempActor as any).state = serviceScope.provide(
       undefined,
       () => (data ? entity.withContext(data) : entity).initialState
-    );
+    ));
     tempActor.getSnapshot = () => initialState;
   }
 

--- a/packages/core/src/Actor.ts
+++ b/packages/core/src/Actor.ts
@@ -84,10 +84,11 @@ export function createDeferredActor(
   if (isMachine(entity)) {
     // "mute" the existing service scope so potential spawned actors within the `.initialState` stay deferred here
     // @ts-ignore
-    tempActor.state = serviceScope.provide(
+    const initialState = serviceScope.provide(
       undefined,
       () => (data ? entity.withContext(data) : entity).initialState
     );
+    tempActor.getSnapshot = () => initialState;
   }
 
   return tempActor;

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -1269,6 +1269,9 @@ export class Interpreter<
   }
 
   public getSnapshot() {
+    if (this.status === InterpreterStatus.NotStarted) {
+      return this.initialState;
+    }
     return this._state!;
   }
 }

--- a/packages/xstate-react/README.md
+++ b/packages/xstate-react/README.md
@@ -115,6 +115,12 @@ A [React hook](https://reactjs.org/hooks) that interprets the given `machine` an
 
 ### `useService(service)`
 
+::: warning Deprecated
+
+In the next major version, `useService(service)` will be replaced with `useActor(service)`. Prefer using the `useActor(service)` hook for services instead, since services are also actors.
+
+:::
+
 A [React hook](https://reactjs.org/hooks) that subscribes to state changes from an existing [service](https://xstate.js.org/docs/guides/interpretation.html).
 
 **Arguments**
@@ -126,7 +132,7 @@ A [React hook](https://reactjs.org/hooks) that subscribes to state changes from 
 - `state` - Represents the current state of the service as an XState `State` object.
 - `send` - A function that sends events to the running service.
 
-### `useActor(actor, getSnapshot)`
+### `useActor(actor, getSnapshot?)`
 
 A [React hook](https://reactjs.org/hooks) that subscribes to emitted changes from an existing [actor](https://xstate.js.org/docs/guides/actors.html).
 
@@ -348,11 +354,13 @@ const fetchMachine = createMachine({
   }
 });
 
-const Fetcher = ({ onFetch = () => new Promise(res => res('some data')) }) => {
+const Fetcher = ({
+  onFetch = () => new Promise((res) => res('some data'))
+}) => {
   const [state, send] = useMachine(fetchMachine, {
     actions: {
       load: () => {
-        onFetch().then(res => {
+        onFetch().then((res) => {
           send({ type: 'RESOLVE', data: res });
         });
       }
@@ -361,7 +369,7 @@ const Fetcher = ({ onFetch = () => new Promise(res => res('some data')) }) => {
 
   switch (state.value) {
     case 'idle':
-      return <button onClick={_ => send('FETCH')}>Fetch</button>;
+      return <button onClick={(_) => send('FETCH')}>Fetch</button>;
     case 'loading':
       return <div>Loading...</div>;
     case 'success':

--- a/packages/xstate-react/src/useActor.ts
+++ b/packages/xstate-react/src/useActor.ts
@@ -31,7 +31,11 @@ const noop = () => {
 function defaultGetSnapshot<TEmitted>(
   actorRef: ActorRef<any, TEmitted>
 ): TEmitted | undefined {
-  return 'getSnapshot' in actorRef ? actorRef.getSnapshot() : undefined;
+  return 'getSnapshot' in actorRef
+    ? actorRef.getSnapshot()
+    : isActorWithState(actorRef)
+    ? actorRef.state
+    : undefined;
 }
 
 export function useActor<TActor extends ActorRef<any, any>>(

--- a/packages/xstate-react/src/useActor.ts
+++ b/packages/xstate-react/src/useActor.ts
@@ -31,11 +31,7 @@ const noop = () => {
 function defaultGetSnapshot<TEmitted>(
   actorRef: ActorRef<any, TEmitted>
 ): TEmitted | undefined {
-  return isActorWithState(actorRef)
-    ? actorRef.state
-    : 'getSnapshot' in actorRef
-    ? actorRef.getSnapshot()
-    : undefined;
+  return 'getSnapshot' in actorRef ? actorRef.getSnapshot() : undefined;
 }
 
 export function useActor<TActor extends ActorRef<any, any>>(

--- a/packages/xstate-react/src/useService.ts
+++ b/packages/xstate-react/src/useService.ts
@@ -24,6 +24,12 @@ export function useService<
 >(
   service: Interpreter<TContext, any, TEvent, TTypestate>
 ): [State<TContext, TEvent, any, TTypestate>, PayloadSender<TEvent>] {
+  if (process.env.NODE_ENV !== 'production' && !('machine' in service)) {
+    throw new Error(
+      `Attempted to use an actor-like object instead of a service in the useService() hook. Please use the useActor() hook instead.`
+    );
+  }
+
   const [state] = useActor(service);
 
   return [state, service.send];

--- a/packages/xstate-react/src/useService.ts
+++ b/packages/xstate-react/src/useService.ts
@@ -18,13 +18,7 @@ export function useService<
 >(
   service: Interpreter<TContext, any, TEvent, TTypestate>
 ): [State<TContext, TEvent, any, TTypestate>, PayloadSender<TEvent>] {
-  if (process.env.NODE_ENV !== 'production' && !('machine' in service)) {
-    throw new Error(
-      `Attempted to use an actor-like object instead of a service in the useService() hook. Please use the useActor() hook instead.`
-    );
-  }
-
-  const [state] = useActor(service, getServiceSnapshot);
+  const [state] = useActor(service);
 
   return [state, service.send];
 }

--- a/packages/xstate-react/src/useService.ts
+++ b/packages/xstate-react/src/useService.ts
@@ -11,6 +11,12 @@ export function getServiceSnapshot<
     : service.machine.initialState;
 }
 
+/**
+ * @deprecated Use `useActor` instead.
+ *
+ * @param service The interpreted machine
+ * @returns A tuple of the current `state` of the service and the service's `send(event)` method
+ */
 export function useService<
   TContext,
   TEvent extends EventObject,

--- a/packages/xstate-react/test/useActor.test.tsx
+++ b/packages/xstate-react/test/useActor.test.tsx
@@ -402,33 +402,32 @@ describe('useActor', () => {
     // it will always refer to the latest actor.
   });
 
-  const counterMachine = createMachine<
-    { count: number },
-    { type: 'INC' } | { type: 'SOMETHING' }
-  >(
-    {
-      id: 'counter',
-      initial: 'active',
-      context: { count: 0 },
-      states: {
-        active: {
-          on: {
-            INC: { actions: assign({ count: (ctx) => ctx.count + 1 }) },
-            SOMETHING: { actions: 'doSomething' }
+  it('should also work with services', () => {
+    const counterMachine = createMachine<
+      { count: number },
+      { type: 'INC' } | { type: 'SOMETHING' }
+    >(
+      {
+        id: 'counter',
+        initial: 'active',
+        context: { count: 0 },
+        states: {
+          active: {
+            on: {
+              INC: { actions: assign({ count: (ctx) => ctx.count + 1 }) },
+              SOMETHING: { actions: 'doSomething' }
+            }
+          }
+        }
+      },
+      {
+        actions: {
+          doSomething: () => {
+            /* do nothing */
           }
         }
       }
-    },
-    {
-      actions: {
-        doSomething: () => {
-          /* do nothing */
-        }
-      }
-    }
-  );
-
-  it('should also work with services', () => {
+    );
     const counterService = interpret(counterMachine).start();
 
     const Counter = () => {

--- a/packages/xstate-react/test/useActor.test.tsx
+++ b/packages/xstate-react/test/useActor.test.tsx
@@ -6,10 +6,11 @@ import {
   assign,
   spawn,
   ActorRef,
-  ActorRefFrom
+  ActorRefFrom,
+  interpret
 } from 'xstate';
 import { toActorRef } from 'xstate/lib/Actor';
-import { render, cleanup, fireEvent } from '@testing-library/react';
+import { render, cleanup, fireEvent, act } from '@testing-library/react';
 import { useActor } from '../src/useActor';
 import { useState } from 'react';
 
@@ -399,5 +400,64 @@ describe('useActor', () => {
     // The effect will call the closed-in `send`, which originally
     // was the reference to the first actor. Now that `send` is stable,
     // it will always refer to the latest actor.
+  });
+
+  const counterMachine = createMachine<
+    { count: number },
+    { type: 'INC' } | { type: 'SOMETHING' }
+  >(
+    {
+      id: 'counter',
+      initial: 'active',
+      context: { count: 0 },
+      states: {
+        active: {
+          on: {
+            INC: { actions: assign({ count: (ctx) => ctx.count + 1 }) },
+            SOMETHING: { actions: 'doSomething' }
+          }
+        }
+      }
+    },
+    {
+      actions: {
+        doSomething: () => {
+          /* do nothing */
+        }
+      }
+    }
+  );
+
+  it('should also work with services', () => {
+    const counterService = interpret(counterMachine).start();
+
+    const Counter = () => {
+      const [state] = useActor(counterService);
+
+      return <div data-testid="count">{state.context.count}</div>;
+    };
+
+    const { getAllByTestId } = render(
+      <>
+        <Counter />
+        <Counter />
+      </>
+    );
+
+    const countEls = getAllByTestId('count');
+
+    expect(countEls.length).toBe(2);
+
+    countEls.forEach((countEl) => {
+      expect(countEl.textContent).toBe('0');
+    });
+
+    act(() => {
+      counterService.send({ type: 'INC' });
+    });
+
+    countEls.forEach((countEl) => {
+      expect(countEl.textContent).toBe('1');
+    });
   });
 });

--- a/packages/xstate-react/test/useService.test.tsx
+++ b/packages/xstate-react/test/useService.test.tsx
@@ -137,7 +137,7 @@ describe('useService hook', () => {
     expect(countEl.textContent).toBe('1');
   });
 
-  it.skip('should throw if provided an actor instead of a service', (done) => {
+  it('should throw if provided an actor instead of a service', (done) => {
     const Test = () => {
       expect(() => {
         useService({

--- a/packages/xstate-react/test/useService.test.tsx
+++ b/packages/xstate-react/test/useService.test.tsx
@@ -137,7 +137,7 @@ describe('useService hook', () => {
     expect(countEl.textContent).toBe('1');
   });
 
-  it('should throw if provided an actor instead of a service', (done) => {
+  it.skip('should throw if provided an actor instead of a service', (done) => {
     const Test = () => {
       expect(() => {
         useService({

--- a/packages/xstate-vue/src/useActor.ts
+++ b/packages/xstate-vue/src/useActor.ts
@@ -35,7 +35,11 @@ export function useActor(
     | ActorRef<EventObject, unknown>
     | Ref<ActorRef<EventObject, unknown>>,
   getSnapshot: (actor: ActorRef<EventObject, unknown>) => unknown = (a) =>
-    'getSnapshot' in a ? a.getSnapshot() : undefined
+    'getSnapshot' in a
+      ? a.getSnapshot()
+      : isActorWithState(a)
+      ? a.state
+      : undefined
 ): {
   state: Ref<unknown>;
   send: Sender<EventObject>;

--- a/packages/xstate-vue/src/useActor.ts
+++ b/packages/xstate-vue/src/useActor.ts
@@ -35,11 +35,7 @@ export function useActor(
     | ActorRef<EventObject, unknown>
     | Ref<ActorRef<EventObject, unknown>>,
   getSnapshot: (actor: ActorRef<EventObject, unknown>) => unknown = (a) =>
-    isActorWithState(a)
-      ? a.state
-      : 'getSnapshot' in a
-      ? a.getSnapshot()
-      : undefined
+    'getSnapshot' in a ? a.getSnapshot() : undefined
 ): {
   state: Ref<unknown>;
   send: Sender<EventObject>;

--- a/packages/xstate-vue/src/useActor.ts
+++ b/packages/xstate-vue/src/useActor.ts
@@ -35,7 +35,11 @@ export function useActor(
     | ActorRef<EventObject, unknown>
     | Ref<ActorRef<EventObject, unknown>>,
   getSnapshot: (actor: ActorRef<EventObject, unknown>) => unknown = (a) =>
-    isActorWithState(a) ? a.state : undefined
+    isActorWithState(a)
+      ? a.state
+      : 'getSnapshot' in a
+      ? a.getSnapshot()
+      : undefined
 ): {
   state: Ref<unknown>;
   send: Sender<EventObject>;


### PR DESCRIPTION
With `.getSnapshot()`, the `useService()` hooks are virtually the same as `useActor()`.