### PR TITLE
Remove tests from prepublish scripts

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,11 +30,7 @@
     "clean": "rm -rf lib es dist tsconfig.tsbuildinfo",
     "test": "jest",
     "build": "rollup -c",
-    "preversion": "npm run test",
-    "version": "npm run build",
-    "postversion": "git push --follow-tags",
-    "prepublishOnly": "npm run build",
-    "publish:next": "npm version prerelease && npm publish --tag next"
+    "prepublishOnly": "npm run build"
   },
   "repository": {
     "type": "git",

--- a/packages/xstate-analytics/package.json
+++ b/packages/xstate-analytics/package.json
@@ -29,7 +29,7 @@
     "clean": "rm -rf dist lib tsconfig.tsbuildinfo",
     "build": "tsc",
     "test": "jest",
-    "prepublish": "npm run build && npm run test"
+    "prepublish": "npm run build"
   },
   "bugs": {
     "url": "https://github.com/davidkpiano/xstate/issues"

--- a/packages/xstate-react/package.json
+++ b/packages/xstate-react/package.json
@@ -39,7 +39,7 @@
     "clean": "rm -rf dist lib tsconfig.tsbuildinfo",
     "build": "tsc && tsc --outDir es --module es2015 && rollup -c",
     "test": "jest",
-    "prepublish": "npm run build && npm run test"
+    "prepublish": "npm run build"
   },
   "bugs": {
     "url": "https://github.com/davidkpiano/xstate/issues"

--- a/packages/xstate-scxml/package.json
+++ b/packages/xstate-scxml/package.json
@@ -28,7 +28,7 @@
     "clean": "rm -rf dist lib tsconfig.tsbuildinfo",
     "test": "jest",
     "build": "tsc",
-    "prepublish": "npm run build && npm run test"
+    "prepublish": "npm run build"
   },
   "bugs": {
     "url": "https://github.com/davidkpiano/xstate/issues"

--- a/packages/xstate-svelte/package.json
+++ b/packages/xstate-svelte/package.json
@@ -34,7 +34,7 @@
     "clean": "rm -rf dist lib tsconfig.tsbuildinfo",
     "build": "tsc",
     "test": "jest",
-    "prepublish": "npm run build && npm run test"
+    "prepublish": "npm run build"
   },
   "bugs": {
     "url": "https://github.com/davidkpiano/xstate/issues"

--- a/packages/xstate-test/package.json
+++ b/packages/xstate-test/package.json
@@ -38,7 +38,7 @@
     "clean": "rm -rf dist lib es tsconfig.tsbuildinfo",
     "test": "jest --runInBand",
     "build": "tsc && tsc --outDir es --module es2015",
-    "prepublish": "npm run build && npm run test"
+    "prepublish": "npm run build"
   },
   "bugs": {
     "url": "https://github.com/davidkpiano/xstate/issues"

--- a/packages/xstate-vue/package.json
+++ b/packages/xstate-vue/package.json
@@ -38,7 +38,7 @@
     "clean": "rm -rf dist lib es tsconfig.tsbuildinfo",
     "build": "tsc && tsc --outDir es --module es2015 && rollup -c",
     "test": "jest",
-    "prepublish": "npm run build && npm run test"
+    "prepublish": "npm run build"
   },
   "bugs": {
     "url": "https://github.com/davidkpiano/xstate/issues"


### PR DESCRIPTION
Last publish has failed:
https://github.com/statelyai/xstate/runs/4001224306?check_suite_focus=true

This is partly because Changesets has an issue with parsing stdout content - I have a plan to refactor this there and fix the issue altogether but it's not trivial to do so.

We are already running tests before `release` script that is used by Changesets:
https://github.com/statelyai/xstate/blob/0546db7776edb09eda98812294f7237600dbcbbf/package.json#L21-L22

Therefore running this before publishing a package is wasteful. In addition to that this should prevent the sdtout+Changesets issue from happening.