### PR TITLE
Fix typo in ChooseCondition type

### DIFF
--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -31,7 +31,7 @@ import {
   DelayFunctionMap,
   SCXML,
   ExprWithMeta,
-  ChooseConditon,
+  ChooseCondition,
   ChooseAction,
   AnyEventObject,
   Expr
@@ -562,7 +562,7 @@ export function escalate<
 }
 
 export function choose<TContext, TEvent extends EventObject>(
-  conds: Array<ChooseConditon<TContext, TEvent>>
+  conds: Array<ChooseCondition<TContext, TEvent>>
 ): ChooseAction<TContext, TEvent> {
   return {
     type: ActionTypes.Choose,

--- a/packages/core/src/scxml.ts
+++ b/packages/core/src/scxml.ts
@@ -5,7 +5,7 @@ import {
   SCXMLEventMeta,
   SendExpr,
   DelayExpr,
-  ChooseConditon
+  ChooseCondition
 } from './types';
 import { StateNode, Machine } from './index';
 import { mapValues, keys, isString } from './utils';
@@ -215,9 +215,9 @@ function mapAction<
       );
     }
     case 'if': {
-      const conds: ChooseConditon<TContext, TEvent>[] = [];
+      const conds: ChooseCondition<TContext, TEvent>[] = [];
 
-      let current: ChooseConditon<TContext, TEvent> = {
+      let current: ChooseCondition<TContext, TEvent> = {
         cond: createCond(element.attributes!.cond as string),
         actions: []
       };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -84,7 +84,7 @@ export type ActionFunction<
   meta: ActionMeta<TContext, TEvent, TAction>
 ) => void;
 
-export interface ChooseConditon<TContext, TEvent extends EventObject> {
+export interface ChooseCondition<TContext, TEvent extends EventObject> {
   cond?: Condition<TContext, TEvent>;
   actions: Actions<TContext, TEvent>;
 }
@@ -1131,7 +1131,7 @@ export interface PureAction<TContext, TEvent extends EventObject>
 export interface ChooseAction<TContext, TEvent extends EventObject>
   extends ActionObject<TContext, TEvent> {
   type: ActionTypes.Choose;
-  conds: Array<ChooseConditon<TContext, TEvent>>;
+  conds: Array<ChooseCondition<TContext, TEvent>>;
 }
 
 export interface TransitionDefinition<TContext, TEvent extends EventObject>


### PR DESCRIPTION
Renamed TypeScript interface from `ChooseConditon` to `ChooseCondition`.