### PR TITLE
Ensure that context is defined when model type provided to createMachine()

### DIFF
--- a/.changeset/grumpy-planes-greet.md
+++ b/.changeset/grumpy-planes-greet.md
@@ -1,0 +1,16 @@
+---
+'xstate': patch
+---
+
+When using a model type in `createMachine<typeof someModel>(...)`, TypeScript will no longer compile machines that are missing the `context` property in the machine configuration:
+
+```ts
+const machine = createMachine<typeof someModel>({
+  // missing context - will give a TS error!
+  // context: someModel.initialContext,
+  initial: 'somewhere',
+  states: {
+    somewhere: {}
+  }
+});
+```

--- a/packages/core/src/Machine.ts
+++ b/packages/core/src/Machine.ts
@@ -63,6 +63,8 @@ export function createMachine<
   TEvent extends EventObject = AnyEventObject,
   TTypestate extends Typestate<TContext> = { value: any; context: TContext }
 >(
+  // Ensure that only the first overload matches models, and prevent
+  // accidental inference of the model as the `TContext` (which leads to cryptic errors)
   config: TContext extends Model<any, any, any>
     ? never
     : MachineConfig<TContext, any, TEvent>,

--- a/packages/core/src/Machine.ts
+++ b/packages/core/src/Machine.ts
@@ -55,7 +55,7 @@ export function createMachine<
   TEvent extends EventObject = ModelEventsFrom<TModel>,
   TTypestate extends Typestate<TContext> = { value: any; context: TContext }
 >(
-  config: MachineConfig<TContext, any, TEvent>,
+  config: MachineConfig<TContext, any, TEvent> & { context: TContext },
   options?: Partial<MachineOptions<TContext, TEvent>>
 ): StateMachine<TContext, any, TEvent, TTypestate>;
 export function createMachine<
@@ -63,7 +63,9 @@ export function createMachine<
   TEvent extends EventObject = AnyEventObject,
   TTypestate extends Typestate<TContext> = { value: any; context: TContext }
 >(
-  config: MachineConfig<TContext, any, TEvent>,
+  config: TContext extends Model<any, any, any>
+    ? never
+    : MachineConfig<TContext, any, TEvent>,
   options?: Partial<MachineOptions<TContext, TEvent>>
 ): StateMachine<TContext, any, TEvent, TTypestate>;
 export function createMachine<

--- a/packages/core/test/model.test.ts
+++ b/packages/core/test/model.test.ts
@@ -220,4 +220,19 @@ describe('createModel', () => {
 
     expect(machine.initialState.context.count).toBe(0);
   });
+
+  it('should not compile if missing context', () => {
+    const toggleModel = createModel({ count: 0 });
+
+    // @ts-expect-error
+    const m = createMachine<typeof toggleModel>({
+      id: 'machine',
+      initial: 'inactive',
+      // missing context:
+      // context: toggleModel.initialContext,
+      states: {
+        inactive: {}
+      }
+    });
+  });
 });


### PR DESCRIPTION
When using a model type in `createMachine<typeof someModel>(...)`, TypeScript will no longer compile machines that are missing the `context` property in the machine configuration:

```ts
const machine = createMachine<typeof someModel>({
  // missing context - will give a TS error!
  // context: someModel.initialContext,
  initial: 'somewhere',
  states: {
    somewhere: {}
  }
});
```