### PR TITLE
Fix initialTransition for invoked system IDs

### DIFF
--- a/.changeset/clever-llamas-lay.md
+++ b/.changeset/clever-llamas-lay.md
@@ -1,0 +1,5 @@
+---
+"xstate": patch
+---
+
+Fix `initialTransition` for machines that invoke actors with a `systemId`.

--- a/packages/core/src/getNextSnapshot.ts
+++ b/packages/core/src/getNextSnapshot.ts
@@ -1,4 +1,4 @@
-import { createActor } from './createActor.ts';
+import { createEmptyActor } from './actors/index.ts';
 import {
   ActorScope,
   AnyActorLogic,
@@ -13,7 +13,7 @@ import {
 export function createInertActorScope<T extends AnyActorLogic>(
   actorLogic: T
 ): AnyActorScope {
-  const self = createActor(actorLogic as AnyActorLogic);
+  const self = createEmptyActor();
   const inertActorScope: ActorScope<
     SnapshotFrom<T>,
     EventFromLogic<T>,

--- a/packages/core/test/transition.test.ts
+++ b/packages/core/test/transition.test.ts
@@ -253,6 +253,32 @@ describe('transition function', () => {
     );
   });
 
+  it('should not throw when invoked actors define a systemId', () => {
+    const machine = createMachine({
+      initial: 'a',
+      states: {
+        a: {
+          invoke: {
+            src: createMachine({}),
+            systemId: 'child'
+          }
+        }
+      }
+    });
+
+    const [state, actions] = initialTransition(machine);
+
+    expect(state.value).toBe('a');
+    expect(actions).toContainEqual(
+      expect.objectContaining({
+        type: 'xstate.spawnChild',
+        params: expect.objectContaining({
+          systemId: 'child'
+        })
+      })
+    );
+  });
+
   it('emit actions should be returned', async () => {
     const machine = createMachine({
       initial: 'a',


### PR DESCRIPTION
Fixes #5454.\n\n was creating an inert actor scope by instantiating the target logic through , which meant invoked children with a  were effectively evaluated twice during the initial snapshot path. That could register the same system ID more than once and throw.\n\nThis changes the inert scope to use  instead, keeping  pure while still providing the scope properties needed by transition logic. A regression test covers the  case.