### PR TITLE
Upgrade `actions/setup-node`

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,9 @@ jobs:
           fetch-depth: 0
 
       - name: Use Node.js 14.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
-          version: 14.x
+          node-version: 14.x
 
       - name: Install Dependencies
         run: yarn


### PR DESCRIPTION
I've noticed this warning in the CI logs:
```
Warning: Input 'version' has been deprecated with message: The version property will not be supported after October 1, 2019. Use node-version instead
```

So I've decided to get rid of it