### PR TITLE
[@xstate/lit] Add Lit Controller - templates

### DIFF
--- a/templates/lit-ts/.gitignore
+++ b/templates/lit-ts/.gitignore
@@ -1,0 +1,25 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+lib
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/templates/lit-ts/README.md
+++ b/templates/lit-ts/README.md
@@ -1,0 +1,9 @@
+# XState Lit TypeScript template
+
+A starting point template for using XState with [Lit](https://lit.dev) and TypeScript. Create a feedback form using a simple state machine.
+
+Using [Vite](https://vitejs.dev/) as a build tool and to run the local development server.
+
+## [➡️ Open in CodeSandbox](https://codesandbox.io/p/sandbox/github/statelyai/xstate/tree/main/templates/lit-ts?file=%2Fsrc%2FfeedbackMachine.ts)
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/statelyai/xstate/tree/main/templates/lit-ts?file=%2Fsrc%2FfeedbackMachine.ts)

--- a/templates/lit-ts/demo/counter.html
+++ b/templates/lit-ts/demo/counter.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>Demo - feedback-element</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" href="data:image/x-icon;base64,B" />
+    <meta name="description" content="feedback-element" />
+    <style>
+      html,
+      body {
+        height: 100%;
+        margin: 0;
+        font-family: sans-serif;
+      }
+      body {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        background: #eaeaea;
+      }
+      :not(:defined) {
+        visibility: hidden;
+      }
+    </style>
+  </head>
+  <body>
+    <counter-element>
+      <a href="./index.html">View feedback demo</a>
+    </counter-element>
+    <script src="./entry.js" type="module"></script>
+  </body>
+</html>

--- a/templates/lit-ts/demo/entry.js
+++ b/templates/lit-ts/demo/entry.js
@@ -1,0 +1,2 @@
+import '../src/define/feedback-element.ts';
+import '../src/define/counter-element.ts';

--- a/templates/lit-ts/demo/index.html
+++ b/templates/lit-ts/demo/index.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>Demo - feedback-element</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" href="data:image/x-icon;base64,B" />
+    <meta name="description" content="feedback-element" />
+    <style>
+      html,
+      body {
+        height: 100%;
+        margin: 0;
+        font-family: sans-serif;
+      }
+      body {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        background: #eaeaea;
+      }
+      :not(:defined) {
+        visibility: hidden;
+      }
+    </style>
+  </head>
+  <body>
+    <feedback-element>
+      <a href="./counter.html">View counter demo</a>
+    </feedback-element>
+    <script src="./entry.js" type="module"></script>
+  </body>
+</html>

--- a/templates/lit-ts/index.html
+++ b/templates/lit-ts/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Redirect feedback-element url=/demo/index.html"</title>
+    <meta http-equiv="refresh" content="0; url=/demo/index.html" />
+  </head>
+  <body></body>
+</html>

--- a/templates/lit-ts/package.json
+++ b/templates/lit-ts/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "lit-ts",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build && npm run build:lib",
+    "build:lib": "vite build --config vite.lib.config.js && tsc",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "@custom-elements-manifest/analyzer": "^0.10.4",
+    "@web/rollup-plugin-html": "^2.3.0",
+    "rollup-plugin-copy": "^3.5.0",
+    "rollup-plugin-node-externals": "^8.0.1",
+    "tinyglobby": "^0.2.14",
+    "tslib": "^2.8.1",
+    "typescript": "^5.8.3",
+    "vite": "^7.0.6"
+  },
+    "dependencies": {
+    "@statelyai/inspect": "^0.4.0",
+    "lit": "^3.3.1",
+    "xstate": "^5.20.1"
+  }
+}

--- a/templates/lit-ts/pnpm-lock.yaml
+++ b/templates/lit-ts/pnpm-lock.yaml
@@ -1,0 +1,5 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false

