### PR TITLE
[@xstate/vue] Update useActor, useSelector & useService

### DIFF
--- a/.changeset/tender-meals-shave.md
+++ b/.changeset/tender-meals-shave.md
@@ -1,0 +1,7 @@
+---
+'@xstate/vue': minor
+---
+
+The `send` type returned in the object from `useActor(someService)` was an incorrect `never` type; this has been fixed.
+
+Also adds deprecation notice to `useService`.

--- a/packages/xstate-vue/src/useActor.ts
+++ b/packages/xstate-vue/src/useActor.ts
@@ -15,7 +15,7 @@ const noop = () => {
   /* ... */
 };
 
-function defaultGetSnapshot<TEmitted>(
+export function defaultGetSnapshot<TEmitted>(
   actorRef: ActorRef<any, TEmitted>
 ): TEmitted | undefined {
   return 'getSnapshot' in actorRef

--- a/packages/xstate-vue/src/useSelector.ts
+++ b/packages/xstate-vue/src/useSelector.ts
@@ -1,19 +1,8 @@
 import { onMounted, onBeforeUnmount, shallowRef } from 'vue';
-import { ActorRef, Interpreter, Subscribable } from 'xstate';
-import { isActorWithState } from './useActor';
-import { getServiceSnapshot } from './useService';
-
-function isService(actor: any): actor is Interpreter<any, any, any, any> {
-  return 'state' in actor && 'machine' in actor;
-}
+import { ActorRef, Subscribable } from 'xstate';
+import { defaultGetSnapshot } from './useActor';
 
 const defaultCompare = (a, b) => a === b;
-const defaultGetSnapshot = (a) =>
-  isService(a)
-    ? getServiceSnapshot(a)
-    : isActorWithState(a)
-    ? a.state
-    : undefined;
 
 export function useSelector<
   TActor extends ActorRef<any, any>,

--- a/packages/xstate-vue/src/useService.ts
+++ b/packages/xstate-vue/src/useService.ts
@@ -19,6 +19,12 @@ export function getServiceSnapshot<
     : service.machine.initialState;
 }
 
+/**
+ * @deprecated Use `useActor` instead.
+ *
+ * @param service The interpreted machine
+ * @returns A tuple of the current `state` of the service and the service's `send(event)` method
+ */
 export function useService<
   TContext,
   TEvent extends EventObject,
@@ -40,7 +46,7 @@ export function useService<
     );
   }
 
-  const { state, send } = useActor(service, getServiceSnapshot);
+  const { state, send } = useActor(service);
 
   return { state, send };
 }

--- a/packages/xstate-vue/src/useService.ts
+++ b/packages/xstate-vue/src/useService.ts
@@ -10,15 +10,6 @@ import { Ref, isRef } from 'vue';
 
 import { useActor } from './useActor';
 
-export function getServiceSnapshot<
-  TService extends Interpreter<any, any, any, any>
->(service: TService): TService['state'] {
-  // TODO: remove compat lines in a new major, replace literal number with InterpreterStatus then as well
-  return ('status' in service ? service.status : (service as any)._status) !== 0
-    ? service.state
-    : service.machine.initialState;
-}
-
 /**
  * @deprecated Use `useActor` instead.
  *


### PR DESCRIPTION
This PR brings the latests changes from `@xstate/react` to `@xstate/vue`. Mainly uses the new `.getSnapshot()` from actors and services, updates some types and removes unnecessary code :)