### PR TITLE
[@xstate/react] Expose error snapshots in useActor/useMachine

### DIFF
--- a/.changeset/clear-islands-cheer.md
+++ b/.changeset/clear-islands-cheer.md
@@ -1,0 +1,18 @@
+---
+'@xstate/react': patch
+---
+
+`useActor` (and `useMachine` by alias) now properly re-renders when an action throws, exposing `status: 'error'` and `error` on the snapshot.
+
+```tsx
+const App = () => {
+  // Machine that might throw an error, e.g.:
+  // entry: () => throw new Error('error');
+  const [state, send, actor] = useActor(machine);
+
+  const errorMessage =
+    state.status === 'error' ? (state.error as Error)?.message : null;
+
+  // ...
+};
+```

--- a/packages/xstate-react/src/useActor.ts
+++ b/packages/xstate-react/src/useActor.ts
@@ -43,7 +43,10 @@ export function useActor<TLogic extends AnyActorLogic>(
 
   const subscribe = useCallback(
     (handleStoreChange: () => void) => {
-      const { unsubscribe } = actorRef.subscribe(handleStoreChange);
+      const { unsubscribe } = actorRef.subscribe({
+        next: handleStoreChange,
+        error: handleStoreChange
+      });
       return unsubscribe;
     },
     [actorRef]


### PR DESCRIPTION
`useActor` (and `useMachine` by alias) now properly re-renders when an action throws, exposing `status: 'error'` and `error` on the snapshot.

```tsx
const App = () => {
  // Machine that might throw an error, e.g.:
  // entry: () => throw new Error('error');
  const [state, send, actor] = useActor(machine);

  const errorMessage = state.status === 'error' ? (state.error as Error)?.message : null;
  
  // ...
};
```

Fixes #5455 
