### PR TITLE
[v5] Restrict `context` to object 

### DIFF
--- a/.changeset/cold-steaks-drop.md
+++ b/.changeset/cold-steaks-drop.md
@@ -1,0 +1,24 @@
+---
+'xstate': major
+---
+
+The machine's `context` is now restricted to an `object`. This was the most common usage, but now the typings prevent `context` from being anything but an object:
+
+```ts
+const machine = createMachine({
+  // This will produce the TS error:
+  // "Type 'string' is not assignable to type 'object | undefined'"
+  context: 'some string'
+});
+```
+
+If `context` is `undefined`, it will now default to an empty object `{}`:
+
+```ts
+const machine = createMachine({
+  // No context
+});
+
+machine.initialState.context;
+// => {}
+```

--- a/packages/core/src/Actor.ts
+++ b/packages/core/src/Actor.ts
@@ -6,7 +6,8 @@ import {
   InterpreterOptions,
   ActorRef,
   Lazy,
-  BaseActorRef
+  BaseActorRef,
+  MachineContext
 } from './types';
 import { StateMachine } from './StateMachine';
 import { State } from './State';
@@ -68,7 +69,10 @@ export function fromCallback<TEvent extends EventObject>(
   );
 }
 
-export function fromMachine<TContext, TEvent extends EventObject>(
+export function fromMachine<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+>(
   machine: StateMachine<TContext, TEvent>,
   name: string,
   options?: Partial<InterpreterOptions>

--- a/packages/core/src/Machine.ts
+++ b/packages/core/src/Machine.ts
@@ -3,14 +3,15 @@ import {
   MachineConfig,
   EventObject,
   AnyEventObject,
-  Typestate
+  Typestate,
+  MachineContext
 } from './types';
 import { StateMachine } from './StateMachine';
 import { Model, ModelContextFrom, ModelEventsFrom } from './model';
 
 export function createMachine<
   TModel extends Model<any, any, any>,
-  TContext = ModelContextFrom<TModel>,
+  TContext extends MachineContext = ModelContextFrom<TModel>,
   TEvent extends EventObject = ModelEventsFrom<TModel>,
   TTypestate extends Typestate<TContext> = { value: any; context: TContext }
 >(
@@ -18,7 +19,7 @@ export function createMachine<
   options?: Partial<MachineImplementations<TContext, TEvent>>
 ): StateMachine<TContext, TEvent, TTypestate>;
 export function createMachine<
-  TContext,
+  TContext extends MachineContext,
   TEvent extends EventObject = AnyEventObject,
   TTypestate extends Typestate<TContext> = { value: any; context: TContext }
 >(
@@ -26,7 +27,7 @@ export function createMachine<
   options?: Partial<MachineImplementations<TContext, TEvent>>
 ): StateMachine<TContext, TEvent, TTypestate>;
 export function createMachine<
-  TContext,
+  TContext extends MachineContext,
   TEvent extends EventObject = AnyEventObject,
   TTypestate extends Typestate<TContext> = { value: any; context: TContext }
 >(

--- a/packages/core/src/State.ts
+++ b/packages/core/src/State.ts
@@ -9,7 +9,8 @@ import {
   Typestate,
   HistoryValue,
   NullEvent,
-  ActorRef
+  ActorRef,
+  MachineContext
 } from './types';
 import { matchesState, keys, isString } from './utils';
 import { StateNode } from './StateNode';
@@ -17,7 +18,7 @@ import { isInFinalState, nextEvents, getMeta } from './stateUtils';
 import { initEvent } from './actions';
 
 export function isState<
-  TContext,
+  TContext extends MachineContext,
   TEvent extends EventObject,
   TTypestate extends Typestate<TContext> = { value: any; context: TContext }
 >(state: object | string): state is State<TContext, TEvent, TTypestate> {
@@ -27,17 +28,20 @@ export function isState<
 
   return 'value' in state && 'history' in state;
 }
-export function bindActionToState<TC, TE extends EventObject>(
-  action: ActionObject<TC, TE>,
-  state: State<TC, TE, any>
-): ActionObject<TC, TE> {
+export function bindActionToState<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+>(
+  action: ActionObject<TContext, TEvent>,
+  state: State<TContext, TEvent, any>
+): ActionObject<TContext, TEvent> {
   const { exec } = action;
-  const boundAction: ActionObject<TC, TE> = {
+  const boundAction: ActionObject<TContext, TEvent> = {
     ...action,
     exec:
       exec !== undefined
         ? () =>
-            exec(state.context, state.event as TE, {
+            exec(state.context, state.event as TEvent, {
               action,
               state,
               _event: state._event
@@ -49,7 +53,7 @@ export function bindActionToState<TC, TE extends EventObject>(
 }
 
 export class State<
-  TContext,
+  TContext extends MachineContext,
   TEvent extends EventObject = EventObject,
   TTypestate extends Typestate<TContext> = { value: any; context: TContext }
 > {
@@ -95,15 +99,18 @@ export class State<
    * @param stateValue
    * @param context
    */
-  public static from<TC, TE extends EventObject = EventObject>(
-    stateValue: State<TC, TE, any> | StateValue,
-    context?: TC | undefined
-  ): State<TC, TE, any> {
+  public static from<
+    TContext extends MachineContext,
+    TEvent extends EventObject = EventObject
+  >(
+    stateValue: State<TContext, TEvent, any> | StateValue,
+    context?: TContext | undefined
+  ): State<TContext, TEvent, any> {
     if (stateValue instanceof State) {
       if (stateValue.context !== context) {
-        return new State<TC, TE>({
+        return new State<TContext, TEvent>({
           value: stateValue.value,
-          context: context as TC,
+          context: context as TContext,
           _event: stateValue._event,
           _sessionid: null,
           history: stateValue.history,
@@ -118,11 +125,11 @@ export class State<
       return stateValue;
     }
 
-    const _event = initEvent as SCXML.Event<TE>;
+    const _event = initEvent as SCXML.Event<TEvent>;
 
-    return new State<TC, TE>({
+    return new State<TContext, TEvent>({
       value: stateValue,
-      context: context as TC,
+      context: context as TContext,
       _event,
       _sessionid: null,
       history: undefined,
@@ -137,9 +144,10 @@ export class State<
    * Creates a new State instance for the given `config`.
    * @param config The state config
    */
-  public static create<TC, TE extends EventObject = EventObject>(
-    config: StateConfig<TC, TE>
-  ): State<TC, TE, any> {
+  public static create<
+    TContext extends MachineContext,
+    TEvent extends EventObject = EventObject
+  >(config: StateConfig<TContext, TEvent>): State<TContext, TEvent, any> {
     return new State(config);
   }
   /**
@@ -151,10 +159,10 @@ export class State<
     state: TState,
     context: any
   ): TState;
-  public static inert<TC, TE extends EventObject = EventObject>(
-    stateValue: StateValue,
-    context: TC
-  ): State<TC, TE>;
+  public static inert<
+    TContext extends MachineContext,
+    TEvent extends EventObject = EventObject
+  >(stateValue: StateValue, context: TContext): State<TContext, TEvent>;
   public static inert(
     stateValue: State<any, any> | StateValue,
     context: any

--- a/packages/core/src/State.ts
+++ b/packages/core/src/State.ts
@@ -104,7 +104,7 @@ export class State<
     TEvent extends EventObject = EventObject
   >(
     stateValue: State<TContext, TEvent, any> | StateValue,
-    context?: TContext | undefined
+    context: TContext = {} as TContext
   ): State<TContext, TEvent, any> {
     if (stateValue instanceof State) {
       if (stateValue.context !== context) {

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -31,7 +31,7 @@ export const NULL_EVENT = '';
 export const STATE_IDENTIFIER = '#';
 export const WILDCARD = '*';
 
-const createDefaultOptions = <TContext>(
+const createDefaultOptions = <TContext extends MachineContext>(
   context: TContext
 ): MachineImplementations<TContext, any> => ({
   actions: {},

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -9,7 +9,8 @@ import {
   Typestate,
   Transitions,
   MachineSchema,
-  StateNodeDefinition
+  StateNodeDefinition,
+  MachineContext
 } from './types';
 import { State } from './State';
 
@@ -44,10 +45,6 @@ function resolveContext<TContext>(
   context: TContext,
   partialContext?: Partial<TContext>
 ): TContext {
-  if (context === undefined) {
-    return context;
-  }
-
   return {
     ...context,
     ...partialContext
@@ -55,7 +52,7 @@ function resolveContext<TContext>(
 }
 
 export class StateMachine<
-  TContext = any,
+  TContext extends MachineContext = any,
   TEvent extends EventObject = EventObject,
   TTypestate extends Typestate<TContext> = any
 > {
@@ -100,10 +97,7 @@ export class StateMachine<
       createDefaultOptions(config.context!),
       options
     );
-    this.context = resolveContext<TContext>(
-      config.context as TContext,
-      this.options.context
-    );
+    this.context = resolveContext(config.context, options?.context) as TContext;
     this.delimiter = this.config.delimiter || STATE_DELIMITER;
     this.version = this.config.version;
     this.schema = this.config.schema ?? (({} as any) as this['schema']);

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -55,7 +55,7 @@ interface StateNodeOptions<
 }
 
 export class StateNode<
-  TContext extends MachineContext = {},
+  TContext extends MachineContext = MachineContext,
   TEvent extends EventObject = EventObject
 > {
   /**

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -28,7 +28,8 @@ import {
   NullEvent,
   SCXML,
   TransitionDefinitionMap,
-  InitialTransitionDefinition
+  InitialTransitionDefinition,
+  MachineContext
 } from './types';
 import { State } from './State';
 import * as actionTypes from './actionTypes';
@@ -44,14 +45,17 @@ import { StateMachine } from './StateMachine';
 
 const EMPTY_OBJECT = {};
 
-interface StateNodeOptions<TContext, TEvent extends EventObject> {
+interface StateNodeOptions<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> {
   _key: string;
   _parent?: StateNode<TContext, TEvent>;
   _machine: StateMachine<TContext, TEvent>;
 }
 
 export class StateNode<
-  TContext = any,
+  TContext extends MachineContext = {},
   TEvent extends EventObject = EventObject
 > {
   /**

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -41,7 +41,8 @@ import {
   StopAction,
   BehaviorCreator,
   ActorMap,
-  InvokeActionObject
+  InvokeActionObject,
+  MachineContext
 } from './types';
 import * as actionTypes from './actionTypes';
 import {
@@ -58,7 +59,10 @@ export { actionTypes };
 
 export const initEvent = toSCXMLEvent({ type: actionTypes.init });
 
-export function getActionFunction<TContext, TEvent extends EventObject>(
+export function getActionFunction<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+>(
   actionType: ActionType,
   actionFunctionMap?: ActionFunctionMap<TContext, TEvent>
 ):
@@ -70,7 +74,10 @@ export function getActionFunction<TContext, TEvent extends EventObject>(
     : undefined;
 }
 
-export function toActionObject<TContext, TEvent extends EventObject>(
+export function toActionObject<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+>(
   action: Action<TContext, TEvent>,
   actionFunctionMap?: ActionFunctionMap<TContext, TEvent>
 ): ActionObject<TContext, TEvent> {
@@ -123,7 +130,10 @@ export function toActionObject<TContext, TEvent extends EventObject>(
   return actionObject;
 }
 
-export const toActionObjects = <TContext, TEvent extends EventObject>(
+export const toActionObjects = <
+  TContext extends MachineContext,
+  TEvent extends EventObject
+>(
   action?: SingleOrArray<Action<TContext, TEvent>> | undefined,
   actionFunctionMap?: ActionFunctionMap<TContext, TEvent>
 ): Array<ActionObject<TContext, TEvent>> => {
@@ -144,7 +154,10 @@ export const toActionObjects = <TContext, TEvent extends EventObject>(
  *
  * @param eventType The event to raise.
  */
-export function raise<TContext, TEvent extends EventObject>(
+export function raise<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+>(
   event: Event<TEvent>
 ): RaiseAction<TEvent> | SendAction<TContext, AnyEventObject, TEvent> {
   if (!isString(event)) {
@@ -176,7 +189,7 @@ export function resolveRaise<TEvent extends EventObject>(
  *  - `to` - The target of this event (by default, the machine the event was sent from).
  */
 export function send<
-  TContext,
+  TContext extends MachineContext,
   TEvent extends EventObject,
   TSentEvent extends EventObject = AnyEventObject
 >(
@@ -198,7 +211,7 @@ export function send<
 }
 
 export function resolveSend<
-  TContext,
+  TContext extends MachineContext,
   TEvent extends EventObject,
   TSentEvent extends EventObject
 >(
@@ -250,7 +263,10 @@ export function resolveSend<
   };
 }
 
-export function resolveInvoke<TContext, TEvent extends EventObject>(
+export function resolveInvoke<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+>(
   action: InvokeAction,
   ctx: TContext,
   _event: SCXML.Event<TEvent>,
@@ -292,7 +308,7 @@ export function resolveInvoke<TContext, TEvent extends EventObject>(
  * @param options Options to pass into the send event.
  */
 export function sendParent<
-  TContext,
+  TContext extends MachineContext,
   TEvent extends EventObject,
   TSentEvent extends EventObject = AnyEventObject
 >(
@@ -308,11 +324,10 @@ export function sendParent<
 /**
  * Sends an update event to this machine's parent.
  */
-export function sendUpdate<TContext, TEvent extends EventObject>(): SendAction<
-  TContext,
-  TEvent,
-  { type: ActionTypes.Update }
-> {
+export function sendUpdate<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+>(): SendAction<TContext, TEvent, { type: ActionTypes.Update }> {
   return sendParent<TContext, TEvent, { type: ActionTypes.Update }>(
     actionTypes.update
   );
@@ -325,7 +340,7 @@ export function sendUpdate<TContext, TEvent extends EventObject>(): SendAction<
  * @param options Options to pass into the send event
  */
 export function respond<
-  TContext,
+  TContext extends MachineContext,
   TEvent extends EventObject,
   TSentEvent extends EventObject = AnyEventObject
 >(
@@ -356,7 +371,10 @@ const defaultLogExpr = <TContext, TEvent extends EventObject>(
  *  - `event` - the event that caused this action to be executed.
  * @param label The label to give to the logged expression.
  */
-export function log<TContext, TEvent extends EventObject>(
+export function log<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+>(
   expr: string | LogExpr<TContext, TEvent> = defaultLogExpr,
   label?: string
 ): LogAction<TContext, TEvent> {
@@ -367,7 +385,10 @@ export function log<TContext, TEvent extends EventObject>(
   };
 }
 
-export const resolveLog = <TContext, TEvent extends EventObject>(
+export const resolveLog = <
+  TContext extends MachineContext,
+  TEvent extends EventObject
+>(
   action: LogAction<TContext, TEvent>,
   ctx: TContext,
   _event: SCXML.Event<TEvent>
@@ -388,7 +409,10 @@ export const resolveLog = <TContext, TEvent extends EventObject>(
  *
  * @param sendId The `id` of the `send(...)` action to cancel.
  */
-export const cancel = <TContext, TEvent extends EventObject>(
+export const cancel = <
+  TContext extends MachineContext,
+  TEvent extends EventObject
+>(
   sendId: string | ExprWithMeta<TContext, TEvent, string>
 ): CancelAction<TContext, TEvent> => {
   return {
@@ -397,7 +421,10 @@ export const cancel = <TContext, TEvent extends EventObject>(
   };
 };
 
-export const resolveCancel = <TContext, TEvent extends EventObject>(
+export const resolveCancel = <
+  TContext extends MachineContext,
+  TEvent extends EventObject
+>(
   action: CancelAction<TContext, TEvent>,
   ctx: TContext,
   _event: SCXML.Event<TEvent>
@@ -414,9 +441,10 @@ export const resolveCancel = <TContext, TEvent extends EventObject>(
   return action as CancelActionObject<TContext, TEvent>;
 };
 
-export function invoke<TContext, TEvent extends EventObject>(
-  invokeDef: InvokeDefinition<TContext, TEvent>
-): InvokeAction {
+export function invoke<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+>(invokeDef: InvokeDefinition<TContext, TEvent>): InvokeAction {
   return {
     type: ActionTypes.Invoke,
     src: invokeDef.src,
@@ -432,7 +460,10 @@ export function invoke<TContext, TEvent extends EventObject>(
  *
  * @param actorRef The activity to stop.
  */
-export function stop<TContext, TEvent extends EventObject>(
+export function stop<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+>(
   actorRef: string | Expr<TContext, TEvent, ActorRef<any>>
 ): StopAction<TContext, TEvent> {
   const activity = isFunction(actorRef) ? actorRef : actorRef;
@@ -443,7 +474,10 @@ export function stop<TContext, TEvent extends EventObject>(
   };
 }
 
-export function resolveStop<TContext, TEvent extends EventObject>(
+export function resolveStop<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+>(
   action: StopAction<TContext, TEvent>,
   context: TContext,
   _event: SCXML.Event<TEvent>
@@ -465,7 +499,10 @@ export function resolveStop<TContext, TEvent extends EventObject>(
  *
  * @param assignment An object that represents the partial context to update.
  */
-export const assign = <TContext, TEvent extends EventObject = EventObject>(
+export const assign = <
+  TContext extends MachineContext,
+  TEvent extends EventObject = EventObject
+>(
   assignment: Assigner<TContext, TEvent> | PropertyAssigner<TContext, TEvent>
 ): AssignAction<TContext, TEvent> => {
   return {
@@ -474,9 +511,10 @@ export const assign = <TContext, TEvent extends EventObject = EventObject>(
   };
 };
 
-export function isActionObject<TContext, TEvent extends EventObject>(
-  action: Action<TContext, TEvent>
-): action is ActionObject<TContext, TEvent> {
+export function isActionObject<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+>(action: Action<TContext, TEvent>): action is ActionObject<TContext, TEvent> {
   return typeof action === 'object' && 'type' in action;
 }
 
@@ -541,7 +579,10 @@ export function error(id: string, data?: any): ErrorPlatformEvent & string {
   return eventObject as ErrorPlatformEvent & string;
 }
 
-export function pure<TContext, TEvent extends EventObject>(
+export function pure<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+>(
   getActions: (
     context: TContext,
     event: TEvent
@@ -559,7 +600,10 @@ export function pure<TContext, TEvent extends EventObject>(
  * @param target The target service to forward the event to.
  * @param options Options to pass into the send action creator.
  */
-export function forwardTo<TContext, TEvent extends EventObject>(
+export function forwardTo<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+>(
   target: Required<SendActionOptions<TContext, TEvent>>['to'],
   options?: SendActionOptions<TContext, TEvent>
 ): SendAction<TContext, TEvent, AnyEventObject> {
@@ -577,7 +621,7 @@ export function forwardTo<TContext, TEvent extends EventObject>(
  * @param options Options to pass into the send action creator.
  */
 export function escalate<
-  TContext,
+  TContext extends MachineContext,
   TEvent extends EventObject,
   TErrorData = any
 >(
@@ -600,7 +644,10 @@ export function escalate<
   );
 }
 
-export function choose<TContext, TEvent extends EventObject>(
+export function choose<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+>(
   guards: Array<ChooseConditon<TContext, TEvent>>
 ): ChooseAction<TContext, TEvent> {
   return {

--- a/packages/core/src/behavior.ts
+++ b/packages/core/src/behavior.ts
@@ -9,7 +9,8 @@ import {
   Lazy,
   Sender,
   Receiver,
-  ActorRef
+  ActorRef,
+  MachineContext
 } from './types';
 import {
   toSCXMLEvent,
@@ -252,7 +253,10 @@ export function createObservableBehavior<
   return behavior;
 }
 
-export function createMachineBehavior<TContext, TEvent extends EventObject>(
+export function createMachineBehavior<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+>(
   machine:
     | StateMachine<TContext, TEvent>
     | Lazy<StateMachine<TContext, TEvent>>,

--- a/packages/core/src/each.ts
+++ b/packages/core/src/each.ts
@@ -1,17 +1,31 @@
-import { EventObject, SingleOrArray, ActionObject } from '.';
+import {
+  EventObject,
+  SingleOrArray,
+  ActionObject,
+  MachineContext
+} from './types';
 
-export function each<TContext, TEvent extends EventObject>(
+export function each<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+>(
   collection: keyof TContext,
   item: keyof TContext,
   actions: SingleOrArray<ActionObject<TContext, TEvent>>
 ): ActionObject<TContext, TEvent>;
-export function each<TContext, TEvent extends EventObject>(
+export function each<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+>(
   collection: keyof TContext,
   item: keyof TContext,
   index: keyof TContext,
   actions: SingleOrArray<ActionObject<TContext, TEvent>>
 ): ActionObject<TContext, TEvent>;
-export function each<TContext, TEvent extends EventObject>(
+export function each<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+>(
   collection: keyof TContext,
   item: keyof TContext,
   indexOrActions:

--- a/packages/core/src/guards.ts
+++ b/packages/core/src/guards.ts
@@ -6,15 +6,17 @@ import {
   GuardDefinition,
   GuardMeta,
   SCXML,
-  GuardPredicate
+  GuardPredicate,
+  MachineContext
 } from './types';
 import { isStateId } from './stateUtils';
 import { isFunction, isString } from './utils';
 import { State } from './State';
 
-export function stateIn<TContext, TEvent extends EventObject>(
-  stateValue: StateValue
-): GuardDefinition<TContext, TEvent> {
+export function stateIn<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+>(stateValue: StateValue): GuardDefinition<TContext, TEvent> {
   return {
     type: 'xstate.guard:in',
     params: { stateValue },
@@ -28,7 +30,10 @@ export function stateIn<TContext, TEvent extends EventObject>(
   };
 }
 
-export function not<TContext, TEvent extends EventObject>(
+export function not<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+>(
   guard: GuardConfig<TContext, TEvent>
 ): BooleanGuardDefinition<TContext, TEvent> {
   return {
@@ -46,7 +51,10 @@ export function not<TContext, TEvent extends EventObject>(
   };
 }
 
-export function and<TContext, TEvent extends EventObject>(
+export function and<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+>(
   guards: Array<GuardConfig<TContext, TEvent>>
 ): BooleanGuardDefinition<TContext, TEvent> {
   return {
@@ -61,7 +69,7 @@ export function and<TContext, TEvent extends EventObject>(
   };
 }
 
-export function or<TContext, TEvent extends EventObject>(
+export function or<TContext extends MachineContext, TEvent extends EventObject>(
   guards: Array<GuardConfig<TContext, TEvent>>
 ): BooleanGuardDefinition<TContext, TEvent> {
   return {
@@ -76,7 +84,10 @@ export function or<TContext, TEvent extends EventObject>(
   };
 }
 
-export function evaluateGuard<TContext, TEvent extends EventObject>(
+export function evaluateGuard<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+>(
   guard: GuardDefinition<TContext, TEvent>,
   context: TContext,
   _event: SCXML.Event<TEvent>,
@@ -98,7 +109,10 @@ export function evaluateGuard<TContext, TEvent extends EventObject>(
   return predicate(context, _event.data, guardMeta);
 }
 
-export function toGuardDefinition<TContext, TEvent extends EventObject>(
+export function toGuardDefinition<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+>(
   guardConfig: GuardConfig<TContext, TEvent>,
   getPredicate?: (guardType: string) => GuardPredicate<TContext, TEvent>
 ): GuardDefinition<TContext, TEvent> {

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -42,10 +42,10 @@ import { registry } from './registry';
 import { StateMachine } from './StateMachine';
 import { devToolsAdapter } from './dev';
 import { CapturedState } from './capturedState';
-import { PayloadSender, StopActionObject } from '.';
+import { MachineContext, PayloadSender, StopActionObject } from '.';
 
 export type StateListener<
-  TContext,
+  TContext extends MachineContext,
   TEvent extends EventObject,
   TTypestate extends Typestate<TContext> = { value: any; context: TContext }
 > = (state: State<TContext, TEvent, TTypestate>, event: TEvent) => void;
@@ -83,7 +83,7 @@ const defaultOptions: InterpreterOptions = ((global) => ({
 }))(typeof window === 'undefined' ? global : window);
 
 export class Interpreter<
-  TContext,
+  TContext extends MachineContext,
   TEvent extends EventObject = EventObject,
   TTypestate extends Typestate<TContext> = { value: any; context: TContext }
 > {
@@ -845,7 +845,7 @@ export class Interpreter<
  * @param options Interpreter options
  */
 export function interpret<
-  TContext,
+  TContext extends MachineContext,
   TEvent extends EventObject = EventObject,
   TTypestate extends Typestate<TContext> = { value: any; context: TContext }
 >(

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -2,7 +2,6 @@ import {
   Event,
   EventObject,
   CancelActionObject,
-  DefaultContext,
   ActionObject,
   SpecialTargets,
   ActionTypes,
@@ -846,7 +845,7 @@ export class Interpreter<
  * @param options Interpreter options
  */
 export function interpret<
-  TContext = DefaultContext,
+  TContext,
   TEvent extends EventObject = EventObject,
   TTypestate extends Typestate<TContext> = { value: any; context: TContext }
 >(

--- a/packages/core/src/invoke.ts
+++ b/packages/core/src/invoke.ts
@@ -4,7 +4,8 @@ import {
   Subscribable,
   BehaviorCreator,
   SCXML,
-  InvokeMeta
+  InvokeMeta,
+  MachineContext
 } from './types';
 
 import { isFunction, mapContext } from './utils';
@@ -21,7 +22,7 @@ import {
 export const DEFAULT_SPAWN_OPTIONS = { sync: false };
 
 export function invokeMachine<
-  TContext,
+  TContext extends MachineContext,
   TEvent extends EventObject,
   TMachine extends StateMachine<any, any, any>
 >(
@@ -65,7 +66,10 @@ export function invokePromise<T>(
   };
 }
 
-export function invokeActivity<TContext, TEvent extends EventObject>(
+export function invokeActivity<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+>(
   activityCreator: (ctx: TContext, event: TEvent) => any
 ): BehaviorCreator<TContext, TEvent> {
   const callbackCreator = (ctx: TContext, event: TEvent) => () => {
@@ -76,7 +80,7 @@ export function invokeActivity<TContext, TEvent extends EventObject>(
 }
 
 export function invokeCallback<
-  TContext,
+  TContext extends MachineContext,
   TEvent extends EventObject = AnyEventObject
 >(
   callbackCreator: (ctx: TContext, e: TEvent) => InvokeCallback

--- a/packages/core/src/invokeUtils.ts
+++ b/packages/core/src/invokeUtils.ts
@@ -3,7 +3,8 @@ import {
   EventObject,
   InvokeConfig,
   InvokeDefinition,
-  InvokeSourceDefinition
+  InvokeSourceDefinition,
+  MachineContext
 } from './types';
 
 export function toInvokeSource(
@@ -16,7 +17,10 @@ export function toInvokeSource(
   return src;
 }
 
-export function toInvokeDefinition<TContext, TEvent extends EventObject>(
+export function toInvokeDefinition<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+>(
   invokeConfig: InvokeConfig<TContext, TEvent> & {
     src: string | InvokeSourceDefinition;
     id: string;

--- a/packages/core/src/match.ts
+++ b/packages/core/src/match.ts
@@ -1,16 +1,23 @@
 import { State } from './State';
-import { StateValue, EventObject } from './types';
+import { StateValue, EventObject, MachineContext } from './types';
 
-export type ValueFromStateGetter<T, TContext, TEvent extends EventObject> = (
-  state: State<TContext, TEvent>
-) => T;
+export type ValueFromStateGetter<
+  T,
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> = (state: State<TContext, TEvent>) => T;
 
-export type StatePatternTuple<T, TContext, TEvent extends EventObject> = [
-  StateValue,
-  ValueFromStateGetter<T, TContext, TEvent>
-];
+export type StatePatternTuple<
+  T,
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> = [StateValue, ValueFromStateGetter<T, TContext, TEvent>];
 
-export function matchState<T, TContext, TEvent extends EventObject>(
+export function matchState<
+  T,
+  TContext extends MachineContext,
+  TEvent extends EventObject
+>(
   state: State<TContext, TEvent> | StateValue,
   patterns: Array<StatePatternTuple<T, TContext, TEvent>>,
   defaultValue: ValueFromStateGetter<T, TContext, TEvent>

--- a/packages/core/src/model.ts
+++ b/packages/core/src/model.ts
@@ -16,7 +16,7 @@ type Compute<A extends any> = { [K in keyof A]: A[K] } & unknown;
 type Prop<T, K> = K extends keyof T ? T[K] : never;
 
 export interface Model<
-  TContext,
+  TContext extends MachineContext,
   TEvent extends EventObject,
   TModelCreators = void
 > {

--- a/packages/core/src/model.ts
+++ b/packages/core/src/model.ts
@@ -4,7 +4,8 @@ import type {
   Assigner,
   PropertyAssigner,
   ExtractEvent,
-  EventObject
+  EventObject,
+  MachineContext
 } from './types';
 import { mapValues } from './utils';
 
@@ -85,11 +86,12 @@ type EventFromEventCreators<EventCreators> = {
     : never;
 }[keyof EventCreators];
 
-export function createModel<TContext, TEvent extends EventObject>(
-  initialContext: TContext
-): Model<TContext, TEvent, void>;
 export function createModel<
-  TContext,
+  TContext extends MachineContext,
+  TEvent extends EventObject
+>(initialContext: TContext): Model<TContext, TEvent, void>;
+export function createModel<
+  TContext extends MachineContext,
   TModelCreators extends ModelCreators<TModelCreators>,
   TFinalModelCreators = FinalModelCreators<TModelCreators>
 >(

--- a/packages/core/src/scxml.ts
+++ b/packages/core/src/scxml.ts
@@ -8,7 +8,7 @@ import {
   ChooseConditon
 } from './types';
 import { createMachine } from './index';
-import { mapValues, keys, isString, flatten } from './utils';
+import { mapValues, isString, flatten } from './utils';
 import * as actions from './actions';
 import { invokeMachine } from './invoke';
 import { StateMachine } from './StateMachine';

--- a/packages/core/src/scxml.ts
+++ b/packages/core/src/scxml.ts
@@ -104,24 +104,21 @@ const evaluateExecutableContent = <
   meta: SCXMLEventMeta<TEvent>,
   body: string
 ) => {
-  const datamodel = context
-    ? keys(context)
-        .map((key) => `const ${key} = context['${key}'];`)
-        .join('\n')
-    : '';
-
-  const scope = ['const _sessionid = "NOT_IMPLEMENTED";', datamodel]
+  const scope = ['const _sessionid = "NOT_IMPLEMENTED";']
     .filter(Boolean)
     .join('\n');
 
   const args = ['context', '_event'];
 
   const fnBody = `
-    ${scope}
-    ${body}
+${scope}
+with (context) {
+  ${body}
+}
   `;
 
   const fn = new Function(...args, fnBody);
+
   return fn(context, meta._event);
 };
 
@@ -147,9 +144,10 @@ function mapAction<
     case 'assign': {
       return actions.assign<TContext, TEvent>((context, e, meta) => {
         const fnBody = `
-            return {'${element.attributes!.location}': ${
-          element.attributes!.expr
-        }};
+
+${element.attributes!.location};
+
+return {'${element.attributes!.location}': ${element.attributes!.expr}};
           `;
 
         return evaluateExecutableContent(context, e, meta, fnBody);
@@ -161,7 +159,7 @@ function mapAction<
       }
       return actions.cancel((context, e, meta) => {
         const fnBody = `
-            return ${element.attributes!.sendidexpr};
+return ${element.attributes!.sendidexpr};
           `;
 
         return evaluateExecutableContent(context, e, meta, fnBody);
@@ -188,9 +186,7 @@ function mapAction<
       } else {
         convertedEvent = (context, _ev, meta) => {
           const fnBody = `
-              return { type: ${event ? `"${event}"` : eventexpr}, ${
-            params ? params : ''
-          } }
+return { type: ${event ? `"${event}"` : eventexpr}, ${params ? params : ''} }
             `;
 
           return evaluateExecutableContent(context, _ev, meta, fnBody);
@@ -202,7 +198,7 @@ function mapAction<
       } else if (element.attributes!.delayexpr) {
         convertedDelay = (context, _ev, meta) => {
           const fnBody = `
-              return (${delayToMs})(${element.attributes!.delayexpr});
+return (${delayToMs})(${element.attributes!.delayexpr});
             `;
 
           return evaluateExecutableContent(context, _ev, meta, fnBody);
@@ -221,7 +217,7 @@ function mapAction<
       return actions.log<TContext, TEvent>(
         (context, e, meta) => {
           const fnBody = `
-              return ${element.attributes!.expr};
+return ${element.attributes!.expr};
             `;
 
           return evaluateExecutableContent(context, e, meta, fnBody);

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -38,7 +38,7 @@ export interface ActionObject<TContext, TEvent extends EventObject> {
   [other: string]: any;
 }
 
-export type DefaultContext = Record<string, any> | undefined;
+export type MachineContext = object | undefined;
 
 /**
  * The specified string event types or the specified event objects.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -26,7 +26,10 @@ export interface AnyEventObject extends EventObject {
  * The full definition of an action, with a string `type` and an
  * `exec` implementation function.
  */
-export interface ActionObject<TContext, TEvent extends EventObject> {
+export interface ActionObject<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> {
   /**
    * The type of action that is executed.
    */
@@ -45,8 +48,10 @@ export type MachineContext = object;
  */
 export type Event<TEvent extends EventObject> = TEvent['type'] | TEvent;
 
-export interface ActionMeta<TContext, TEvent extends EventObject>
-  extends StateMeta<TContext, TEvent> {
+export interface ActionMeta<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> extends StateMeta<TContext, TEvent> {
   action: ActionObject<TContext, TEvent>;
   _event: SCXML.Event<TEvent>;
 }
@@ -58,31 +63,44 @@ export type Spawner = <T extends Behavior<any, any>>(
   ? ActorRef<TActorEvent, TActorEmitted>
   : never;
 
-export interface AssignMeta<TContext, TEvent extends EventObject> {
+export interface AssignMeta<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> {
   state?: State<TContext, TEvent>;
   action: AssignAction<TContext, TEvent>;
   _event: SCXML.Event<TEvent>;
 }
 
-export type ActionFunction<TContext, TEvent extends EventObject> = (
+export type ActionFunction<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> = (
   context: TContext,
   event: TEvent,
   meta: ActionMeta<TContext, TEvent>
 ) => void;
 
-export interface ChooseConditon<TContext, TEvent extends EventObject> {
+export interface ChooseConditon<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> {
   guard?: GuardConfig<TContext, TEvent>;
   actions: Actions<TContext, TEvent>;
 }
 
-export type Action<TContext, TEvent extends EventObject> =
+export type Action<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> =
   | ActionType
   | ActionObject<TContext, TEvent>
   | ActionFunction<TContext, TEvent>;
 
-export type Actions<TContext, TEvent extends EventObject> = SingleOrArray<
-  Action<TContext, TEvent>
->;
+export type Actions<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> = SingleOrArray<Action<TContext, TEvent>>;
 
 export type StateKey = string | State<any>;
 
@@ -98,13 +116,19 @@ export interface StateValueMap {
  */
 export type StateValue = string | StateValueMap;
 
-export type GuardPredicate<TContext, TEvent extends EventObject> = (
+export type GuardPredicate<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> = (
   context: TContext,
   event: TEvent,
   meta: GuardMeta<TContext, TEvent>
 ) => boolean;
 
-export interface DefaultGuardObject<TContext, TEvent extends EventObject> {
+export interface DefaultGuardObject<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> {
   type: string;
   params?: { [key: string]: any };
   /**
@@ -114,36 +138,48 @@ export interface DefaultGuardObject<TContext, TEvent extends EventObject> {
   predicate?: GuardPredicate<TContext, TEvent>;
 }
 
-export type GuardEvaluator<TContext, TEvent extends EventObject> = (
+export type GuardEvaluator<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> = (
   guard: GuardDefinition<TContext, TEvent>,
   context: TContext,
   _event: SCXML.Event<TEvent>,
   state: State<TContext, TEvent>
 ) => boolean;
 
-export interface GuardMeta<TContext, TEvent extends EventObject>
-  extends StateMeta<TContext, TEvent> {
+export interface GuardMeta<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> extends StateMeta<TContext, TEvent> {
   guard: GuardDefinition<TContext, TEvent>;
   evaluate: GuardEvaluator<TContext, TEvent>;
 }
 
-export type GuardConfig<TContext, TEvent extends EventObject> =
-  | string
-  | GuardPredicate<TContext, TEvent>
-  | GuardObject<TContext, TEvent>;
+export type GuardConfig<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> = string | GuardPredicate<TContext, TEvent> | GuardObject<TContext, TEvent>;
 
-export type GuardObject<TContext, TEvent extends EventObject> =
-  | BooleanGuardObject<TContext, TEvent>
-  | DefaultGuardObject<TContext, TEvent>;
+export type GuardObject<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> = BooleanGuardObject<TContext, TEvent> | DefaultGuardObject<TContext, TEvent>;
 
-export interface GuardDefinition<TContext, TEvent extends EventObject> {
+export interface GuardDefinition<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> {
   type: string;
   children?: Array<GuardDefinition<TContext, TEvent>>;
   predicate?: GuardPredicate<TContext, TEvent>;
   params: { [key: string]: any };
 }
 
-export interface BooleanGuardObject<TContext, TEvent extends EventObject> {
+export interface BooleanGuardObject<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> {
   type: 'xstate.boolean';
   children: Array<GuardConfig<TContext, TEvent>>;
   params: {
@@ -152,8 +188,10 @@ export interface BooleanGuardObject<TContext, TEvent extends EventObject> {
   predicate: undefined;
 }
 
-export interface BooleanGuardDefinition<TContext, TEvent extends EventObject>
-  extends GuardDefinition<TContext, TEvent> {
+export interface BooleanGuardDefinition<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> extends GuardDefinition<TContext, TEvent> {
   type: 'xstate.boolean';
   params: {
     op: 'and' | 'or' | 'not';
@@ -161,15 +199,18 @@ export interface BooleanGuardDefinition<TContext, TEvent extends EventObject>
 }
 
 export type TransitionTarget<
-  TContext,
+  TContext extends MachineContext,
   TEvent extends EventObject
 > = SingleOrArray<string | StateNode<TContext, TEvent>>;
 
-export type TransitionTargets<TContext> = Array<
+export type TransitionTargets<TContext extends MachineContext> = Array<
   string | StateNode<TContext, any>
 >;
 
-export interface TransitionConfig<TContext, TEvent extends EventObject> {
+export interface TransitionConfig<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> {
   guard?: GuardConfig<TContext, TEvent>;
   actions?: Actions<TContext, TEvent>;
   internal?: boolean;
@@ -177,23 +218,30 @@ export interface TransitionConfig<TContext, TEvent extends EventObject> {
   meta?: Record<string, any>;
 }
 
-export interface TargetTransitionConfig<TContext, TEvent extends EventObject>
-  extends TransitionConfig<TContext, TEvent> {
+export interface TargetTransitionConfig<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> extends TransitionConfig<TContext, TEvent> {
   target: TransitionTarget<TContext, TEvent>; // TODO: just make this non-optional
 }
 
 export type ConditionalTransitionConfig<
-  TContext,
+  TContext extends MachineContext,
   TEvent extends EventObject = EventObject
 > = Array<TransitionConfig<TContext, TEvent>>;
 
-export interface InitialTransitionConfig<TContext, TEvent extends EventObject>
-  extends TransitionConfig<TContext, TEvent> {
+export interface InitialTransitionConfig<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> extends TransitionConfig<TContext, TEvent> {
   guard?: never;
   target: TransitionTarget<TContext, TEvent>;
 }
 
-export type Transition<TContext, TEvent extends EventObject = EventObject> =
+export type Transition<
+  TContext extends MachineContext,
+  TEvent extends EventObject = EventObject
+> =
   | string
   | TransitionConfig<TContext, TEvent>
   | ConditionalTransitionConfig<TContext, TEvent>;
@@ -235,7 +283,10 @@ export type InvokeCallback<TEvent extends EventObject = AnyEventObject> = (
   onReceive: Receiver<TEvent>
 ) => any;
 
-export type BehaviorCreator<TContext, TEvent extends EventObject> = (
+export type BehaviorCreator<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> = (
   context: TContext,
   event: TEvent,
   meta: {
@@ -251,7 +302,10 @@ export interface InvokeMeta {
   src: InvokeSourceDefinition;
 }
 
-export interface InvokeDefinition<TContext, TEvent extends EventObject> {
+export interface InvokeDefinition<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> {
   id: string;
   /**
    * The source of the actor's behavior to be invoked
@@ -297,7 +351,10 @@ export interface Delay {
   delay: number;
 }
 
-export type DelayedTransitions<TContext, TEvent extends EventObject> =
+export type DelayedTransitions<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> =
   | Record<
       string | number,
       string | SingleOrArray<TransitionConfig<TContext, TEvent>>
@@ -318,31 +375,43 @@ export type StateTypes =
 
 export type SingleOrArray<T> = T[] | T;
 
-export type StateNodesConfig<TContext, TEvent extends EventObject> = {
+export type StateNodesConfig<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> = {
   [K in string]: StateNode<TContext, TEvent>;
 };
 
-export type StatesConfig<TContext, TEvent extends EventObject> = {
+export type StatesConfig<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> = {
   [K in string]: StateNodeConfig<TContext, TEvent>;
 };
 
-export type StatesDefinition<TContext, TEvent extends EventObject> = {
+export type StatesDefinition<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> = {
   [K in string]: StateNodeDefinition<TContext, TEvent>;
 };
 
-export type TransitionConfigTarget<TContext, TEvent extends EventObject> =
-  | string
-  | undefined
-  | StateNode<TContext, TEvent>;
+export type TransitionConfigTarget<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> = string | undefined | StateNode<TContext, TEvent>;
 
 export type TransitionConfigOrTarget<
-  TContext,
+  TContext extends MachineContext,
   TEvent extends EventObject
 > = SingleOrArray<
   TransitionConfigTarget<TContext, TEvent> | TransitionConfig<TContext, TEvent>
 >;
 
-export type TransitionsConfigMap<TContext, TEvent extends EventObject> = {
+export type TransitionsConfigMap<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> = {
   [K in TEvent['type']]?: TransitionConfigOrTarget<
     TContext,
     TEvent extends { type: K } ? TEvent : never
@@ -353,7 +422,10 @@ export type TransitionsConfigMap<TContext, TEvent extends EventObject> = {
   '*'?: TransitionConfigOrTarget<TContext, TEvent>;
 };
 
-type TransitionsConfigArray<TContext, TEvent extends EventObject> = Array<
+type TransitionsConfigArray<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> = Array<
   // distribute the union
   | (TEvent extends EventObject
       ? TransitionConfig<TContext, TEvent> & { event: TEvent['type'] }
@@ -362,7 +434,10 @@ type TransitionsConfigArray<TContext, TEvent extends EventObject> = Array<
   | (TransitionConfig<TContext, TEvent> & { event: '*' })
 >;
 
-export type TransitionsConfig<TContext, TEvent extends EventObject> =
+export type TransitionsConfig<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> =
   | TransitionsConfigMap<TContext, TEvent>
   | TransitionsConfigArray<TContext, TEvent>;
 
@@ -371,7 +446,10 @@ export interface InvokeSourceDefinition {
   type: string;
 }
 
-export interface InvokeConfig<TContext, TEvent extends EventObject> {
+export interface InvokeConfig<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> {
   /**
    * The unique identifier for the invoked machine. If not specified, this
    * will be the machine's own `id`, or the URL (from `src`).
@@ -408,7 +486,10 @@ export interface InvokeConfig<TContext, TEvent extends EventObject> {
     | SingleOrArray<TransitionConfig<TContext, DoneInvokeEvent<any>>>;
 }
 
-export interface StateNodeConfig<TContext, TEvent extends EventObject> {
+export interface StateNodeConfig<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> {
   /**
    * The relative key of the state node, which represents its location in the overall state value.
    * This is automatically determined by the configuration shape via the key where it was defined.
@@ -518,7 +599,10 @@ export interface StateNodeConfig<TContext, TEvent extends EventObject> {
   tags?: SingleOrArray<string>;
 }
 
-export interface StateNodeDefinition<TContext, TEvent extends EventObject> {
+export interface StateNodeDefinition<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> {
   id: string;
   version?: string | undefined;
   key: string;
@@ -538,22 +622,29 @@ export interface StateNodeDefinition<TContext, TEvent extends EventObject> {
 }
 
 export type AnyStateNodeDefinition = StateNodeDefinition<any, any>;
-export interface AtomicStateNodeConfig<TContext, TEvent extends EventObject>
-  extends StateNodeConfig<TContext, TEvent> {
+
+export interface AtomicStateNodeConfig<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> extends StateNodeConfig<TContext, TEvent> {
   initial?: undefined;
   parallel?: false | undefined;
   states?: undefined;
   onDone?: undefined;
 }
 
-export interface HistoryStateNodeConfig<TContext, TEvent extends EventObject>
-  extends AtomicStateNodeConfig<TContext, TEvent> {
+export interface HistoryStateNodeConfig<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> extends AtomicStateNodeConfig<TContext, TEvent> {
   history: 'shallow' | 'deep' | true;
   target: string | undefined;
 }
 
-export interface FinalStateNodeConfig<TContext, TEvent extends EventObject>
-  extends AtomicStateNodeConfig<TContext, TEvent> {
+export interface FinalStateNodeConfig<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> extends AtomicStateNodeConfig<TContext, TEvent> {
   type: 'final';
   /**
    * The data to be sent with the "done.state.<id>" event. The data can be
@@ -562,38 +653,49 @@ export interface FinalStateNodeConfig<TContext, TEvent extends EventObject>
   data?: Mapper<TContext, TEvent, any> | PropertyMapper<TContext, TEvent, any>;
 }
 
-export type SimpleOrStateNodeConfig<TContext, TEvent extends EventObject> =
-  | AtomicStateNodeConfig<TContext, TEvent>
-  | StateNodeConfig<TContext, TEvent>;
+export type SimpleOrStateNodeConfig<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> = AtomicStateNodeConfig<TContext, TEvent> | StateNodeConfig<TContext, TEvent>;
 
-export type ActionFunctionMap<TContext, TEvent extends EventObject> = Record<
+export type ActionFunctionMap<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> = Record<
   string,
   ActionObject<TContext, TEvent> | ActionFunction<TContext, TEvent>
 >;
 
-export type DelayFunctionMap<TContext, TEvent extends EventObject> = Record<
-  string,
-  DelayConfig<TContext, TEvent>
->;
+export type DelayFunctionMap<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> = Record<string, DelayConfig<TContext, TEvent>>;
 
-export type DelayConfig<TContext, TEvent extends EventObject> =
-  | number
-  | DelayExpr<TContext, TEvent>;
+export type DelayConfig<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> = number | DelayExpr<TContext, TEvent>;
 
-export type ActorMap<TContext, TEvent extends EventObject> = Record<
-  string,
-  BehaviorCreator<TContext, TEvent>
->;
+export type ActorMap<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> = Record<string, BehaviorCreator<TContext, TEvent>>;
 
-export interface MachineImplementations<TContext, TEvent extends EventObject> {
+export interface MachineImplementations<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> {
   guards: Record<string, GuardPredicate<TContext, TEvent>>;
   actions: ActionFunctionMap<TContext, TEvent>;
   actors: ActorMap<TContext, TEvent>;
   delays: DelayFunctionMap<TContext, TEvent>;
   context: Partial<TContext>;
 }
-export interface MachineConfig<TContext, TEvent extends EventObject>
-  extends StateNodeConfig<TContext, TEvent> {
+
+export interface MachineConfig<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> extends StateNodeConfig<TContext, TEvent> {
   /**
    * The initial context (extended state)
    */
@@ -609,7 +711,10 @@ export interface MachineConfig<TContext, TEvent extends EventObject>
   schema?: MachineSchema<TContext, TEvent>;
 }
 
-export interface MachineSchema<TContext, TEvent extends EventObject> {
+export interface MachineSchema<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> {
   context?: TContext;
   events?: TEvent;
   actions?: { type: string; [key: string]: any };
@@ -617,23 +722,25 @@ export interface MachineSchema<TContext, TEvent extends EventObject> {
   services?: { type: string; [key: string]: any };
 }
 
-export interface HistoryStateNode<TContext> extends StateNode<TContext> {
+export interface HistoryStateNode<TContext extends MachineContext>
+  extends StateNode<TContext> {
   history: 'shallow' | 'deep';
   target: string | undefined;
 }
 
-export type HistoryValue<TContext, TEvent extends EventObject> = Record<
-  string,
-  Array<StateNode<TContext, TEvent>>
->;
+export type HistoryValue<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> = Record<string, Array<StateNode<TContext, TEvent>>>;
 
 export type StateFrom<
   TMachine extends StateMachine<any, any, any>
 > = ReturnType<TMachine['transition']>;
 
-export type Transitions<TContext, TEvent extends EventObject> = Array<
-  TransitionDefinition<TContext, TEvent>
->;
+export type Transitions<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> = Array<TransitionDefinition<TContext, TEvent>>;
 
 export enum ActionTypes {
   Stop = 'xstate.stop',
@@ -718,7 +825,7 @@ export interface InvokeActionObject extends InvokeAction {
   ref?: ActorRef<any>;
 }
 
-export interface StopAction<TC, TE extends EventObject> {
+export interface StopAction<TC extends MachineContext, TE extends EventObject> {
   type: ActionTypes.Stop;
   actor: string | ActorRef<any> | Expr<TC, TE, ActorRef<any>>;
 }
@@ -727,31 +834,33 @@ export interface StopActionObject {
   actor: string | ActorRef<any>;
 }
 
-export type DelayExpr<TContext, TEvent extends EventObject> = ExprWithMeta<
-  TContext,
-  TEvent,
-  number
->;
+export type DelayExpr<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> = ExprWithMeta<TContext, TEvent, number>;
 
-export type LogExpr<TContext, TEvent extends EventObject> = ExprWithMeta<
-  TContext,
-  TEvent,
-  any
->;
+export type LogExpr<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> = ExprWithMeta<TContext, TEvent, any>;
 
-export interface LogAction<TContext, TEvent extends EventObject>
-  extends ActionObject<TContext, TEvent> {
+export interface LogAction<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> extends ActionObject<TContext, TEvent> {
   label: string | undefined;
   expr: string | LogExpr<TContext, TEvent>;
 }
 
-export interface LogActionObject<TContext, TEvent extends EventObject>
-  extends LogAction<TContext, TEvent> {
+export interface LogActionObject<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> extends LogAction<TContext, TEvent> {
   value: any;
 }
 
 export interface SendAction<
-  TContext,
+  TContext extends MachineContext,
   TEvent extends EventObject,
   TSentEvent extends EventObject
 > extends ActionObject<TContext, TEvent> {
@@ -766,7 +875,7 @@ export interface SendAction<
 }
 
 export interface SendActionObject<
-  TContext,
+  TContext extends MachineContext,
   TEvent extends EventObject,
   TSentEvent extends EventObject = AnyEventObject
 > extends SendAction<TContext, TEvent, TSentEvent> {
@@ -777,19 +886,20 @@ export interface SendActionObject<
   id: string | number;
 }
 
-export type Expr<TContext, TEvent extends EventObject, T> = (
-  context: TContext,
-  event: TEvent
-) => T;
+export type Expr<
+  TContext extends MachineContext,
+  TEvent extends EventObject,
+  T
+> = (context: TContext, event: TEvent) => T;
 
-export type ExprWithMeta<TContext, TEvent extends EventObject, T> = (
-  context: TContext,
-  event: TEvent,
-  meta: SCXMLEventMeta<TEvent>
-) => T;
+export type ExprWithMeta<
+  TContext extends MachineContext,
+  TEvent extends EventObject,
+  T
+> = (context: TContext, event: TEvent, meta: SCXMLEventMeta<TEvent>) => T;
 
 export type SendExpr<
-  TContext,
+  TContext extends MachineContext,
   TEvent extends EventObject,
   TSentEvent extends EventObject = AnyEventObject
 > = ExprWithMeta<TContext, TEvent, TSentEvent>;
@@ -799,7 +909,10 @@ export enum SpecialTargets {
   Internal = '#_internal'
 }
 
-export interface SendActionOptions<TContext, TEvent extends EventObject> {
+export interface SendActionOptions<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> {
   id?: string | number;
   delay?: number | string | DelayExpr<TContext, TEvent>;
   to?:
@@ -808,24 +921,31 @@ export interface SendActionOptions<TContext, TEvent extends EventObject> {
     | undefined;
 }
 
-export interface CancelAction<TContext, TEvent extends EventObject>
-  extends ActionObject<TContext, TEvent> {
+export interface CancelAction<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> extends ActionObject<TContext, TEvent> {
   sendId: string | ExprWithMeta<TContext, TEvent, string>;
 }
 
-export interface CancelActionObject<TContext, TEvent extends EventObject>
-  extends CancelAction<TContext, TEvent> {
+export interface CancelActionObject<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> extends CancelAction<TContext, TEvent> {
   sendId: string;
 }
 
-export type Assigner<TContext, TEvent extends EventObject> = (
+export type Assigner<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> = (
   context: TContext,
   event: TEvent,
   meta: AssignMeta<TContext, TEvent>
 ) => Partial<TContext>;
 
 export type PartialAssigner<
-  TContext,
+  TContext extends MachineContext,
   TEvent extends EventObject,
   TKey extends keyof TContext
 > = (
@@ -834,17 +954,21 @@ export type PartialAssigner<
   meta: AssignMeta<TContext, TEvent>
 ) => TContext[TKey];
 
-export type PropertyAssigner<TContext, TEvent extends EventObject> = {
+export type PropertyAssigner<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> = {
   [K in keyof TContext]?: PartialAssigner<TContext, TEvent, K> | TContext[K];
 };
 
-export type Mapper<TContext, TEvent extends EventObject, TParams extends {}> = (
-  context: TContext,
-  event: TEvent
-) => TParams;
+export type Mapper<
+  TContext extends MachineContext,
+  TEvent extends EventObject,
+  TParams extends {}
+> = (context: TContext, event: TEvent) => TParams;
 
 export type PropertyMapper<
-  TContext,
+  TContext extends MachineContext,
   TEvent extends EventObject,
   TParams extends {}
 > = {
@@ -853,20 +977,26 @@ export type PropertyMapper<
     | TParams[K];
 };
 
-export interface AnyAssignAction<TContext, TEvent extends EventObject>
-  extends ActionObject<TContext, TEvent> {
+export interface AnyAssignAction<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> extends ActionObject<TContext, TEvent> {
   type: ActionTypes.Assign;
   assignment: any;
 }
 
-export interface AssignAction<TContext, TEvent extends EventObject>
-  extends ActionObject<TContext, TEvent> {
+export interface AssignAction<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> extends ActionObject<TContext, TEvent> {
   type: ActionTypes.Assign;
   assignment: Assigner<TContext, TEvent> | PropertyAssigner<TContext, TEvent>;
 }
 
-export interface PureAction<TContext, TEvent extends EventObject>
-  extends ActionObject<TContext, TEvent> {
+export interface PureAction<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> extends ActionObject<TContext, TEvent> {
   type: ActionTypes.Pure;
   get: (
     context: TContext,
@@ -874,14 +1004,18 @@ export interface PureAction<TContext, TEvent extends EventObject>
   ) => SingleOrArray<ActionObject<TContext, TEvent>> | undefined;
 }
 
-export interface ChooseAction<TContext, TEvent extends EventObject>
-  extends ActionObject<TContext, TEvent> {
+export interface ChooseAction<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> extends ActionObject<TContext, TEvent> {
   type: ActionTypes.Choose;
   guards: Array<ChooseConditon<TContext, TEvent>>;
 }
 
-export interface TransitionDefinition<TContext, TEvent extends EventObject>
-  extends TransitionConfig<TContext, TEvent> {
+export interface TransitionDefinition<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> extends TransitionConfig<TContext, TEvent> {
   target: Array<StateNode<TContext, TEvent>> | undefined;
   source: StateNode<TContext, TEvent>;
   actions: Array<ActionObject<TContext, TEvent>>;
@@ -898,14 +1032,17 @@ export interface TransitionDefinition<TContext, TEvent extends EventObject>
 }
 
 export interface InitialTransitionDefinition<
-  TContext,
+  TContext extends MachineContext,
   TEvent extends EventObject
 > extends TransitionDefinition<TContext, TEvent> {
   target: Array<StateNode<TContext, TEvent>>;
   guard?: never;
 }
 
-export type TransitionDefinitionMap<TContext, TEvent extends EventObject> = {
+export type TransitionDefinitionMap<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> = {
   [K in TEvent['type'] | NullEvent['type'] | '*']: Array<
     TransitionDefinition<
       TContext,
@@ -915,14 +1052,14 @@ export type TransitionDefinitionMap<TContext, TEvent extends EventObject> = {
 };
 
 export interface DelayedTransitionDefinition<
-  TContext,
+  TContext extends MachineContext,
   TEvent extends EventObject
 > extends TransitionDefinition<TContext, TEvent> {
   delay: number | string | DelayExpr<TContext, TEvent>;
 }
 
 export interface Edge<
-  TContext,
+  TContext extends MachineContext,
   TEvent extends EventObject,
   TEventType extends TEvent['type'] = string
 > {
@@ -934,12 +1071,18 @@ export interface Edge<
   meta?: MetaObject;
   transition: TransitionDefinition<TContext, TEvent>;
 }
-export interface NodesAndEdges<TContext, TEvent extends EventObject> {
+export interface NodesAndEdges<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> {
   nodes: StateNode[];
   edges: Array<Edge<TContext, TEvent, TEvent['type']>>;
 }
 
-export interface Segment<TContext, TEvent extends EventObject> {
+export interface Segment<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> {
   /**
    * From state.
    */
@@ -950,22 +1093,34 @@ export interface Segment<TContext, TEvent extends EventObject> {
   event: TEvent;
 }
 
-export interface PathItem<TContext, TEvent extends EventObject> {
+export interface PathItem<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> {
   state: State<TContext, TEvent>;
   path: Array<Segment<TContext, TEvent>>;
   weight?: number;
 }
 
-export interface PathMap<TContext, TEvent extends EventObject> {
+export interface PathMap<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> {
   [key: string]: PathItem<TContext, TEvent>;
 }
 
-export interface PathsItem<TContext, TEvent extends EventObject> {
+export interface PathsItem<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> {
   state: State<TContext, TEvent>;
   paths: Array<Array<Segment<TContext, TEvent>>>;
 }
 
-export interface PathsMap<TContext, TEvent extends EventObject> {
+export interface PathsMap<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> {
   [key: string]: PathsItem<TContext, TEvent>;
 }
 
@@ -977,7 +1132,10 @@ export interface AdjacencyMap {
   [stateId: string]: Record<string, TransitionMap>;
 }
 
-export interface ValueAdjacencyMap<TContext, TEvent extends EventObject> {
+export interface ValueAdjacencyMap<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> {
   [stateId: string]: Record<string, State<TContext, TEvent>>;
 }
 
@@ -985,24 +1143,30 @@ export interface SCXMLEventMeta<TEvent extends EventObject> {
   _event: SCXML.Event<TEvent>;
 }
 
-export interface StateMeta<TContext, TEvent extends EventObject> {
+export interface StateMeta<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> {
   state: State<TContext, TEvent, any>;
   _event: SCXML.Event<TEvent>;
 }
 
-export interface Typestate<TContext> {
+export interface Typestate<TContext extends MachineContext> {
   value: StateValue;
   context: TContext;
 }
 
-export interface StateLike<TContext> {
+export interface StateLike<TContext extends MachineContext> {
   value: StateValue;
   context: TContext;
   event: EventObject;
   _event: SCXML.Event<EventObject>;
 }
 
-export interface StateConfig<TContext, TEvent extends EventObject> {
+export interface StateConfig<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> {
   value: StateValue;
   context: TContext;
   _event: SCXML.Event<TEvent>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -38,7 +38,7 @@ export interface ActionObject<TContext, TEvent extends EventObject> {
   [other: string]: any;
 }
 
-export type MachineContext = object | undefined;
+export type MachineContext = object;
 
 /**
  * The specified string event types or the specified event objects.

--- a/packages/core/src/updateContext.ts
+++ b/packages/core/src/updateContext.ts
@@ -4,14 +4,18 @@ import {
   SCXML,
   AssignMeta,
   ActionObject,
-  InvokeActionObject
+  InvokeActionObject,
+  MachineContext
 } from './types';
 import { State } from '.';
 import { isFunction, keys } from './utils';
 
 import * as capturedState from './capturedState';
 
-export function updateContext<TContext, TEvent extends EventObject>(
+export function updateContext<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+>(
   context: TContext,
   _event: SCXML.Event<TEvent>,
   assignActions: Array<AssignAction<TContext, TEvent>>,

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -14,7 +14,8 @@ import {
   SingleOrArray,
   BehaviorCreator,
   InvokeSourceDefinition,
-  Observer
+  Observer,
+  MachineContext
 } from './types';
 import { STATE_DELIMITER, TARGETLESS_KEY } from './constants';
 import { IS_PRODUCTION } from './environment';
@@ -236,7 +237,10 @@ export function toArray<T>(value: T[] | T | undefined): T[] {
   return toArrayStrict(value);
 }
 
-export function mapContext<TContext, TEvent extends EventObject>(
+export function mapContext<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+>(
   mapper: Mapper<TContext, TEvent, any> | PropertyMapper<TContext, TEvent, any>,
   context: TContext,
   _event: SCXML.Event<TEvent>
@@ -389,7 +393,10 @@ export function toSCXMLEvent<TEvent extends EventObject>(
   };
 }
 
-export function toTransitionConfigArray<TContext, TEvent extends EventObject>(
+export function toTransitionConfigArray<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+>(
   event: TEvent['type'] | NullEvent['type'] | '*',
   configLike: SingleOrArray<
     | TransitionConfig<TContext, TEvent>
@@ -419,7 +426,10 @@ export function toTransitionConfigArray<TContext, TEvent extends EventObject>(
   return transitions;
 }
 
-export function normalizeTarget<TContext, TEvent extends EventObject>(
+export function normalizeTarget<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+>(
   target: SingleOrArray<string | StateNode<TContext, TEvent>> | undefined
 ): Array<string | StateNode<TContext, TEvent>> | undefined {
   if (target === undefined || target === TARGETLESS_KEY) {
@@ -455,7 +465,10 @@ export function reportUnhandledExceptionOnInvocation(
   }
 }
 
-export function toInvokeConfig<TContext, TEvent extends EventObject>(
+export function toInvokeConfig<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+>(
   invocable:
     | InvokeConfig<TContext, TEvent>
     | string

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -1003,7 +1003,7 @@ describe('purely defined actions', () => {
 
 describe('forwardTo()', () => {
   it('should forward an event to a service', (done) => {
-    const child = createMachine<void, { type: 'EVENT'; value: number }>({
+    const child = createMachine<undefined, { type: 'EVENT'; value: number }>({
       id: 'child',
       initial: 'active',
       states: {
@@ -1048,7 +1048,7 @@ describe('forwardTo()', () => {
   });
 
   it('should forward an event to a service (dynamic)', (done) => {
-    const child = createMachine<void, { type: 'EVENT'; value: number }>({
+    const child = createMachine<undefined, { type: 'EVENT'; value: number }>({
       id: 'child',
       initial: 'active',
       states: {

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -1003,7 +1003,7 @@ describe('purely defined actions', () => {
 
 describe('forwardTo()', () => {
   it('should forward an event to a service', (done) => {
-    const child = createMachine<undefined, { type: 'EVENT'; value: number }>({
+    const child = createMachine<any, { type: 'EVENT'; value: number }>({
       id: 'child',
       initial: 'active',
       states: {
@@ -1019,7 +1019,7 @@ describe('forwardTo()', () => {
     });
 
     const parent = createMachine<
-      undefined,
+      any,
       { type: 'EVENT'; value: number } | { type: 'SUCCESS' }
     >({
       id: 'parent',
@@ -1048,7 +1048,7 @@ describe('forwardTo()', () => {
   });
 
   it('should forward an event to a service (dynamic)', (done) => {
-    const child = createMachine<undefined, { type: 'EVENT'; value: number }>({
+    const child = createMachine<any, { type: 'EVENT'; value: number }>({
       id: 'child',
       initial: 'active',
       states: {

--- a/packages/core/test/activities.test.ts
+++ b/packages/core/test/activities.test.ts
@@ -39,7 +39,7 @@ const lightMachine = createMachine({
 
 describe('activities with guarded transitions', () => {
   it('should activate even if there are subsequent automatic, but blocked transitions', (done) => {
-    const machine = createMachine<undefined, any>(
+    const machine = createMachine(
       {
         initial: 'A',
         states: {

--- a/packages/core/test/invoke.test.ts
+++ b/packages/core/test/invoke.test.ts
@@ -492,7 +492,7 @@ describe('invoke', () => {
 
   it('should start services (machine as invoke config)', (done) => {
     const machineInvokeMachine = createMachine<
-      void,
+      undefined,
       { type: 'SUCCESS'; data: number }
     >({
       id: 'machine-invoke',
@@ -532,7 +532,7 @@ describe('invoke', () => {
 
   it('should start deeply nested service (machine as invoke config)', (done) => {
     const machineInvokeMachine = createMachine<
-      void,
+      undefined,
       { type: 'SUCCESS'; data: number }
     >({
       id: 'parent',

--- a/packages/core/test/invoke.test.ts
+++ b/packages/core/test/invoke.test.ts
@@ -492,7 +492,7 @@ describe('invoke', () => {
 
   it('should start services (machine as invoke config)', (done) => {
     const machineInvokeMachine = createMachine<
-      undefined,
+      any,
       { type: 'SUCCESS'; data: number }
     >({
       id: 'machine-invoke',
@@ -532,7 +532,7 @@ describe('invoke', () => {
 
   it('should start deeply nested service (machine as invoke config)', (done) => {
     const machineInvokeMachine = createMachine<
-      undefined,
+      any,
       { type: 'SUCCESS'; data: number }
     >({
       id: 'parent',
@@ -2079,7 +2079,7 @@ describe('invoke', () => {
         }
       });
 
-      const machine = createMachine<undefined, UpdateObject>({
+      const machine = createMachine<any, UpdateObject>({
         initial: 'pending',
         states: {
           pending: {

--- a/packages/core/test/machine.test.ts
+++ b/packages/core/test/machine.test.ts
@@ -18,7 +18,7 @@ const pedestrianStates = {
   }
 };
 
-const lightMachine = createMachine<undefined, any>({
+const lightMachine = createMachine({
   key: 'light',
   initial: 'green',
   states: {
@@ -202,6 +202,12 @@ describe('machine', () => {
         });
       }).toThrow();
     });
+
+    it('machines defined without context should have a default empty object for context', () => {
+      const machine = createMachine({});
+
+      expect(machine.initialState.context).toEqual({});
+    });
   });
 
   describe('machine.withContext', () => {
@@ -227,7 +233,7 @@ describe('machine', () => {
       });
     });
 
-    it('should not override undefined context', () => {
+    it('should override undefined context', () => {
       const fooBarMachine = createMachine({
         initial: 'active',
         states: {
@@ -239,7 +245,7 @@ describe('machine', () => {
         bar: 42
       });
 
-      expect(changedBarMachine.initialState.context).toBeUndefined();
+      expect(changedBarMachine.initialState.context).toEqual({ bar: 42 });
     });
   });
 

--- a/packages/core/test/scxml.test.ts
+++ b/packages/core/test/scxml.test.ts
@@ -427,6 +427,7 @@ async function runTestToCompletion(
 describe('scxml', () => {
   const onlyTests: string[] = [
     // e.g., 'test399.txml'
+    // 'test286.txml'
   ];
   const testGroupKeys = Object.keys(testGroups);
 

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -1,5 +1,6 @@
 import { assign, createMachine, interpret } from '../src/index';
 import { raise } from '../src/actions';
+import { createModel } from '../src/model';
 
 function noop(_x) {
   return;
@@ -295,5 +296,19 @@ describe('Typestates', () => {
       ? startedService.state.context
       : { result: none, error: 'oops' };
     expect(failed).toEqual({ result: none, error: 'oops' });
+  });
+});
+
+describe('types', () => {
+  it('defined context in createMachine() should be an object', () => {
+    createMachine({
+      // @ts-expect-error
+      context: 'string'
+    });
+  });
+
+  it('defined context passed to createModel() should be an object', () => {
+    // @ts-expect-error
+    createModel('string');
   });
 });

--- a/packages/core/test/utils.ts
+++ b/packages/core/test/utils.ts
@@ -1,8 +1,9 @@
 import { State } from '../src/index';
 import { matchesState } from '../src';
 import { StateMachine } from '../src/StateMachine';
+import { MachineContext } from '../src/types';
 
-export function testMultiTransition<TContext>(
+export function testMultiTransition<TContext extends MachineContext>(
   machine: StateMachine<TContext>,
   fromState: string,
   eventTypes: string

--- a/packages/xstate-analytics/test/analytics.test.ts
+++ b/packages/xstate-analytics/test/analytics.test.ts
@@ -85,25 +85,25 @@ describe('@xstate/analytics', () => {
               "count": 1,
               "currentWeight": 1,
               "relativeWeight": 1,
-              "state": "{\\"value\\":\\"green\\"}",
+              "state": "{\\"value\\":\\"green\\",\\"context\\":{}}",
               "weight": 0.3333333333333333,
             },
           },
-          "{\\"value\\":\\"green\\"}": Object {
+          "{\\"value\\":\\"green\\",\\"context\\":{}}": Object {
             "{\\"type\\":\\"TIMER\\"}": Object {
               "count": 1,
               "currentWeight": 1,
               "relativeWeight": 1,
-              "state": "{\\"value\\":\\"yellow\\"}",
+              "state": "{\\"value\\":\\"yellow\\",\\"context\\":{}}",
               "weight": 0.3333333333333333,
             },
           },
-          "{\\"value\\":\\"yellow\\"}": Object {
+          "{\\"value\\":\\"yellow\\",\\"context\\":{}}": Object {
             "{\\"type\\":\\"TIMER\\"}": Object {
               "count": 1,
               "currentWeight": 1,
               "relativeWeight": 1,
-              "state": "{\\"value\\":{\\"red\\":\\"walk\\"}}",
+              "state": "{\\"value\\":{\\"red\\":\\"walk\\"},\\"context\\":{}}",
               "weight": 0.3333333333333333,
             },
           },

--- a/packages/xstate-graph/src/graph.ts
+++ b/packages/xstate-graph/src/graph.ts
@@ -62,7 +62,9 @@ export function getChildren(stateNode: StateNode): StateNode[] {
   return children;
 }
 
-export function serializeState<TContext>(state: State<TContext, any>): string {
+export function serializeState<TContext extends MachineContext>(
+  state: State<TContext, any>
+): string {
   const { value, context } = state;
   return context === undefined
     ? JSON.stringify(value)
@@ -88,7 +90,10 @@ const defaultValueAdjMapOptions: Required<ValueAdjMapOptions<any, any>> = {
   eventSerializer: serializeEvent
 };
 
-function getValueAdjMapOptions<TContext, TEvent extends EventObject>(
+function getValueAdjMapOptions<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+>(
   options?: ValueAdjMapOptions<TContext, TEvent>
 ): Required<ValueAdjMapOptions<TContext, TEvent>> {
   return {
@@ -100,7 +105,7 @@ function getValueAdjMapOptions<TContext, TEvent extends EventObject>(
 }
 
 export function getAdjacencyMap<
-  TContext = MachineContext,
+  TContext extends MachineContext,
   TEvent extends EventObject = AnyEventObject
 >(
   node: MachineNode<TContext, TEvent>,
@@ -170,7 +175,7 @@ export function getAdjacencyMap<
 }
 
 export function getShortestPaths<
-  TContext = MachineContext,
+  TContext extends MachineContext,
   TEvent extends EventObject = EventObject
 >(
   machine: MachineNode<TContext, TEvent>,
@@ -259,7 +264,7 @@ export function getShortestPaths<
 }
 
 export function getSimplePaths<
-  TContext = MachineContext,
+  TContext extends MachineContext,
   TEvent extends EventObject = EventObject
 >(
   machine: MachineNode<TContext, TEvent>,
@@ -332,7 +337,7 @@ export function getSimplePaths<
 }
 
 export function getSimplePathsAsArray<
-  TContext = MachineContext,
+  TContext extends MachineContext,
   TEvent extends EventObject = EventObject
 >(
   machine: MachineNode<TContext, TEvent>,

--- a/packages/xstate-graph/src/graph.ts
+++ b/packages/xstate-graph/src/graph.ts
@@ -66,7 +66,7 @@ export function serializeState<TContext extends MachineContext>(
   state: State<TContext, any>
 ): string {
   const { value, context } = state;
-  return context === undefined
+  return context === undefined || Object.keys(context).length === 0
     ? JSON.stringify(value)
     : JSON.stringify(value) + ' | ' + JSON.stringify(context);
 }

--- a/packages/xstate-graph/src/graph.ts
+++ b/packages/xstate-graph/src/graph.ts
@@ -1,7 +1,7 @@
 import {
   StateNode,
   State,
-  DefaultContext,
+  MachineContext,
   Event,
   EventObject,
   AnyEventObject,
@@ -100,7 +100,7 @@ function getValueAdjMapOptions<TContext, TEvent extends EventObject>(
 }
 
 export function getAdjacencyMap<
-  TContext = DefaultContext,
+  TContext = MachineContext,
   TEvent extends EventObject = AnyEventObject
 >(
   node: MachineNode<TContext, TEvent>,
@@ -170,7 +170,7 @@ export function getAdjacencyMap<
 }
 
 export function getShortestPaths<
-  TContext = DefaultContext,
+  TContext = MachineContext,
   TEvent extends EventObject = EventObject
 >(
   machine: MachineNode<TContext, TEvent>,
@@ -259,7 +259,7 @@ export function getShortestPaths<
 }
 
 export function getSimplePaths<
-  TContext = DefaultContext,
+  TContext = MachineContext,
   TEvent extends EventObject = EventObject
 >(
   machine: MachineNode<TContext, TEvent>,
@@ -332,7 +332,7 @@ export function getSimplePaths<
 }
 
 export function getSimplePathsAsArray<
-  TContext = DefaultContext,
+  TContext = MachineContext,
   TEvent extends EventObject = EventObject
 >(
   machine: MachineNode<TContext, TEvent>,

--- a/packages/xstate-graph/src/graph.ts
+++ b/packages/xstate-graph/src/graph.ts
@@ -66,7 +66,7 @@ export function serializeState<TContext extends MachineContext>(
   state: State<TContext, any>
 ): string {
   const { value, context } = state;
-  return context === undefined || Object.keys(context).length === 0
+  return Object.keys(context).length === 0
     ? JSON.stringify(value)
     : JSON.stringify(value) + ' | ' + JSON.stringify(context);
 }

--- a/packages/xstate-graph/src/types.ts
+++ b/packages/xstate-graph/src/types.ts
@@ -3,7 +3,8 @@ import {
   EventObject,
   StateValue,
   StateNode,
-  TransitionDefinition
+  TransitionDefinition,
+  MachineContext
 } from 'xstate';
 
 export interface TransitionMap {
@@ -55,7 +56,10 @@ export type DirectedGraphNode = JSONSerializable<
   }
 >;
 
-export interface AdjacencyMap<TContext, TEvent extends EventObject> {
+export interface AdjacencyMap<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> {
   [stateId: string]: Record<
     string,
     {
@@ -65,7 +69,10 @@ export interface AdjacencyMap<TContext, TEvent extends EventObject> {
   >;
 }
 
-export interface StatePaths<TContext, TEvent extends EventObject> {
+export interface StatePaths<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> {
   /**
    * The target state.
    */
@@ -76,7 +83,10 @@ export interface StatePaths<TContext, TEvent extends EventObject> {
   paths: Array<StatePath<TContext, TEvent>>;
 }
 
-export interface StatePath<TContext, TEvent extends EventObject> {
+export interface StatePath<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> {
   /**
    * The ending state of the path.
    */
@@ -91,10 +101,16 @@ export interface StatePath<TContext, TEvent extends EventObject> {
   weight: number;
 }
 
-export interface StatePathsMap<TContext, TEvent extends EventObject> {
+export interface StatePathsMap<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> {
   [key: string]: StatePaths<TContext, TEvent>;
 }
-export interface Segment<TContext, TEvent extends EventObject> {
+export interface Segment<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> {
   /**
    * The current state before taking the event.
    */
@@ -105,16 +121,20 @@ export interface Segment<TContext, TEvent extends EventObject> {
   event: TEvent;
 }
 
-export type Segments<TContext, TEvent extends EventObject> = Array<
-  Segment<TContext, TEvent>
->;
+export type Segments<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> = Array<Segment<TContext, TEvent>>;
 
 export type ExtractEvent<
   TEvent extends EventObject,
   TType extends TEvent['type']
 > = TEvent extends { type: TType } ? TEvent : never;
 
-export interface ValueAdjMapOptions<TContext, TEvent extends EventObject> {
+export interface ValueAdjMapOptions<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> {
   events?: {
     [K in TEvent['type']]?:
       | Array<ExtractEvent<TEvent, K>>

--- a/packages/xstate-graph/test/__snapshots__/graph.test.ts.snap
+++ b/packages/xstate-graph/test/__snapshots__/graph.test.ts.snap
@@ -394,7 +394,7 @@ Object {
           "actions": Array [],
           "changed": true,
           "children": Object {},
-          "context": undefined,
+          "context": Object {},
           "event": Object {
             "type": "1",
           },
@@ -412,7 +412,7 @@ Object {
             "actions": Array [],
             "changed": true,
             "children": Object {},
-            "context": undefined,
+            "context": Object {},
             "event": Object {
               "type": "2",
             },
@@ -453,7 +453,7 @@ Object {
       "actions": Array [],
       "changed": true,
       "children": Object {},
-      "context": undefined,
+      "context": Object {},
       "event": Object {
         "type": "1",
       },
@@ -471,7 +471,7 @@ Object {
         "actions": Array [],
         "changed": true,
         "children": Object {},
-        "context": undefined,
+        "context": Object {},
         "event": Object {
           "type": "2",
         },
@@ -518,7 +518,7 @@ Object {
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "1",
               },
@@ -536,7 +536,7 @@ Object {
                 "actions": Array [],
                 "changed": true,
                 "children": Object {},
-                "context": undefined,
+                "context": Object {},
                 "event": Object {
                   "type": "2",
                 },
@@ -576,7 +576,7 @@ Object {
           "actions": Array [],
           "changed": true,
           "children": Object {},
-          "context": undefined,
+          "context": Object {},
           "event": Object {
             "type": "2",
           },
@@ -607,7 +607,7 @@ Object {
       "actions": Array [],
       "changed": true,
       "children": Object {},
-      "context": undefined,
+      "context": Object {},
       "event": Object {
         "type": "2",
       },
@@ -644,7 +644,7 @@ Object {
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "1",
               },
@@ -662,7 +662,7 @@ Object {
                 "actions": Array [],
                 "changed": true,
                 "children": Object {},
-                "context": undefined,
+                "context": Object {},
                 "event": Object {
                   "type": "2",
                 },
@@ -702,7 +702,7 @@ Object {
           "actions": Array [],
           "changed": true,
           "children": Object {},
-          "context": undefined,
+          "context": Object {},
           "event": Object {
             "type": "3",
           },
@@ -720,7 +720,7 @@ Object {
             "actions": Array [],
             "changed": true,
             "children": Object {},
-            "context": undefined,
+            "context": Object {},
             "event": Object {
               "type": "2",
             },
@@ -761,7 +761,7 @@ Object {
       "actions": Array [],
       "changed": true,
       "children": Object {},
-      "context": undefined,
+      "context": Object {},
       "event": Object {
         "type": "3",
       },
@@ -779,7 +779,7 @@ Object {
         "actions": Array [],
         "changed": true,
         "children": Object {},
-        "context": undefined,
+        "context": Object {},
         "event": Object {
           "type": "2",
         },
@@ -827,7 +827,7 @@ Object {
           "actions": Array [],
           "changed": true,
           "children": Object {},
-          "context": undefined,
+          "context": Object {},
           "event": Object {
             "type": "TIMER",
           },
@@ -845,7 +845,7 @@ Object {
             "actions": Array [],
             "changed": true,
             "children": Object {},
-            "context": undefined,
+            "context": Object {},
             "event": Object {
               "type": "PED_COUNTDOWN",
             },
@@ -882,7 +882,7 @@ Object {
       "actions": Array [],
       "changed": true,
       "children": Object {},
-      "context": undefined,
+      "context": Object {},
       "event": Object {
         "type": "TIMER",
       },
@@ -900,7 +900,7 @@ Object {
         "actions": Array [],
         "changed": true,
         "children": Object {},
-        "context": undefined,
+        "context": Object {},
         "event": Object {
           "type": "PED_COUNTDOWN",
         },
@@ -943,7 +943,7 @@ Object {
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -961,7 +961,7 @@ Object {
                 "actions": Array [],
                 "changed": true,
                 "children": Object {},
-                "context": undefined,
+                "context": Object {},
                 "event": Object {
                   "type": "PED_COUNTDOWN",
                 },
@@ -997,7 +997,7 @@ Object {
           "actions": Array [],
           "changed": true,
           "children": Object {},
-          "context": undefined,
+          "context": Object {},
           "event": Object {
             "type": "TIMER",
           },
@@ -1025,7 +1025,7 @@ Object {
       "actions": Array [],
       "changed": true,
       "children": Object {},
-      "context": undefined,
+      "context": Object {},
       "event": Object {
         "type": "TIMER",
       },
@@ -1059,7 +1059,7 @@ Object {
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -1077,7 +1077,7 @@ Object {
                 "actions": Array [],
                 "changed": true,
                 "children": Object {},
-                "context": undefined,
+                "context": Object {},
                 "event": Object {
                   "type": "PED_COUNTDOWN",
                 },
@@ -1113,7 +1113,7 @@ Object {
           "actions": Array [],
           "changed": true,
           "children": Object {},
-          "context": undefined,
+          "context": Object {},
           "event": Object {
             "type": "POWER_OUTAGE",
           },
@@ -1131,7 +1131,7 @@ Object {
             "actions": Array [],
             "changed": true,
             "children": Object {},
-            "context": undefined,
+            "context": Object {},
             "event": Object {
               "type": "PED_COUNTDOWN",
             },
@@ -1170,7 +1170,7 @@ Object {
       "actions": Array [],
       "changed": true,
       "children": Object {},
-      "context": undefined,
+      "context": Object {},
       "event": Object {
         "type": "POWER_OUTAGE",
       },
@@ -1188,7 +1188,7 @@ Object {
         "actions": Array [],
         "changed": true,
         "children": Object {},
-        "context": undefined,
+        "context": Object {},
         "event": Object {
           "type": "PED_COUNTDOWN",
         },
@@ -1233,7 +1233,7 @@ Object {
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -1251,7 +1251,7 @@ Object {
                 "actions": Array [],
                 "changed": true,
                 "children": Object {},
-                "context": undefined,
+                "context": Object {},
                 "event": Object {
                   "type": "PED_COUNTDOWN",
                 },
@@ -1290,7 +1290,7 @@ Object {
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -1320,7 +1320,7 @@ Object {
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -1357,7 +1357,7 @@ Object {
               ],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "PED_COUNTDOWN",
               },
@@ -1386,7 +1386,7 @@ Object {
           "actions": Array [],
           "changed": true,
           "children": Object {},
-          "context": undefined,
+          "context": Object {},
           "event": Object {
             "type": "PED_COUNTDOWN",
           },
@@ -1416,7 +1416,7 @@ Object {
       "actions": Array [],
       "changed": true,
       "children": Object {},
-      "context": undefined,
+      "context": Object {},
       "event": Object {
         "type": "PED_COUNTDOWN",
       },
@@ -1452,7 +1452,7 @@ Object {
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -1470,7 +1470,7 @@ Object {
                 "actions": Array [],
                 "changed": true,
                 "children": Object {},
-                "context": undefined,
+                "context": Object {},
                 "event": Object {
                   "type": "PED_COUNTDOWN",
                 },
@@ -1509,7 +1509,7 @@ Object {
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -1539,7 +1539,7 @@ Object {
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -1573,7 +1573,7 @@ Object {
           ],
           "changed": true,
           "children": Object {},
-          "context": undefined,
+          "context": Object {},
           "event": Object {
             "type": "PED_COUNTDOWN",
           },
@@ -1608,7 +1608,7 @@ Object {
       ],
       "changed": true,
       "children": Object {},
-      "context": undefined,
+      "context": Object {},
       "event": Object {
         "type": "PED_COUNTDOWN",
       },
@@ -1644,7 +1644,7 @@ Object {
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -1662,7 +1662,7 @@ Object {
                 "actions": Array [],
                 "changed": true,
                 "children": Object {},
-                "context": undefined,
+                "context": Object {},
                 "event": Object {
                   "type": "PED_COUNTDOWN",
                 },
@@ -1701,7 +1701,7 @@ Object {
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -1728,7 +1728,7 @@ Object {
           "actions": Array [],
           "changed": true,
           "children": Object {},
-          "context": undefined,
+          "context": Object {},
           "event": Object {
             "type": "TIMER",
           },
@@ -1758,7 +1758,7 @@ Object {
       "actions": Array [],
       "changed": true,
       "children": Object {},
-      "context": undefined,
+      "context": Object {},
       "event": Object {
         "type": "TIMER",
       },
@@ -1795,7 +1795,7 @@ Object {
           "actions": Array [],
           "changed": undefined,
           "children": Object {},
-          "context": undefined,
+          "context": Object {},
           "event": Object {
             "type": "xstate.init",
           },
@@ -1824,7 +1824,7 @@ Object {
       "actions": Array [],
       "changed": undefined,
       "children": Object {},
-      "context": undefined,
+      "context": Object {},
       "event": Object {
         "type": "xstate.init",
       },
@@ -1859,7 +1859,7 @@ Object {
               "actions": Array [],
               "changed": undefined,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "xstate.init",
               },
@@ -1887,7 +1887,7 @@ Object {
           "actions": Array [],
           "changed": true,
           "children": Object {},
-          "context": undefined,
+          "context": Object {},
           "event": Object {
             "type": "TIMER",
           },
@@ -1915,7 +1915,7 @@ Object {
       "actions": Array [],
       "changed": true,
       "children": Object {},
-      "context": undefined,
+      "context": Object {},
       "event": Object {
         "type": "TIMER",
       },
@@ -1949,7 +1949,7 @@ Object {
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -1967,7 +1967,7 @@ Object {
                 "actions": Array [],
                 "changed": true,
                 "children": Object {},
-                "context": undefined,
+                "context": Object {},
                 "event": Object {
                   "type": "POWER_OUTAGE",
                 },
@@ -2006,7 +2006,7 @@ Object {
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -2036,7 +2036,7 @@ Object {
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -2065,7 +2065,7 @@ Object {
           "actions": Array [],
           "changed": true,
           "children": Object {},
-          "context": undefined,
+          "context": Object {},
           "event": Object {
             "type": "POWER_OUTAGE",
           },
@@ -2100,7 +2100,7 @@ Object {
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -2118,7 +2118,7 @@ Object {
                 "actions": Array [],
                 "changed": true,
                 "children": Object {},
-                "context": undefined,
+                "context": Object {},
                 "event": Object {
                   "type": "POWER_OUTAGE",
                 },
@@ -2157,7 +2157,7 @@ Object {
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -2187,7 +2187,7 @@ Object {
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -2224,7 +2224,7 @@ Object {
               ],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "PED_COUNTDOWN",
               },
@@ -2253,7 +2253,7 @@ Object {
           "actions": Array [],
           "changed": true,
           "children": Object {},
-          "context": undefined,
+          "context": Object {},
           "event": Object {
             "type": "POWER_OUTAGE",
           },
@@ -2276,7 +2276,7 @@ Object {
             ],
             "changed": true,
             "children": Object {},
-            "context": undefined,
+            "context": Object {},
             "event": Object {
               "type": "PED_COUNTDOWN",
             },
@@ -2320,7 +2320,7 @@ Object {
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -2338,7 +2338,7 @@ Object {
                 "actions": Array [],
                 "changed": true,
                 "children": Object {},
-                "context": undefined,
+                "context": Object {},
                 "event": Object {
                   "type": "POWER_OUTAGE",
                 },
@@ -2377,7 +2377,7 @@ Object {
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -2407,7 +2407,7 @@ Object {
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -2444,7 +2444,7 @@ Object {
               ],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "PED_COUNTDOWN",
               },
@@ -2476,7 +2476,7 @@ Object {
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "PED_COUNTDOWN",
               },
@@ -2505,7 +2505,7 @@ Object {
           "actions": Array [],
           "changed": true,
           "children": Object {},
-          "context": undefined,
+          "context": Object {},
           "event": Object {
             "type": "POWER_OUTAGE",
           },
@@ -2523,7 +2523,7 @@ Object {
             "actions": Array [],
             "changed": true,
             "children": Object {},
-            "context": undefined,
+            "context": Object {},
             "event": Object {
               "type": "PED_COUNTDOWN",
             },
@@ -2567,7 +2567,7 @@ Object {
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -2585,7 +2585,7 @@ Object {
                 "actions": Array [],
                 "changed": true,
                 "children": Object {},
-                "context": undefined,
+                "context": Object {},
                 "event": Object {
                   "type": "POWER_OUTAGE",
                 },
@@ -2624,7 +2624,7 @@ Object {
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -2651,7 +2651,7 @@ Object {
           "actions": Array [],
           "changed": true,
           "children": Object {},
-          "context": undefined,
+          "context": Object {},
           "event": Object {
             "type": "POWER_OUTAGE",
           },
@@ -2669,7 +2669,7 @@ Object {
             "actions": Array [],
             "changed": true,
             "children": Object {},
-            "context": undefined,
+            "context": Object {},
             "event": Object {
               "type": "TIMER",
             },
@@ -2711,7 +2711,7 @@ Object {
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -2729,7 +2729,7 @@ Object {
                 "actions": Array [],
                 "changed": true,
                 "children": Object {},
-                "context": undefined,
+                "context": Object {},
                 "event": Object {
                   "type": "PED_COUNTDOWN",
                 },
@@ -2765,7 +2765,7 @@ Object {
           "actions": Array [],
           "changed": true,
           "children": Object {},
-          "context": undefined,
+          "context": Object {},
           "event": Object {
             "type": "POWER_OUTAGE",
           },
@@ -2783,7 +2783,7 @@ Object {
             "actions": Array [],
             "changed": undefined,
             "children": Object {},
-            "context": undefined,
+            "context": Object {},
             "event": Object {
               "type": "xstate.init",
             },
@@ -2820,7 +2820,7 @@ Object {
       "actions": Array [],
       "changed": true,
       "children": Object {},
-      "context": undefined,
+      "context": Object {},
       "event": Object {
         "type": "POWER_OUTAGE",
       },
@@ -2856,7 +2856,7 @@ Object {
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -2874,7 +2874,7 @@ Object {
                 "actions": Array [],
                 "changed": true,
                 "children": Object {},
-                "context": undefined,
+                "context": Object {},
                 "event": Object {
                   "type": "POWER_OUTAGE",
                 },
@@ -2913,7 +2913,7 @@ Object {
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -2943,7 +2943,7 @@ Object {
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -2980,7 +2980,7 @@ Object {
               ],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "PED_COUNTDOWN",
               },
@@ -3009,7 +3009,7 @@ Object {
           "actions": Array [],
           "changed": true,
           "children": Object {},
-          "context": undefined,
+          "context": Object {},
           "event": Object {
             "type": "PED_COUNTDOWN",
           },
@@ -3039,7 +3039,7 @@ Object {
       "actions": Array [],
       "changed": true,
       "children": Object {},
-      "context": undefined,
+      "context": Object {},
       "event": Object {
         "type": "PED_COUNTDOWN",
       },
@@ -3075,7 +3075,7 @@ Object {
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -3093,7 +3093,7 @@ Object {
                 "actions": Array [],
                 "changed": true,
                 "children": Object {},
-                "context": undefined,
+                "context": Object {},
                 "event": Object {
                   "type": "PED_COUNTDOWN",
                 },
@@ -3132,7 +3132,7 @@ Object {
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -3162,7 +3162,7 @@ Object {
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -3196,7 +3196,7 @@ Object {
           ],
           "changed": true,
           "children": Object {},
-          "context": undefined,
+          "context": Object {},
           "event": Object {
             "type": "PED_COUNTDOWN",
           },
@@ -3231,7 +3231,7 @@ Object {
       ],
       "changed": true,
       "children": Object {},
-      "context": undefined,
+      "context": Object {},
       "event": Object {
         "type": "PED_COUNTDOWN",
       },
@@ -3267,7 +3267,7 @@ Object {
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -3285,7 +3285,7 @@ Object {
                 "actions": Array [],
                 "changed": true,
                 "children": Object {},
-                "context": undefined,
+                "context": Object {},
                 "event": Object {
                   "type": "POWER_OUTAGE",
                 },
@@ -3324,7 +3324,7 @@ Object {
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -3351,7 +3351,7 @@ Object {
           "actions": Array [],
           "changed": true,
           "children": Object {},
-          "context": undefined,
+          "context": Object {},
           "event": Object {
             "type": "TIMER",
           },
@@ -3381,7 +3381,7 @@ Object {
       "actions": Array [],
       "changed": true,
       "children": Object {},
-      "context": undefined,
+      "context": Object {},
       "event": Object {
         "type": "TIMER",
       },
@@ -3418,7 +3418,7 @@ Object {
           "actions": Array [],
           "changed": undefined,
           "children": Object {},
-          "context": undefined,
+          "context": Object {},
           "event": Object {
             "type": "xstate.init",
           },
@@ -3450,7 +3450,7 @@ Object {
       "actions": Array [],
       "changed": undefined,
       "children": Object {},
-      "context": undefined,
+      "context": Object {},
       "event": Object {
         "type": "xstate.init",
       },
@@ -3488,7 +3488,7 @@ Object {
               "actions": Array [],
               "changed": undefined,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "xstate.init",
               },
@@ -3519,7 +3519,7 @@ Object {
           "actions": Array [],
           "changed": true,
           "children": Object {},
-          "context": undefined,
+          "context": Object {},
           "event": Object {
             "type": "2",
           },
@@ -3550,7 +3550,7 @@ Object {
       "actions": Array [],
       "changed": true,
       "children": Object {},
-      "context": undefined,
+      "context": Object {},
       "event": Object {
         "type": "2",
       },
@@ -3587,7 +3587,7 @@ Object {
               "actions": Array [],
               "changed": undefined,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "xstate.init",
               },
@@ -3621,7 +3621,7 @@ Object {
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "2",
               },
@@ -3651,7 +3651,7 @@ Object {
           "actions": Array [],
           "changed": true,
           "children": Object {},
-          "context": undefined,
+          "context": Object {},
           "event": Object {
             "type": "3",
           },
@@ -3669,7 +3669,7 @@ Object {
             "actions": Array [],
             "changed": true,
             "children": Object {},
-            "context": undefined,
+            "context": Object {},
             "event": Object {
               "type": "2",
             },
@@ -3715,7 +3715,7 @@ Object {
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "1",
               },
@@ -3733,7 +3733,7 @@ Object {
                 "actions": Array [],
                 "changed": true,
                 "children": Object {},
-                "context": undefined,
+                "context": Object {},
                 "event": Object {
                   "type": "2",
                 },
@@ -3773,7 +3773,7 @@ Object {
           "actions": Array [],
           "changed": true,
           "children": Object {},
-          "context": undefined,
+          "context": Object {},
           "event": Object {
             "type": "3",
           },
@@ -3791,7 +3791,7 @@ Object {
             "actions": Array [],
             "changed": undefined,
             "children": Object {},
-            "context": undefined,
+            "context": Object {},
             "event": Object {
               "type": "xstate.init",
             },
@@ -3832,7 +3832,7 @@ Object {
       "actions": Array [],
       "changed": true,
       "children": Object {},
-      "context": undefined,
+      "context": Object {},
       "event": Object {
         "type": "3",
       },
@@ -3850,7 +3850,7 @@ Object {
         "actions": Array [],
         "changed": true,
         "children": Object {},
-        "context": undefined,
+        "context": Object {},
         "event": Object {
           "type": "2",
         },
@@ -3898,7 +3898,7 @@ Object {
           "actions": Array [],
           "changed": undefined,
           "children": Object {},
-          "context": undefined,
+          "context": Object {},
           "event": Object {
             "type": "xstate.init",
           },
@@ -3927,7 +3927,7 @@ Object {
       "actions": Array [],
       "changed": undefined,
       "children": Object {},
-      "context": undefined,
+      "context": Object {},
       "event": Object {
         "type": "xstate.init",
       },
@@ -3962,7 +3962,7 @@ Object {
               "actions": Array [],
               "changed": undefined,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "xstate.init",
               },
@@ -3990,7 +3990,7 @@ Object {
           "actions": Array [],
           "changed": true,
           "children": Object {},
-          "context": undefined,
+          "context": Object {},
           "event": Object {
             "type": "FOO",
           },
@@ -4023,7 +4023,7 @@ Object {
               "actions": Array [],
               "changed": undefined,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "xstate.init",
               },
@@ -4051,7 +4051,7 @@ Object {
           "actions": Array [],
           "changed": true,
           "children": Object {},
-          "context": undefined,
+          "context": Object {},
           "event": Object {
             "type": "BAR",
           },
@@ -4069,7 +4069,7 @@ Object {
             "actions": Array [],
             "changed": undefined,
             "children": Object {},
-            "context": undefined,
+            "context": Object {},
             "event": Object {
               "type": "xstate.init",
             },
@@ -4104,7 +4104,7 @@ Object {
       "actions": Array [],
       "changed": true,
       "children": Object {},
-      "context": undefined,
+      "context": Object {},
       "event": Object {
         "type": "FOO",
       },
@@ -4751,7 +4751,7 @@ Array [
           "actions": Array [],
           "changed": undefined,
           "children": Object {},
-          "context": undefined,
+          "context": Object {},
           "event": Object {
             "type": "xstate.init",
           },
@@ -4780,7 +4780,7 @@ Array [
       "actions": Array [],
       "changed": undefined,
       "children": Object {},
-      "context": undefined,
+      "context": Object {},
       "event": Object {
         "type": "xstate.init",
       },
@@ -4815,7 +4815,7 @@ Array [
               "actions": Array [],
               "changed": undefined,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "xstate.init",
               },
@@ -4843,7 +4843,7 @@ Array [
           "actions": Array [],
           "changed": true,
           "children": Object {},
-          "context": undefined,
+          "context": Object {},
           "event": Object {
             "type": "TIMER",
           },
@@ -4871,7 +4871,7 @@ Array [
       "actions": Array [],
       "changed": true,
       "children": Object {},
-      "context": undefined,
+      "context": Object {},
       "event": Object {
         "type": "TIMER",
       },
@@ -4905,7 +4905,7 @@ Array [
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -4923,7 +4923,7 @@ Array [
                 "actions": Array [],
                 "changed": true,
                 "children": Object {},
-                "context": undefined,
+                "context": Object {},
                 "event": Object {
                   "type": "POWER_OUTAGE",
                 },
@@ -4962,7 +4962,7 @@ Array [
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -4989,7 +4989,7 @@ Array [
           "actions": Array [],
           "changed": true,
           "children": Object {},
-          "context": undefined,
+          "context": Object {},
           "event": Object {
             "type": "TIMER",
           },
@@ -5019,7 +5019,7 @@ Array [
       "actions": Array [],
       "changed": true,
       "children": Object {},
-      "context": undefined,
+      "context": Object {},
       "event": Object {
         "type": "TIMER",
       },
@@ -5055,7 +5055,7 @@ Array [
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -5073,7 +5073,7 @@ Array [
                 "actions": Array [],
                 "changed": true,
                 "children": Object {},
-                "context": undefined,
+                "context": Object {},
                 "event": Object {
                   "type": "POWER_OUTAGE",
                 },
@@ -5112,7 +5112,7 @@ Array [
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -5142,7 +5142,7 @@ Array [
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -5171,7 +5171,7 @@ Array [
           "actions": Array [],
           "changed": true,
           "children": Object {},
-          "context": undefined,
+          "context": Object {},
           "event": Object {
             "type": "POWER_OUTAGE",
           },
@@ -5206,7 +5206,7 @@ Array [
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -5224,7 +5224,7 @@ Array [
                 "actions": Array [],
                 "changed": true,
                 "children": Object {},
-                "context": undefined,
+                "context": Object {},
                 "event": Object {
                   "type": "POWER_OUTAGE",
                 },
@@ -5263,7 +5263,7 @@ Array [
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -5293,7 +5293,7 @@ Array [
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -5330,7 +5330,7 @@ Array [
               ],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "PED_COUNTDOWN",
               },
@@ -5359,7 +5359,7 @@ Array [
           "actions": Array [],
           "changed": true,
           "children": Object {},
-          "context": undefined,
+          "context": Object {},
           "event": Object {
             "type": "POWER_OUTAGE",
           },
@@ -5382,7 +5382,7 @@ Array [
             ],
             "changed": true,
             "children": Object {},
-            "context": undefined,
+            "context": Object {},
             "event": Object {
               "type": "PED_COUNTDOWN",
             },
@@ -5426,7 +5426,7 @@ Array [
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -5444,7 +5444,7 @@ Array [
                 "actions": Array [],
                 "changed": true,
                 "children": Object {},
-                "context": undefined,
+                "context": Object {},
                 "event": Object {
                   "type": "POWER_OUTAGE",
                 },
@@ -5483,7 +5483,7 @@ Array [
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -5513,7 +5513,7 @@ Array [
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -5550,7 +5550,7 @@ Array [
               ],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "PED_COUNTDOWN",
               },
@@ -5582,7 +5582,7 @@ Array [
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "PED_COUNTDOWN",
               },
@@ -5611,7 +5611,7 @@ Array [
           "actions": Array [],
           "changed": true,
           "children": Object {},
-          "context": undefined,
+          "context": Object {},
           "event": Object {
             "type": "POWER_OUTAGE",
           },
@@ -5629,7 +5629,7 @@ Array [
             "actions": Array [],
             "changed": true,
             "children": Object {},
-            "context": undefined,
+            "context": Object {},
             "event": Object {
               "type": "PED_COUNTDOWN",
             },
@@ -5673,7 +5673,7 @@ Array [
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -5691,7 +5691,7 @@ Array [
                 "actions": Array [],
                 "changed": true,
                 "children": Object {},
-                "context": undefined,
+                "context": Object {},
                 "event": Object {
                   "type": "POWER_OUTAGE",
                 },
@@ -5730,7 +5730,7 @@ Array [
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -5757,7 +5757,7 @@ Array [
           "actions": Array [],
           "changed": true,
           "children": Object {},
-          "context": undefined,
+          "context": Object {},
           "event": Object {
             "type": "POWER_OUTAGE",
           },
@@ -5775,7 +5775,7 @@ Array [
             "actions": Array [],
             "changed": true,
             "children": Object {},
-            "context": undefined,
+            "context": Object {},
             "event": Object {
               "type": "TIMER",
             },
@@ -5817,7 +5817,7 @@ Array [
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -5835,7 +5835,7 @@ Array [
                 "actions": Array [],
                 "changed": true,
                 "children": Object {},
-                "context": undefined,
+                "context": Object {},
                 "event": Object {
                   "type": "PED_COUNTDOWN",
                 },
@@ -5871,7 +5871,7 @@ Array [
           "actions": Array [],
           "changed": true,
           "children": Object {},
-          "context": undefined,
+          "context": Object {},
           "event": Object {
             "type": "POWER_OUTAGE",
           },
@@ -5889,7 +5889,7 @@ Array [
             "actions": Array [],
             "changed": undefined,
             "children": Object {},
-            "context": undefined,
+            "context": Object {},
             "event": Object {
               "type": "xstate.init",
             },
@@ -5926,7 +5926,7 @@ Array [
       "actions": Array [],
       "changed": true,
       "children": Object {},
-      "context": undefined,
+      "context": Object {},
       "event": Object {
         "type": "POWER_OUTAGE",
       },
@@ -5962,7 +5962,7 @@ Array [
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -5980,7 +5980,7 @@ Array [
                 "actions": Array [],
                 "changed": true,
                 "children": Object {},
-                "context": undefined,
+                "context": Object {},
                 "event": Object {
                   "type": "PED_COUNTDOWN",
                 },
@@ -6019,7 +6019,7 @@ Array [
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -6049,7 +6049,7 @@ Array [
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -6083,7 +6083,7 @@ Array [
           ],
           "changed": true,
           "children": Object {},
-          "context": undefined,
+          "context": Object {},
           "event": Object {
             "type": "PED_COUNTDOWN",
           },
@@ -6118,7 +6118,7 @@ Array [
       ],
       "changed": true,
       "children": Object {},
-      "context": undefined,
+      "context": Object {},
       "event": Object {
         "type": "PED_COUNTDOWN",
       },
@@ -6154,7 +6154,7 @@ Array [
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -6172,7 +6172,7 @@ Array [
                 "actions": Array [],
                 "changed": true,
                 "children": Object {},
-                "context": undefined,
+                "context": Object {},
                 "event": Object {
                   "type": "POWER_OUTAGE",
                 },
@@ -6211,7 +6211,7 @@ Array [
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -6241,7 +6241,7 @@ Array [
               "actions": Array [],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "TIMER",
               },
@@ -6278,7 +6278,7 @@ Array [
               ],
               "changed": true,
               "children": Object {},
-              "context": undefined,
+              "context": Object {},
               "event": Object {
                 "type": "PED_COUNTDOWN",
               },
@@ -6307,7 +6307,7 @@ Array [
           "actions": Array [],
           "changed": true,
           "children": Object {},
-          "context": undefined,
+          "context": Object {},
           "event": Object {
             "type": "PED_COUNTDOWN",
           },
@@ -6337,7 +6337,7 @@ Array [
       "actions": Array [],
       "changed": true,
       "children": Object {},
-      "context": undefined,
+      "context": Object {},
       "event": Object {
         "type": "PED_COUNTDOWN",
       },

--- a/packages/xstate-immer/src/index.ts
+++ b/packages/xstate-immer/src/index.ts
@@ -3,24 +3,31 @@ import {
   ActionObject,
   AssignAction,
   assign as xstateAssign,
-  AssignMeta
+  AssignMeta,
+  MachineContext
 } from 'xstate';
 import { produce, Draft } from 'immer';
 
-export type ImmerAssigner<TContext, TEvent extends EventObject> = (
+export type ImmerAssigner<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> = (
   context: Draft<TContext>,
   event: TEvent,
   meta: AssignMeta<TContext, TEvent>
 ) => void;
 
-export interface ImmerAssignAction<TContext, TEvent extends EventObject>
-  extends ActionObject<TContext, TEvent> {
+export interface ImmerAssignAction<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> extends ActionObject<TContext, TEvent> {
   assignment: ImmerAssigner<TContext, TEvent>;
 }
 
-function immerAssign<TContext, TEvent extends EventObject = EventObject>(
-  recipe: ImmerAssigner<TContext, TEvent>
-): AssignAction<TContext, TEvent> {
+function immerAssign<
+  TContext extends MachineContext,
+  TEvent extends EventObject = EventObject
+>(recipe: ImmerAssigner<TContext, TEvent>): AssignAction<TContext, TEvent> {
   return xstateAssign((context, event, meta) => {
     return produce(context, (draft) => void recipe(draft, event, meta));
   });
@@ -36,13 +43,19 @@ export interface ImmerUpdateEvent<
   input: TInput;
 }
 
-export interface ImmerUpdater<TContext, TEvent extends ImmerUpdateEvent> {
+export interface ImmerUpdater<
+  TContext extends MachineContext,
+  TEvent extends ImmerUpdateEvent
+> {
   update: (input: TEvent['input']) => TEvent;
   action: AssignAction<TContext, TEvent>;
   type: TEvent['type'];
 }
 
-export function createUpdater<TContext, TEvent extends ImmerUpdateEvent>(
+export function createUpdater<
+  TContext extends MachineContext,
+  TEvent extends ImmerUpdateEvent
+>(
   type: TEvent['type'],
   recipe: ImmerAssigner<TContext, TEvent>
 ): ImmerUpdater<TContext, TEvent> {

--- a/packages/xstate-react/src/types.ts
+++ b/packages/xstate-react/src/types.ts
@@ -2,6 +2,7 @@ import {
   ActionMeta,
   ActionObject,
   EventObject,
+  MachineContext,
   State,
   StateConfig
 } from 'xstate';
@@ -77,7 +78,10 @@ export enum ReactEffectType {
   LayoutEffect = 2
 }
 
-export interface ReactActionFunction<TContext, TEvent extends EventObject> {
+export interface ReactActionFunction<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> {
   (
     context: TContext,
     event: TEvent,
@@ -86,12 +90,17 @@ export interface ReactActionFunction<TContext, TEvent extends EventObject> {
   __effect: ReactEffectType;
 }
 
-export interface ReactActionObject<TContext, TEvent extends EventObject>
-  extends ActionObject<TContext, TEvent> {
+export interface ReactActionObject<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> extends ActionObject<TContext, TEvent> {
   exec: ReactActionFunction<TContext, TEvent>;
 }
 
-export interface UseMachineOptions<TContext, TEvent extends EventObject> {
+export interface UseMachineOptions<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> {
   /**
    * If provided, will be merged with machine's `context`.
    */
@@ -103,7 +112,7 @@ export interface UseMachineOptions<TContext, TEvent extends EventObject> {
   state?: StateConfig<TContext, TEvent>;
 }
 
-export type ActionStateTuple<TContext, TEvent extends EventObject> = [
-  ReactActionObject<TContext, TEvent>,
-  State<TContext, TEvent>
-];
+export type ActionStateTuple<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> = [ReactActionObject<TContext, TEvent>, State<TContext, TEvent>];

--- a/packages/xstate-react/src/useInterpret.ts
+++ b/packages/xstate-react/src/useInterpret.ts
@@ -11,6 +11,7 @@ import {
   Typestate,
   Observer
 } from 'xstate';
+import { MachineContext } from '../../core/src';
 import { MaybeLazy } from './types';
 import useConstant from './useConstant';
 import { UseMachineOptions } from './useMachine';
@@ -37,7 +38,7 @@ function toObserver<T>(
 }
 
 export function useInterpret<
-  TContext,
+  TContext extends MachineContext,
   TEvent extends EventObject,
   TTypestate extends Typestate<TContext> = { value: any; context: TContext }
 >(

--- a/packages/xstate-react/src/useMachine.ts
+++ b/packages/xstate-react/src/useMachine.ts
@@ -8,12 +8,16 @@ import {
   StateConfig,
   Typestate,
   ActionFunction,
-  InterpreterOf
+  InterpreterOf,
+  MachineContext
 } from 'xstate';
 import { MaybeLazy, ReactActionFunction, ReactEffectType } from './types';
 import { useInterpret } from './useInterpret';
 
-function createReactActionFunction<TContext, TEvent extends EventObject>(
+function createReactActionFunction<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+>(
   exec: ActionFunction<TContext, TEvent>,
   tag: ReactEffectType
 ): ReactActionFunction<TContext, TEvent> {
@@ -32,19 +36,28 @@ function createReactActionFunction<TContext, TEvent extends EventObject>(
   return effectExec as ReactActionFunction<TContext, TEvent>;
 }
 
-export function asEffect<TContext, TEvent extends EventObject>(
+export function asEffect<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+>(
   exec: ActionFunction<TContext, TEvent>
 ): ReactActionFunction<TContext, TEvent> {
   return createReactActionFunction(exec, ReactEffectType.Effect);
 }
 
-export function asLayoutEffect<TContext, TEvent extends EventObject>(
+export function asLayoutEffect<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+>(
   exec: ActionFunction<TContext, TEvent>
 ): ReactActionFunction<TContext, TEvent> {
   return createReactActionFunction(exec, ReactEffectType.LayoutEffect);
 }
 
-export interface UseMachineOptions<TContext, TEvent extends EventObject> {
+export interface UseMachineOptions<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> {
   /**
    * If provided, will be merged with machine's `context`.
    */
@@ -57,7 +70,7 @@ export interface UseMachineOptions<TContext, TEvent extends EventObject> {
 }
 
 export function useMachine<
-  TContext,
+  TContext extends MachineContext,
   TEvent extends EventObject,
   TTypestate extends Typestate<TContext> = { value: any; context: TContext }
 >(

--- a/packages/xstate-react/src/useReactEffectActions.ts
+++ b/packages/xstate-react/src/useReactEffectActions.ts
@@ -1,10 +1,13 @@
 import { useEffect, useRef } from 'react';
 import useIsomorphicLayoutEffect from 'use-isomorphic-layout-effect';
-import { EventObject, State, Interpreter } from 'xstate';
+import { EventObject, State, Interpreter, MachineContext } from 'xstate';
 import { ReactActionObject, ReactEffectType, ActionStateTuple } from './types';
 import { partition } from './utils';
 
-function executeEffect<TContext, TEvent extends EventObject>(
+function executeEffect<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+>(
   action: ReactActionObject<TContext, TEvent>,
   state: State<TContext, TEvent, any>
 ): void {
@@ -18,9 +21,10 @@ function executeEffect<TContext, TEvent extends EventObject>(
   originalExec();
 }
 
-export function useReactEffectActions<TContext, TEvent extends EventObject>(
-  service: Interpreter<TContext, TEvent, any>
-) {
+export function useReactEffectActions<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+>(service: Interpreter<TContext, TEvent, any>) {
   const effectActionsRef = useRef<
     Array<[ReactActionObject<TContext, TEvent>, State<TContext, TEvent, any>]>
   >([]);

--- a/packages/xstate-react/src/useService.ts
+++ b/packages/xstate-react/src/useService.ts
@@ -1,4 +1,10 @@
-import { EventObject, State, Interpreter, Typestate } from 'xstate';
+import {
+  EventObject,
+  State,
+  Interpreter,
+  Typestate,
+  MachineContext
+} from 'xstate';
 import { useActor } from './useActor';
 import { PayloadSender } from './types';
 
@@ -12,7 +18,7 @@ export function getServiceSnapshot<TService extends Interpreter<any, any, any>>(
 }
 
 export function useService<
-  TContext,
+  TContext extends MachineContext,
   TEvent extends EventObject,
   TTypestate extends Typestate<TContext> = { value: any; context: TContext }
 >(

--- a/packages/xstate-test/src/index.ts
+++ b/packages/xstate-test/src/index.ts
@@ -5,7 +5,13 @@ import {
   StatePathsMap,
   ValueAdjMapOptions
 } from '@xstate/graph';
-import { MachineNode, EventObject, State, StateValue } from 'xstate';
+import {
+  MachineNode,
+  EventObject,
+  State,
+  StateValue,
+  MachineContext
+} from 'xstate';
 import slimChalk from './slimChalk';
 import {
   TestModelCoverage,
@@ -39,7 +45,7 @@ import {
  * ```
  *
  */
-export class TestModel<TTestContext, TContext> {
+export class TestModel<TTestContext, TContext extends MachineContext> {
   public coverage: TestModelCoverage = {
     stateNodes: new Map(),
     transitions: new Map()
@@ -350,7 +356,9 @@ export class TestModel<TTestContext, TContext> {
   }
 }
 
-function getDescription<T, TContext>(state: State<TContext, any>): string {
+function getDescription<T, TContext extends MachineContext>(
+  state: State<TContext, any>
+): string {
   const contextString =
     state.context === undefined ? '' : `(${JSON.stringify(state.context)})`;
 
@@ -430,7 +438,7 @@ function getEventSamples<T>(eventsOptions: TestModelOptions<T>['events']) {
  * - `events`: an object mapping string event types (e.g., `SUBMIT`)
  * to an event test config (e.g., `{exec: () => {...}, cases: [...]}`)
  */
-export function createModel<TestContext, TContext = any>(
+export function createModel<TestContext, TContext extends MachineContext = any>(
   machine: MachineNode<TContext, any, any>,
   options?: TestModelOptions<TestContext>
 ): TestModel<TestContext, TContext> {

--- a/packages/xstate-test/src/types.ts
+++ b/packages/xstate-test/src/types.ts
@@ -1,5 +1,6 @@
 import { EventObject, State, StateNode } from 'xstate';
-export interface TestMeta<T, TContext> {
+import { MachineContext } from '../../core/src';
+export interface TestMeta<T, TContext extends MachineContext> {
   test?: (testContext: T, state: State<TContext, any>) => Promise<void> | void;
   description?: string | ((state: State<TContext, any>) => string);
   skip?: boolean;
@@ -40,7 +41,7 @@ export interface TestPathResult {
  * A collection of `paths` used to verify that the SUT reaches
  * the target `state`.
  */
-export interface TestPlan<TTestContext, TContext> {
+export interface TestPlan<TTestContext, TContext extends MachineContext> {
   /**
    * The target state.
    */
@@ -84,7 +85,9 @@ interface EventCase {
   [prop: string]: any;
 }
 
-export type StatePredicate<TContext> = (state: State<TContext, any>) => boolean;
+export type StatePredicate<TContext extends MachineContext> = (
+  state: State<TContext, any>
+) => boolean;
 /**
  * Executes an effect using the `testContext` and `event`
  * that triggers the represented `event`.
@@ -139,6 +142,6 @@ export interface TestModelCoverage {
   transitions: Map<string, Map<EventObject, number>>;
 }
 
-export interface CoverageOptions<TContext> {
+export interface CoverageOptions<TContext extends MachineContext> {
   filter?: (stateNode: StateNode<TContext, any>) => boolean;
 }

--- a/packages/xstate-test/test/__snapshots__/index.test.ts.snap
+++ b/packages/xstate-test/test/__snapshots__/index.test.ts.snap
@@ -3,11 +3,11 @@
 exports[`error path trace should return trace for failed state should show an error path trace: error path trace 1`] = `
 "test error
 Path:
-	State: \\"first\\" 
+	State: \\"first\\" {}
 	Event: {\\"type\\":\\"NEXT\\"}
 
-	State: \\"second\\" 
+	State: \\"second\\" {}
 	Event: {\\"type\\":\\"NEXT\\"}
 
-	State: \\"third\\" "
+	State: \\"third\\" {}"
 `;

--- a/packages/xstate-test/test/index.test.ts
+++ b/packages/xstate-test/test/index.test.ts
@@ -395,7 +395,7 @@ describe('events', () => {
       | { type: 'CLOSE' }
       | { type: 'ESC' }
       | { type: 'SUBMIT'; value: string };
-    const feedbackMachine = createMachine<void, Events>({
+    const feedbackMachine = createMachine<undefined, Events>({
       id: 'feedback',
       initial: 'question',
       states: {

--- a/packages/xstate-test/test/index.test.ts
+++ b/packages/xstate-test/test/index.test.ts
@@ -395,7 +395,7 @@ describe('events', () => {
       | { type: 'CLOSE' }
       | { type: 'ESC' }
       | { type: 'SUBMIT'; value: string };
-    const feedbackMachine = createMachine<undefined, Events>({
+    const feedbackMachine = createMachine<any, Events>({
       id: 'feedback',
       initial: 'question',
       states: {

--- a/packages/xstate-vue/src/types.ts
+++ b/packages/xstate-vue/src/types.ts
@@ -1,7 +1,10 @@
-import { EventObject, StateConfig } from 'xstate';
+import { EventObject, MachineContext, StateConfig } from 'xstate';
 
 export type MaybeLazy<T> = T | (() => T);
-export interface UseMachineOptions<TContext, TEvent extends EventObject> {
+export interface UseMachineOptions<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> {
   /**
    * If provided, will be merged with machine's `context`.
    */

--- a/packages/xstate-vue/src/useInterpret.ts
+++ b/packages/xstate-vue/src/useInterpret.ts
@@ -11,6 +11,7 @@ import {
 } from 'xstate';
 import { UseMachineOptions, MaybeLazy } from './types';
 import { onBeforeUnmount, onMounted } from 'vue';
+import { MachineContext } from '../../core/src';
 
 // copied from core/src/utils.ts
 // it avoids a breaking change between this package and XState which is its peer dep
@@ -33,7 +34,7 @@ function toObserver<T>(
 }
 
 export function useInterpret<
-  TContext,
+  TContext extends MachineContext,
   TEvent extends EventObject,
   TTypestate extends Typestate<TContext> = { value: any; context: TContext }
 >(

--- a/packages/xstate-vue/src/useMachine.ts
+++ b/packages/xstate-vue/src/useMachine.ts
@@ -6,7 +6,8 @@ import {
   Interpreter,
   InterpreterOptions,
   MachineImplementations,
-  Typestate
+  Typestate,
+  MachineContext
 } from 'xstate';
 
 import { UseMachineOptions, MaybeLazy } from './types';
@@ -14,7 +15,7 @@ import { UseMachineOptions, MaybeLazy } from './types';
 import { useInterpret } from './useInterpret';
 
 export function useMachine<
-  TContext,
+  TContext extends MachineContext,
   TEvent extends EventObject,
   TTypestate extends Typestate<TContext> = { value: any; context: TContext }
 >(

--- a/packages/xstate-vue/src/useService.ts
+++ b/packages/xstate-vue/src/useService.ts
@@ -3,7 +3,8 @@ import {
   State,
   Interpreter,
   Typestate,
-  PayloadSender
+  PayloadSender,
+  MachineContext
 } from 'xstate';
 
 import { Ref, isRef } from 'vue';
@@ -20,7 +21,7 @@ export function getServiceSnapshot<TService extends Interpreter<any, any, any>>(
 }
 
 export function useService<
-  TContext,
+  TContext extends MachineContext,
   TEvent extends EventObject,
   TTypestate extends Typestate<TContext> = { value: any; context: TContext }
 >(


### PR DESCRIPTION
This PR restricts `context` passed into `createMachine(...)` or `createModel(...)` to be an object.

Closes https://github.com/davidkpiano/xstate/projects/1#card-40598611