### PR TITLE
[core] Add ability to spawn actors in lazy initial context

### DIFF
--- a/.changeset/breezy-countries-tap.md
+++ b/.changeset/breezy-countries-tap.md
@@ -1,0 +1,14 @@
+---
+'xstate': minor
+---
+
+Actors can now be spawned directly in the initial `machine.context` using lazy initialization, avoiding the need for intermediate states and unsafe typings for immediately spawned actors:
+
+```ts
+const machine = createMachine<{ ref: ActorRef<SomeEvent> }>({
+  context: () => ({
+    ref: spawn(anotherMachine, 'some-id') // spawn immediately!
+  })
+  // ...
+});
+```

--- a/packages/core/src/Machine.ts
+++ b/packages/core/src/Machine.ts
@@ -37,15 +37,10 @@ export function Machine<
   options?: Partial<MachineOptions<TContext, TEvent>>,
   initialContext: TContext | (() => TContext) | undefined = config.context
 ): StateMachine<TContext, TStateSchema, TEvent> {
-  const resolvedInitialContext =
-    typeof initialContext === 'function'
-      ? (initialContext as () => TContext)()
-      : initialContext;
-
   return new StateNode<TContext, TStateSchema, TEvent>(
     config,
     options,
-    resolvedInitialContext
+    initialContext
   ) as StateMachine<TContext, TStateSchema, TEvent>;
 }
 
@@ -78,14 +73,8 @@ export function createMachine<
   config: MachineConfig<TContext, any, TEvent>,
   options?: Partial<MachineOptions<TContext, TEvent>>
 ): StateMachine<TContext, any, TEvent, TTypestate> {
-  const resolvedInitialContext =
-    typeof config.context === 'function'
-      ? (config.context as () => TContext)()
-      : config.context;
-
   return new StateNode<TContext, any, TEvent, TTypestate>(
     config,
-    options,
-    resolvedInitialContext
+    options
   ) as StateMachine<TContext, any, TEvent, TTypestate>;
 }

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -159,12 +159,6 @@ export function toActivityDefinition<TContext, TEvent extends EventObject>(
  *
  * @param eventType The event to raise.
  */
-export function raise<TEvent extends EventObject>(
-  event: Event<TEvent>
-): RaiseAction<TEvent> | SendAction<any, AnyEventObject, TEvent>;
-export function raise<TContext, TEvent extends EventObject>(
-  event: Event<TEvent>
-): RaiseAction<TEvent> | SendAction<TContext, AnyEventObject, TEvent>;
 export function raise<TContext, TEvent extends EventObject>(
   event: Event<TEvent>
 ): RaiseAction<TEvent> | SendAction<TContext, AnyEventObject, TEvent> {

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -159,6 +159,9 @@ export function toActivityDefinition<TContext, TEvent extends EventObject>(
  *
  * @param eventType The event to raise.
  */
+export function raise<TEvent extends EventObject>(
+  event: Event<TEvent>
+): RaiseAction<TEvent> | SendAction<any, AnyEventObject, TEvent>;
 export function raise<TContext, TEvent extends EventObject>(
   event: Event<TEvent>
 ): RaiseAction<TEvent> | SendAction<TContext, AnyEventObject, TEvent> {

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -164,6 +164,9 @@ export function raise<TEvent extends EventObject>(
 ): RaiseAction<TEvent> | SendAction<any, AnyEventObject, TEvent>;
 export function raise<TContext, TEvent extends EventObject>(
   event: Event<TEvent>
+): RaiseAction<TEvent> | SendAction<TContext, AnyEventObject, TEvent>;
+export function raise<TContext, TEvent extends EventObject>(
+  event: Event<TEvent>
 ): RaiseAction<TEvent> | SendAction<TContext, AnyEventObject, TEvent> {
   if (!isString(event)) {
     return send(event, { to: SpecialTargets.Internal });

--- a/packages/core/test/machine.test.ts
+++ b/packages/core/test/machine.test.ts
@@ -197,17 +197,17 @@ describe('machine', () => {
   });
 
   describe('machine function context', () => {
-    const testMachineConfig = {
-      initial: 'active',
-      context: () => ({
-        foo: { bar: 'baz' }
-      }),
-      states: {
-        active: {}
-      }
-    };
-
     it('context from a function should be lazily evaluated', () => {
+      const testMachineConfig = {
+        initial: 'active',
+        context: () => ({
+          foo: { bar: 'baz' }
+        }),
+        states: {
+          active: {}
+        }
+      };
+
       const testMachine1 = Machine(testMachineConfig);
       const testMachine2 = Machine(testMachineConfig);
 


### PR DESCRIPTION
Actors can now be spawned directly in the initial `machine.context` using lazy initialization, avoiding the need for intermediate states and unsafe typings for immediately spawned actors:

```ts
const machine = createMachine<{ ref: ActorRef<SomeEvent> }>({
  context: () => ({
    ref: spawn(anotherMachine, 'some-id') // spawn immediately!
  })
  // ...
});
```
