### PR TITLE
Patch environment check for use in web-dev-server

### DIFF
--- a/.changeset/six-windows-impress.md
+++ b/.changeset/six-windows-impress.md
@@ -2,4 +2,4 @@
 'xstate': patch
 ---
 
-Patch environment check for use in web-dev-server
+The global `process` variable is now checked for existence before trying to read the `NODE_ENV` environment variable.

--- a/.changeset/six-windows-impress.md
+++ b/.changeset/six-windows-impress.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Patch environment check for use in web-dev-server

--- a/packages/core/src/environment.ts
+++ b/packages/core/src/environment.ts
@@ -1,1 +1,4 @@
-export const IS_PRODUCTION = process.env.NODE_ENV === 'production';
+export const IS_PRODUCTION =
+  typeof process !== 'undefined'
+    ? process.env.NODE_ENV === 'production'
+    : false;


### PR DESCRIPTION
I've started playing with WebComponents (`lit`) and no-build environments.  I created a test project with open-wc, which uses `web-dev-server` to import ES modules.  With `xstate`,  `environment.ts`  was checking `process.env` which caused `web-dev-server` to throw an exception.  This PR simply guards against `undefined` to allow `xstate` to work directly imported into a browser.