### PR TITLE
[@xstate/store] Fix redo logic bug

### DIFF
--- a/.changeset/fruity-crabs-clean.md
+++ b/.changeset/fruity-crabs-clean.md
@@ -1,0 +1,5 @@
+---
+'@xstate/store': patch
+---
+
+Fix redo logic bug where redo would apply too many events when no transaction grouping is used

--- a/packages/xstate-store/test/undo.test.ts
+++ b/packages/xstate-store/test/undo.test.ts
@@ -34,6 +34,30 @@ it('should redo a previously undone event', () => {
   expect(store.getSnapshot().context.count).toBe(1);
 });
 
+it('should undo/redo multiple events, non-transactional', () => {
+  const store = createStore(
+    undoRedo({
+      context: { count: 0 },
+      on: {
+        inc: (ctx) => ({ count: ctx.count + 1 })
+      }
+    })
+  );
+
+  store.trigger.inc();
+  store.trigger.inc();
+  store.trigger.inc();
+  expect(store.getSnapshot().context.count).toBe(3);
+  store.trigger.undo();
+  expect(store.getSnapshot().context.count).toBe(2);
+  store.trigger.undo();
+  expect(store.getSnapshot().context.count).toBe(1);
+  store.trigger.redo();
+  expect(store.getSnapshot().context.count).toBe(2);
+  store.trigger.redo();
+  expect(store.getSnapshot().context.count).toBe(3);
+});
+
 it('should group events by transaction ID', () => {
   const store = createStore(
     undoRedo(


### PR DESCRIPTION
Fix redo logic bug where redo would apply too many events when no transaction grouping is used
