### PR TITLE
Clarify Invoking with Context documentation

### DIFF
--- a/docs/guides/communication.md
+++ b/docs/guides/communication.md
@@ -423,7 +423,9 @@ data: (context, event) => ({
 })
 ```
 
-Note: any default context defined on the machine is replaced when invoked in this fashion
+::: warning
+The `data` _replaces_ the default `context` defined on the machine; it is not merged. This behavior will change in the next major version.
+:::
 
 ### Done Data
 

--- a/docs/guides/communication.md
+++ b/docs/guides/communication.md
@@ -423,6 +423,8 @@ data: (context, event) => ({
 })
 ```
 
+Note: any default context defined on the machine is replaced when invoked in this fashion
+
 ### Done Data
 
 When a child machine reaches its top-level [final state](./final.md), it can send data in the "done" event (e.g., `{ type: 'done.invoke.someId', data: ... }`). This "done data" is specified on the final state's `data` property:


### PR DESCRIPTION
I was unclear from reading the documentation what would happen to the default context for a machine when invoking it with a `data` function. Would it merge the contexts together or would it replace it?

From testing, it appears to replace the context of the machine with what you return from the `data` function. This seems worth noting in the documentation