### PR TITLE
Add error type to Promise actors

### DIFF
--- a/packages/core/src/actors/promise.ts
+++ b/packages/core/src/actors/promise.ts
@@ -9,7 +9,10 @@ import {
   Snapshot
 } from '../types.ts';
 
-export type PromiseSnapshot<TOutput, TInput> = Snapshot<TOutput> & {
+export type PromiseSnapshot<TOutput, TInput, TError = unknown> = Snapshot<
+  TOutput,
+  TError
+> & {
   input: TInput | undefined;
 };
 
@@ -19,9 +22,10 @@ const XSTATE_PROMISE_REJECT = 'xstate.promise.reject';
 export type PromiseActorLogic<
   TOutput,
   TInput = unknown,
-  TEmitted extends EventObject = EventObject
+  TEmitted extends EventObject = EventObject,
+  TError = unknown
 > = ActorLogic<
-  PromiseSnapshot<TOutput, TInput>,
+  PromiseSnapshot<TOutput, TInput, TError>,
   { type: string; [k: string]: unknown },
   TInput, // input
   AnyActorSystem,
@@ -61,8 +65,8 @@ export type PromiseActorLogic<
  *
  * @see {@link fromPromise}
  */
-export type PromiseActorRef<TOutput> = ActorRefFromLogic<
-  PromiseActorLogic<TOutput, unknown>
+export type PromiseActorRef<TOutput, TError = unknown> = ActorRefFromLogic<
+  PromiseActorLogic<TOutput, unknown, EventObject, TError>
 >;
 
 const controllerMap = new WeakMap<AnyActorRef, AbortController>();
@@ -120,7 +124,8 @@ const controllerMap = new WeakMap<AnyActorRef, AbortController>();
 export function fromPromise<
   TOutput,
   TInput = NonReducibleUnknown,
-  TEmitted extends EventObject = EventObject
+  TEmitted extends EventObject = EventObject,
+  TError = unknown
 >(
   promiseCreator: ({
     input,
@@ -138,8 +143,8 @@ export function fromPromise<
     signal: AbortSignal;
     emit: (emitted: TEmitted) => void;
   }) => PromiseLike<TOutput>
-): PromiseActorLogic<TOutput, TInput, TEmitted> {
-  const logic: PromiseActorLogic<TOutput, TInput, TEmitted> = {
+): PromiseActorLogic<TOutput, TInput, TEmitted, TError> {
+  const logic: PromiseActorLogic<TOutput, TInput, TEmitted, TError> = {
     config: promiseCreator,
     transition: (state, event, scope) => {
       if (state.status !== 'active') {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -176,6 +176,19 @@ export type OutputFrom<T> =
       ? (TSnapshot & { status: 'done' })['output']
       : never;
 
+export type ErrorFrom<T> =
+  T extends ActorLogic<
+    infer TSnapshot,
+    infer _TEvent,
+    infer _TInput,
+    infer _TSystem,
+    infer _TEmitted
+  >
+    ? (TSnapshot & { status: 'error' })['error']
+    : T extends ActorRef<infer TSnapshot, infer _TEvent, infer _TEmitted>
+      ? (TSnapshot & { status: 'error' })['error']
+      : never;
+
 export type ActionFunction<
   TContext extends MachineContext,
   TExpressionEvent extends EventObject,
@@ -420,7 +433,7 @@ export interface InvokeDefinition<
     | SingleOrArray<
         TransitionConfig<
           TContext,
-          ErrorActorEvent,
+          ErrorActorEvent<unknown>,
           TEvent,
           TActor,
           TAction,
@@ -670,7 +683,7 @@ type DistributeActors<
               | SingleOrArray<
                   TransitionConfigOrTarget<
                     TContext,
-                    ErrorActorEvent,
+                    ErrorActorEvent<ErrorFrom<TSpecificActor['logic']>>,
                     TEvent,
                     TActor,
                     TAction,
@@ -725,7 +738,7 @@ type DistributeActors<
             | SingleOrArray<
                 TransitionConfigOrTarget<
                   TContext,
-                  ErrorActorEvent,
+                  ErrorActorEvent<unknown>,
                   TEvent,
                   TActor,
                   TAction,
@@ -818,7 +831,7 @@ export type InvokeConfig<
           | SingleOrArray<
               TransitionConfigOrTarget<
                 TContext,
-                ErrorActorEvent,
+                ErrorActorEvent<unknown>,
                 TEvent,
                 TActor,
                 TAction,
@@ -2182,7 +2195,7 @@ export type AnyActorScope = ActorScope<
 
 export type SnapshotStatus = 'active' | 'done' | 'error' | 'stopped';
 
-export type Snapshot<TOutput> =
+export type Snapshot<TOutput, TError = unknown> =
   | {
       status: 'active';
       output: undefined;
@@ -2196,7 +2209,7 @@ export type Snapshot<TOutput> =
   | {
       status: 'error';
       output: undefined;
-      error: unknown;
+      error: TError;
     }
   | {
       status: 'stopped';


### PR DESCRIPTION
Adds the ability to define an error type for Promise actors, offering more precise type details for error states.

A practical use case for this is my [neverthrow actor wrapper](https://gist.github.com/svemat01/3f9a1144a202defae12c90e923e34e74), which enables creating a promise actor from a ResultAsync function with a known error type. This allows proper handling of results with onDone and onError, avoiding the need to match against the result in onDone, which works but is more cumbersome and less clear in the inspector.