### PR TITLE
Use `vitest run`

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
     "lint": "eslint --cache --quiet",
     "typecheck": "tsc",
     "test": "vitest run",
+    "test:watch": "vitest",
     "test:core": "vitest run --project xstate",
+    "test:core:watch": "vitest --project xstate",
     "changeset": "changeset",
     "release": "pnpm -r publish --access=public && changeset tag",
     "version": "changeset version"


### PR DESCRIPTION
The current test scripts run `vitest` which runs in watch mode. It's a bit of an annoying default especially because AI coding agents use those test commands and expect them to run once.

Now `pnpm test` and `pnpm test:core` will run tests once. If watch mode is still desired, `pnpm test:watch` and `pnpm test:core:watch` will do the trick.