### PR TITLE
Fix issue where always transition not taken in absence of enabled transitions

### DIFF
--- a/.changeset/tasty-books-march.md
+++ b/.changeset/tasty-books-march.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Eventless ("always") transitions will no longer be ignored if an event is sent to a machine in a state that does not have any enabled transitions for that event.

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -1268,19 +1268,31 @@ class StateNode<
       delete history.history;
     }
 
-    if (!resolvedStateValue) {
+    // There are transient transitions if the machine is not in a final state
+    // and if some of the state nodes have transient ("always") transitions.
+    const isTransient =
+      !isDone &&
+      (this._transient ||
+        configuration.some((stateNode) => {
+          return stateNode._transient;
+        }));
+
+    // If there are no enabled transitions, check if there are transient transitions.
+    // If there are transient transitions, continue checking for more transitions
+    // because an transient transition should be triggered even if there are no
+    // enabled transitions.
+    //
+    // If we're already working on an transient transition (by checking
+    // if the event is a NULL_EVENT), then stop to prevent an infinite loop.
+    //
+    // Otherwise, if there are no enabled nor transient transitions, we are done.
+    if (!resolvedStateValue && (!isTransient || _event.name === NULL_EVENT)) {
       return nextState;
     }
 
     let maybeNextState = nextState;
 
     if (!isDone) {
-      const isTransient =
-        this._transient ||
-        configuration.some((stateNode) => {
-          return stateNode._transient;
-        });
-
       if (isTransient) {
         maybeNextState = this.resolveRaisedTransition(
           maybeNextState,

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -1286,7 +1286,7 @@ class StateNode<
     // if the event is a NULL_EVENT), then stop to prevent an infinite loop.
     //
     // Otherwise, if there are no enabled nor transient transitions, we are done.
-    if (!resolvedStateValue && (!isTransient || _event.name === NULL_EVENT)) {
+    if (!willTransition && (!isTransient || _event.name === NULL_EVENT)) {
       return nextState;
     }
 

--- a/packages/core/test/transient.test.ts
+++ b/packages/core/test/transient.test.ts
@@ -677,50 +677,28 @@ describe('transient states (eventless transitions)', () => {
     expect(() => service.start()).not.toThrow();
   });
 
-  it('should be taken even in absence of other transitions', (done) => {
-    const machine = createMachine<{
-      ref?: ActorRef<any>;
-    }>({
+  it('should be taken even in absence of other transitions', () => {
+    let shouldMatch = false;
+
+    const machine = createMachine({
       initial: 'a',
-      context: {
-        ref: undefined
-      },
       states: {
         a: {
-          entry: assign<any>({
-            ref: () =>
-              spawn(
-                createMachine({
-                  initial: 'waiting',
-                  states: {
-                    waiting: { after: { 100: 'done' } },
-                    // This will send the parent a "done.invoke.*" event,
-                    // which is not handled by the parent.
-                    done: { type: 'final' }
-                  }
-                })
-              )
-          }),
-          // There will be no enabled transitions for the "done.invoke.*" event
-          // but there will be transient transitions.
           always: {
             target: 'b',
-            cond: (ctx: any, _e) => {
-              // This will be reached when the ref is done and emits a "done.invoke.*"
-              // event to the parent
-              return ctx.ref.getSnapshot().matches('done');
-            }
+            // TODO: in v5 remove `shouldMatch` and replace this guard with:
+            // cond: (ctx, ev) => ev.type === 'WHATEVER'
+            cond: () => shouldMatch
           }
         },
-        b: {
-          type: 'final'
-        }
+        b: {}
       }
     });
-    const service = interpret(machine).onDone(() => {
-      done();
-    });
+    const service = interpret(machine).start();
 
-    service.start();
+    shouldMatch = true;
+    service.send({ type: 'WHATEVER' });
+
+    expect(service.state.value).toBe('b');
   });
 });

--- a/packages/core/test/transient.test.ts
+++ b/packages/core/test/transient.test.ts
@@ -695,4 +695,36 @@ describe('transient states (eventless transitions)', () => {
 
     expect(service.state.value).toBe('b');
   });
+
+  it('should select subsequent transient transitions even in absence of other transitions', () => {
+    let shouldMatch = false;
+
+    const machine = createMachine({
+      initial: 'a',
+      states: {
+        a: {
+          always: {
+            target: 'b',
+            // TODO: in v5 remove `shouldMatch` and replace this guard with:
+            // cond: (ctx, ev) => ev.type === 'WHATEVER'
+            cond: () => shouldMatch
+          }
+        },
+        b: {
+          always: {
+            target: 'c',
+            cond: () => true
+          }
+        },
+        c: {}
+      }
+    });
+
+    const service = interpret(machine).start();
+
+    shouldMatch = true;
+    service.send({ type: 'WHATEVER' });
+
+    expect(service.state.value).toBe('c');
+  });
 });

--- a/packages/core/test/transient.test.ts
+++ b/packages/core/test/transient.test.ts
@@ -1,10 +1,4 @@
-import {
-  Machine,
-  createMachine,
-  interpret,
-  spawn,
-  ActorRef
-} from '../src/index';
+import { Machine, createMachine, interpret } from '../src/index';
 import { assign, raise } from '../src/actions';
 
 const greetingContext = { hour: 10 };


### PR DESCRIPTION
This PR fixes an issue where, if an event is sent to a machine in a state where it does not accept that event (no enabled transitions), any transient (`always`) transitions will be _ignored_. According to the [SCXML algorithm](https://www.w3.org/TR/scxml/#AlgorithmforSCXMLInterpretation) (see `mainEventLoop`), they should not be ignored.