### PR TITLE
Allow inferring correct Observable type when working with RxJS

### DIFF
--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -326,12 +326,12 @@ export class Interpreter<
     return this;
   }
   public subscribe(
-    observer: Observer<State<TContext, TEvent, any, TTypestate>>
-  ): Subscription;
-  public subscribe(
     nextListener?: (state: State<TContext, TEvent, any, TTypestate>) => void,
     errorListener?: (error: any) => void,
     completeListener?: () => void
+  ): Subscription;
+  public subscribe(
+    observer: Observer<State<TContext, TEvent, any, TTypestate>>
   ): Subscription;
   public subscribe(
     nextListenerOrObserver?:

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1263,12 +1263,12 @@ export interface Subscription {
 }
 
 export interface Subscribable<T> {
-  subscribe(observer: Observer<T>): Subscription;
   subscribe(
     next: (value: T) => void,
     error?: (error: any) => void,
     complete?: () => void
   ): Subscription;
+  subscribe(observer: Observer<T>): Subscription;
 }
 
 export type Spawnable =


### PR DESCRIPTION
I believe this fixes the problem mentioned here: https://github.com/davidkpiano/xstate/pull/2358#issuecomment-870615701

It definitely fixes the inference issue on this line:
https://github.com/davidkpiano/xstate/blob/d018a1a22dc4d889fe558842f332bae911f78401/packages/core/test/interpreter.test.ts#L1698

The resulting variable becomes `Observable<State<...>>`, whereas before this change it was `Observable<unknown>`

This obviously is a very weird change but I believe that it's related to how TS, at times, casts overloaded functions to their last overload signature. It happens when performing certain operations on types, when using conditional types etc. Take a look at this simple example:
https://www.typescriptlang.org/play?#code/CYUwxgNghgTiAEAzArgOzAFwJYHtXwxAGcMAKKALnlWQFsAjEGASipoaYChRJYEV02PAWJlK8EjCyoA5qwkYpszpwD0q+FgwByIvABWyEvCgKlMzhgCeABwQAlEBngBeeI4zIYqACq2QADzWdjiIIiQAfEA

So by reordering overloads I just make it possible for TS to match infer from our signature which starts here:
https://github.com/ReactiveX/rxjs/blob/1f7b9c5b3339d7dbb9303e2e436c62f40ad2ff47/src/internal/observable/from.ts#L17
and goes to this conditional type
https://github.com/ReactiveX/rxjs/blob/1f7b9c5b3339d7dbb9303e2e436c62f40ad2ff47/src/internal/types.ts#L208
