### PR TITLE
Fixed an issue with `EmittedFrom` sometimes not being able to infer the snapshot types from machines

### DIFF
--- a/.changeset/little-frogs-fly.md
+++ b/.changeset/little-frogs-fly.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Fixed an issue with `EmittedFrom` sometimes not being able to infer the snapshot types from machines.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1814,7 +1814,25 @@ export interface Behavior<TEvent extends EventObject, TEmitted = any> {
 }
 
 export type EmittedFrom<T> = ReturnTypeOrValue<T> extends infer R
-  ? R extends Interpreter<infer _, infer __, infer ___, infer ____, infer _____>
+  ? // we need to specialcase the StateMachine here (even though it's a Behavior)
+    // because its `transition` method is too different from the `Behavior["transition"]`
+    R extends StateMachine<
+      infer _,
+      infer __,
+      infer ___,
+      infer ____,
+      infer _____,
+      infer ______,
+      infer _______
+    >
+    ? R['initialState']
+    : R extends Interpreter<
+        infer _,
+        infer __,
+        infer ___,
+        infer ____,
+        infer _____
+      >
     ? R['initialState']
     : R extends ActorRef<infer _, infer TEmitted>
     ? TEmitted

--- a/packages/core/test/typeHelpers.test.ts
+++ b/packages/core/test/typeHelpers.test.ts
@@ -403,4 +403,28 @@ describe('EmittedFrom', () => {
     // @ts-expect-error
     acceptState("isn't any");
   });
+
+  it('should return state from a machine without context', () => {
+    const machine = createMachine({});
+
+    function acceptState(_state: EmittedFrom<typeof machine>) {}
+
+    acceptState(machine.initialState);
+    // @ts-expect-error
+    acceptState("isn't any");
+  });
+
+  it('should return state from a machine with context', () => {
+    const machine = createMachine({
+      context: {
+        counter: 0
+      }
+    });
+
+    function acceptState(_state: EmittedFrom<typeof machine>) {}
+
+    acceptState(machine.initialState);
+    // @ts-expect-error
+    acceptState("isn't any");
+  });
 });


### PR DESCRIPTION
I noticed this problem when working on https://github.com/statelyai/xstate/pull/3778