--- a/templates/lit-ts/src/CounterElement.ts
+++ b/templates/lit-ts/src/CounterElement.ts
@@ -1,0 +1,98 @@
+import { html, LitElement } from 'lit';
+import { state } from 'lit/decorators.js';
+import { type InspectionEvent, type SnapshotFrom } from 'xstate';
+import { counterMachine } from './counterMachine.js';
+import { UseMachine } from '@xstate/lit';
+import { styles } from './styles/counter-element-styles.css.js';
+
+export class CounterElement extends LitElement {
+  static override styles = [styles];
+
+  #inspectEventsHandler: (inspEvent: InspectionEvent) => void =
+    this.#inspectEvents.bind(this);
+
+  #callbackHandler: (snapshot: SnapshotFrom<any>) => void =
+    this.#callbackCounterController.bind(this);
+
+  counterController: UseMachine<typeof counterMachine> = new UseMachine(this, {
+    machine: counterMachine,
+    options: {
+      inspect: this.#inspectEventsHandler
+    },
+    callback: this.#callbackHandler
+  });
+
+  @state()
+  xstate: typeof this.counterController.snapshot =
+    this.counterController.snapshot;
+
+  override updated(props: Map<string, unknown>) {
+    super.updated && super.updated(props);
+    if (props.has('xstate')) {
+      const { context, value } = this.xstate;
+      const detail = { ...(context || {}), value };
+      const counterEvent = new CustomEvent('counterchange', {
+        bubbles: true,
+        detail
+      });
+      this.dispatchEvent(counterEvent);
+    }
+  }
+
+  #callbackCounterController(snapshot: typeof this.counterController.snapshot) {
+    this.xstate = snapshot;
+  }
+
+  #inspectEvents(inspEvent: InspectionEvent) {
+    if (
+      inspEvent.type === '@xstate.snapshot' &&
+      inspEvent.event.type === 'xstate.stop'
+    ) {
+      this.xstate = {} as unknown as typeof this.counterController.snapshot;
+    }
+  }
+
+  get #disabled() {
+    return this.counterController.snapshot.matches('disabled');
+  }
+
+  #send(event: any) {
+    this.counterController.send(event);
+  }
+
+  override render() {
+    return html`
+      <div aria-disabled="${this.#disabled}">
+        <span>
+          <button
+            ?disabled="${this.#disabled}"
+            data-counter="increment"
+            @click=${() => this.#send({ type: 'INC' })}
+          >
+            Increment
+          </button>
+          <button
+            ?disabled="${this.#disabled}"
+            data-counter="decrement"
+            @click=${() => this.#send({ type: 'DEC' })}
+          >
+            Decrement
+          </button>
+        </span>
+        <p>${this.counterController.snapshot.context.counter}</p>
+      </div>
+      <div>
+        <button @click=${() => this.#send({ type: 'TOGGLE' })}>
+          ${this.#disabled ? 'Enabled counter' : 'Disabled counter'}
+        </button>
+        <span><slot></slot></span>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'counter-element': CounterElement;
+  }
+}

--- a/templates/lit-ts/src/FeedbackElement.ts
+++ b/templates/lit-ts/src/FeedbackElement.ts
@@ -1,0 +1,154 @@
+import { html, LitElement } from 'lit';
+import { createBrowserInspector } from '@statelyai/inspect';
+import { feedbackMachine } from './feedbackMachine.js';
+import { UseMachine } from '@xstate/lit';
+import { styles } from './styles/feedback-element-styles.css.js';
+
+const { inspect } = createBrowserInspector({
+  // Comment out the line below to start the inspector
+  autoStart: false
+});
+
+export class FeedbackElement extends LitElement {
+  static override styles = [styles];
+
+  feedbackController: UseMachine<typeof feedbackMachine>;
+
+  constructor() {
+    super();
+    this.feedbackController = new UseMachine(this, {
+      machine: feedbackMachine,
+      options: { inspect }
+    });
+  }
+
+  #getMatches(match: 'prompt' | 'thanks' | 'form' | 'closed') {
+    return this.feedbackController.snapshot.matches(match);
+  }
+
+  #send(ev: any) {
+    this.feedbackController.send(ev);
+  }
+
+  override render() {
+    return html`
+      ${this.#getMatches('closed') ? this._closedTpl : this._feedbackTpl}
+    `;
+  }
+
+  get _feedbackTpl() {
+    return html`
+      <div class="feedback">
+        ${this._closeFeedbackTpl}
+        ${this.#getMatches('prompt') ? this._promptTpl : ''}
+        ${this.#getMatches('thanks') ? this._thanksTpl : ''}
+        ${this.#getMatches('form') ? this._formTpl : ''} ${this._slotTpl}
+      </div>
+    `;
+  }
+
+  get _slotTpl() {
+    return html`<div><slot></slot></div> `;
+  }
+
+  get _closeFeedbackTpl() {
+    return html`
+      <div class="close-feedback">
+        <button
+          class="close-button"
+          @click=${() => this.#send({ type: 'close' })}
+        >
+          Close
+        </button>
+      </div>
+    `;
+  }
+
+  get _promptTpl() {
+    return html`
+      <div class="step">
+        <h2>How was your experience?</h2>
+
+        <button
+          class="button"
+          @click=${() => this.#send({ type: 'feedback.good' })}
+        >
+          Good
+        </button>
+
+        <button
+          class="button"
+          @click=${() => this.#send({ type: 'feedback.bad' })}
+        >
+          Bad
+        </button>
+      </div>
+    `;
+  }
+
+  get _thanksTpl() {
+    return html`
+      <div class="step">
+        <h2>Thanks for your feedback.</h2>
+
+        ${this.feedbackController.snapshot.context.feedback
+          ? html`<p>"${this.feedbackController.snapshot.context.feedback}"</p>`
+          : ''}
+      </div>
+    `;
+  }
+
+  get _formTpl() {
+    return html`
+      <form
+        class="step"
+        @submit=${(ev: Event) => {
+          ev.preventDefault();
+          this.#send({ type: 'submit' });
+        }}
+      >
+        <h2>What can we do better?</h2>
+
+        <textarea
+          name="feedback"
+          rows="4"
+          placeholder="So many things..."
+          @input=${({ target }: { target: HTMLTextAreaElement }) =>
+            this.#send({
+              type: 'feedback.update',
+              value: target.value
+            })}
+        ></textarea>
+
+        <button
+          class="button"
+          ?disabled=${!this.feedbackController.snapshot.can({ type: 'submit' })}
+          @click=${() => this.#send({ type: 'submit' })}
+        >
+          Submit
+        </button>
+
+        <button class="button" @click=${() => this.#send({ type: 'back' })}>
+          Back
+        </button>
+      </form>
+    `;
+  }
+
+  get _closedTpl() {
+    return html`
+      <div>
+        <em>Feedback form closed.</em>
+        <button class="button" @click=${() => this.#send({ type: 'restart' })}>
+          Provide more feedback
+        </button>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'feedback-element': FeedbackElement;
+  }
+}

--- a/templates/lit-ts/src/counterMachine.ts
+++ b/templates/lit-ts/src/counterMachine.ts
@@ -1,0 +1,74 @@
+import { setup, assign } from 'xstate';
+
+/*
+ * This state machine represents a simple counter that can be incremented, decremented, and toggled on and off.
+ * The counter starts in the "enabled" state, where it can be incremented or decremented.
+ * If the counter reaches its maximum value, it cannot be incremented further. Similarly, if the counter reaches its minimum value, it cannot be decremented further. The counter can also be toggled to the "disabled" state, where it cannot be incremented or decremented.
+ * Toggling it again will bring it back to the "enabled" state.
+ */
+
+export const counterMachine = setup({
+  types: {
+    context: {} as { counter: number; event: unknown },
+    events: {} as
+      | {
+          type: 'INC';
+        }
+      | {
+          type: 'DEC';
+        }
+      | {
+          type: 'TOGGLE';
+        }
+  },
+  actions: {
+    increment: assign({
+      counter: ({ context }) => context.counter + 1,
+      event: ({ event }) => event
+    }),
+    decrement: assign({
+      counter: ({ context }) => context.counter - 1,
+      event: ({ event }) => event
+    })
+  },
+  guards: {
+    isNotMax: ({ context }) => context.counter < 10,
+    isNotMin: ({ context }) => context.counter > 0
+  }
+}).createMachine({
+  id: 'counter',
+  context: { counter: 0, event: undefined },
+  initial: 'enabled',
+  states: {
+    enabled: {
+      on: {
+        INC: {
+          actions: {
+            type: 'increment'
+          },
+          guard: {
+            type: 'isNotMax'
+          }
+        },
+        DEC: {
+          actions: {
+            type: 'decrement'
+          },
+          guard: {
+            type: 'isNotMin'
+          }
+        },
+        TOGGLE: {
+          target: 'disabled'
+        }
+      }
+    },
+    disabled: {
+      on: {
+        TOGGLE: {
+          target: 'enabled'
+        }
+      }
+    }
+  }
+});

--- a/templates/lit-ts/src/define/counter-element.ts
+++ b/templates/lit-ts/src/define/counter-element.ts
@@ -1,0 +1,3 @@
+import {CounterElement} from '../CounterElement.js';
+
+window.customElements.define('counter-element', CounterElement);

--- a/templates/lit-ts/src/define/feedback-element.ts
+++ b/templates/lit-ts/src/define/feedback-element.ts
@@ -1,0 +1,3 @@
+import {FeedbackElement} from '../FeedbackElement.js';
+
+window.customElements.define('feedback-element', FeedbackElement);

--- a/templates/lit-ts/src/feedbackMachine.ts
+++ b/templates/lit-ts/src/feedbackMachine.ts
@@ -1,0 +1,69 @@
+import { assign, setup } from 'xstate';
+
+export const feedbackMachine = setup({
+  types: {
+    context: {} as { feedback: string },
+    events: {} as
+      | {
+          type: 'feedback.good';
+        }
+      | {
+          type: 'feedback.bad';
+        }
+      | {
+          type: 'feedback.update';
+          value: string;
+        }
+      | { type: 'submit' }
+      | {
+          type: 'close';
+        }
+      | { type: 'back' }
+      | { type: 'restart' }
+  },
+  guards: {
+    feedbackValid: ({ context }) => context.feedback.length > 0
+  }
+}).createMachine({
+  id: 'feedback',
+  initial: 'prompt',
+  context: {
+    feedback: ''
+  },
+  states: {
+    prompt: {
+      on: {
+        'feedback.good': 'thanks',
+        'feedback.bad': 'form'
+      }
+    },
+    form: {
+      on: {
+        'feedback.update': {
+          actions: assign({
+            feedback: ({ event }) => event.value
+          })
+        },
+        back: { target: 'prompt' },
+        submit: {
+          guard: 'feedbackValid',
+          target: 'thanks'
+        }
+      }
+    },
+    thanks: {},
+    closed: {
+      on: {
+        restart: {
+          target: 'prompt',
+          actions: assign({
+            feedback: ''
+          })
+        }
+      }
+    }
+  },
+  on: {
+    close: '.closed'
+  }
+});

--- a/templates/lit-ts/src/index.ts
+++ b/templates/lit-ts/src/index.ts
@@ -1,0 +1,1 @@
+export {FeedbackElement} from './FeedbackElement.js';

--- a/templates/lit-ts/src/styles/counter-element-styles.css.ts
+++ b/templates/lit-ts/src/styles/counter-element-styles.css.ts
@@ -1,0 +1,107 @@
+import { css } from 'lit';
+
+export const styles = css`
+  :host {
+    --color-primary: #056dff;
+    --_mark-color: rgb(197, 197, 197);
+    display: block;
+    box-sizing: border-box;
+  }
+
+  :host([hidden]),
+  [hidden] {
+    display: none !important;
+  }
+
+  *,
+  *::before,
+  *::after {
+    box-sizing: inherit;
+  }
+
+  ::slotted(*) {
+    display: block;
+    color: var(--color-primary);
+    white-space: nowrap;
+    text-indent: -1.5rem;
+    text-decoration: none;
+    margin-top: 0.5rem;
+  }
+
+  [aria-disabled='true'] {
+    opacity: 0.5;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    user-select: none;
+    pointer-events: none;
+    cursor: not-allowed;
+  }
+
+  p {
+    font-size: 1.5rem;
+    min-width: 4.25rem;
+    text-align: center;
+    margin: auto;
+    padding: 0.8333em;
+    border-radius: 1rem;
+    border: 0.0625rem solid var(--_mark-color);
+  }
+
+  button {
+    appearance: none;
+    color: white;
+    border: none;
+    padding: 1rem 1.5rem;
+    border-radius: 0.25rem;
+    font: inherit;
+    cursor: pointer;
+    display: inline-block;
+    background-color: var(--color-primary);
+  }
+
+  button + button {
+    margin-top: 1rem;
+  }
+
+  div {
+    display: flex;
+    align-items: center;
+    max-width: 25rem;
+    padding: 1em 2em;
+    margin: auto;
+    background-color: rgb(238, 238, 238);
+    padding: 2rem;
+    background: white;
+    border-radius: 0.25rem;
+    box-shadow: 0 0.5rem 1rem #0001;
+    border: 0.0625rem solid var(--_mark-color);
+    border-bottom: none;
+  }
+  div + div {
+    position: relative;
+    border-top: 0.0625rem dashed var(--_mark-color);
+    border-bottom: 0.0625rem solid var(--_mark-color);
+  }
+
+  div + div button {
+    margin: 0 auto;
+    min-width: 10.625rem;
+  }
+
+  div + div span {
+    position: absolute;
+    display: block;
+    bottom: -1.5rem;
+    margin: 0;
+  }
+
+  span {
+    display: flex;
+    flex-direction: column;
+    margin-right: 2rem;
+  }
+
+  ::slotted(*) {
+    white-space: nowrap;
+  }
+`;

--- a/templates/lit-ts/src/styles/feedback-element-styles.css.ts
+++ b/templates/lit-ts/src/styles/feedback-element-styles.css.ts
@@ -1,0 +1,93 @@
+import { css } from 'lit';
+
+export const styles = css`
+  :host {
+    --color-primary: #056dff;
+    display: block;
+    box-sizing: border-box;
+    display: block;
+    margin: auto;
+  }
+
+  :host([hidden]),
+  [hidden] {
+    display: none !important;
+  }
+
+  *,
+  *::before,
+  *::after {
+    box-sizing: inherit;
+  }
+
+  ::slotted(*) {
+    display: block;
+    color: var(--color-primary);
+    text-indent: 1rem;
+    white-space: nowrap;
+    text-decoration: none;
+    margin-top: 0.5rem;
+  }
+
+  em {
+    display: block;
+    margin-bottom: 1rem;
+    text-align: center;
+  }
+
+  .step {
+    padding: 2rem;
+    background: white;
+    border-radius: 1rem;
+    box-shadow: 0 0.5rem 1rem #0001;
+    width: 75vw;
+    max-width: 40rem;
+  }
+
+  .feedback {
+    position: relative;
+  }
+
+  .close-feedback {
+    position: absolute;
+    top: 0;
+    right: 0;
+  }
+
+  .close-button {
+    appearance: none;
+    background: transparent;
+    font: inherit;
+    cursor: pointer;
+    border: none;
+    padding: 1rem;
+  }
+
+  .button {
+    appearance: none;
+    color: white;
+    border: none;
+    padding: 1rem 1.5rem;
+    border-radius: 0.25rem;
+    font: inherit;
+    font-weight: bold;
+    cursor: pointer;
+    display: inline-block;
+    margin-right: 1rem;
+    background-color: var(--color-primary);
+  }
+
+  .button:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+
+  textarea {
+    display: block;
+    border: 2px solid #eaeaea;
+    border-radius: 0.25rem;
+    margin-bottom: 1rem;
+    width: 100%;
+    padding: 0.5rem;
+  }
+`;

--- a/templates/lit-ts/tsconfig.json
+++ b/templates/lit-ts/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "declaration": true,
+    "declarationDir": "./lib/",
+    "experimentalDecorators": true,
+    "useDefineForClassFields": false,
+    "module": "ESNext",
+    "lib": ["ESNext", "DOM"],
+    "moduleResolution": "Node",
+    "strict": true,
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "noEmit": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/templates/lit-ts/vite.config.js
+++ b/templates/lit-ts/vite.config.js
@@ -1,0 +1,44 @@
+import {defineConfig} from 'vite';
+import {globSync} from 'tinyglobby';
+import copy from 'rollup-plugin-copy';
+
+const OUT_DIR = 'dist';
+const ENTRIES_DIR = 'demo';
+const ENTRIES_GLOB = [`${ENTRIES_DIR}/**/*.js`];
+
+const copyConfig = {
+  targets: [
+    {
+      src: [`${ENTRIES_DIR}/**/*.*`, `!${ENTRIES_GLOB}`],
+      dest: OUT_DIR,
+    },
+  ],
+  hook: 'writeBundle',
+};
+
+// https://github.com/vitejs/vite/discussions/1736#discussioncomment-5126923
+const entries = Object.fromEntries(
+  globSync(ENTRIES_GLOB).map((file) => {
+    const [key] = file.match(new RegExp(`(?<=${ENTRIES_DIR}/).*`)) || [];
+    return [key?.replace(/\.[^.]*$/, ''), file];
+  })
+);
+
+export default defineConfig({
+  plugins: [
+    copy(copyConfig),
+  ],
+
+  build: {
+    outDir: OUT_DIR,
+    rollupOptions: {
+      preserveEntrySignatures: 'exports-only',
+      input: entries,
+      output: {
+        dir: OUT_DIR,
+        entryFileNames: '[name].js',
+        format: 'es',
+      },
+    },
+  },
+});

--- a/templates/lit-ts/vite.lib.config.js
+++ b/templates/lit-ts/vite.lib.config.js
@@ -1,0 +1,26 @@
+import {defineConfig} from 'vite';
+import {nodeExternals} from 'rollup-plugin-node-externals';
+import {globSync} from 'tinyglobby';
+
+const ENTRIES_DIR = 'src';
+const ENTRIES_GLOB = [`${ENTRIES_DIR}/**/*.ts`];
+
+// https://github.com/vitejs/vite/discussions/1736#discussioncomment-5126923
+const entries = Object.fromEntries(
+  globSync(ENTRIES_GLOB).map((file) => {
+    const [key] = file.match(new RegExp(`(?<=${ENTRIES_DIR}/).*`)) || [];
+    return [key?.replace(/\.[^.]*$/, ''), file];
+  })
+);
+
+export default defineConfig({
+  plugins: [nodeExternals()],
+  build: {
+    outDir: 'lib',
+    lib: {
+      entry: entries,
+      formats: ['es'],
+    },
+    minify: false,
+  },
+});


### PR DESCRIPTION
Hi!

Please review and merge the packages [PR 5340 first](https://github.com/statelyai/xstate/pull/5340), as this one depends on it.

This PR adds a template example that uses the new @xstate/lit package:

```js
import { UseMachine } from '@xstate/lit';
``` 

**Main idea:**
This demonstrates compatibility for linking XState with Lit.

**Motivation:**
XState’s state machines provide a structured, predictable approach to complex logic, while Lit enables reactive UI updates in response to state changes. Combining both allows for robust and maintainable architectures for web components.

---

The implementation is stable and production-ready. If maintaining Lit-specific code isn't a priority for the team, feel free to close this PR. Thank you!