### PR TITLE
Small change to the type of `State.inert`

### DIFF
--- a/packages/core/src/State.ts
+++ b/packages/core/src/State.ts
@@ -110,7 +110,7 @@ export class State<
       if (stateValue.context !== context) {
         return new State<TContext, TEvent>({
           value: stateValue.value,
-          context: context as TContext,
+          context,
           _event: stateValue._event,
           _sessionid: null,
           history: stateValue.history,
@@ -129,7 +129,7 @@ export class State<
 
     return new State<TContext, TEvent>({
       value: stateValue,
-      context: context as TContext,
+      context,
       _event,
       _sessionid: null,
       history: undefined,
@@ -156,8 +156,7 @@ export class State<
    * @param context
    */
   public static inert<TState extends State<any, any, any>>(
-    state: TState,
-    context: any
+    state: TState
   ): TState;
   public static inert<
     TContext extends MachineContext,
@@ -165,7 +164,7 @@ export class State<
   >(stateValue: StateValue, context: TContext): State<TContext, TEvent>;
   public static inert(
     stateValue: State<any, any> | StateValue,
-    context: any
+    context?: MachineContext
   ): State<any, any> {
     if (stateValue instanceof State) {
       if (!stateValue.actions.length) {
@@ -175,7 +174,7 @@ export class State<
 
       return new State<any>({
         value: stateValue.value,
-        context,
+        context: stateValue.context,
         _event,
         _sessionid: null,
         history: stateValue.history,

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -1560,7 +1560,7 @@ export function resolveMicroTransition<
   );
 
   if (currentState && !willTransition) {
-    const inertState = State.inert(currentState, currentState.context);
+    const inertState = State.inert(currentState);
     inertState.event = _event.data;
     inertState._event = _event;
     inertState.changed = _event.name === actionTypes.update;

--- a/packages/core/test/state.test.ts
+++ b/packages/core/test/state.test.ts
@@ -334,7 +334,7 @@ describe('State', () => {
     it('should create an inert instance of the given State', () => {
       const { initialState } = machine;
 
-      expect(State.inert(initialState, undefined).actions).toEqual([]);
+      expect(State.inert(initialState).actions).toEqual([]);
     });
 
     it('should create an inert instance of the given stateValue and context', () => {
@@ -348,9 +348,7 @@ describe('State', () => {
     it('should preserve the given State if there are no actions', () => {
       const naturallyInertState = State.from('foo');
 
-      expect(State.inert(naturallyInertState, undefined)).toEqual(
-        naturallyInertState
-      );
+      expect(State.inert(naturallyInertState)).toEqual(naturallyInertState);
     });
   });
 


### PR DESCRIPTION
Since this param was basically ignored when `State<any, any, any>` was given to this function I thought that it could be just removed from this overload signature.